### PR TITLE
PP-6981 Make e2e optional for selfservice

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -199,6 +199,11 @@ definitions:
   - &node-test
     task: test
     file: omnibus/ci/tasks/node-build-pr.yml
+  - &node-build
+    task: build
+    file: omnibus/ci/tasks/node-build-pr.yml
+    params:
+      skip_tests: true
   - x-pact-credentials: &pact-credentials
       pact-broker-username: ((pact-broker-username))
       pact-broker-password: ((pact-broker-password))
@@ -417,6 +422,7 @@ groups:
   - name: Selfservice
     jobs:
       - selfservice-test
+      - selfservice-card-e2e
       - selfservice-pact-provider-verification
       - record-selfservice-build-time
 
@@ -1734,8 +1740,20 @@ jobs:
         consumer_name: selfservice
     - <<: *put-test-success-status
       put: selfservice-pull-request
+
+  - <<: *job-definition
+    name: selfservice-card-e2e
+    serial: true
+    plan:
+    - <<: *get-pull-request
+      resource: selfservice-pull-request
+      trigger: false
     - <<: *put-card-e2e-pending-status
       put: selfservice-pull-request
+    - <<: *node-build
+      on_failure:
+        <<: *put-card-e2e-failed-status
+        put: selfservice-pull-request
     - <<: *build-docker-image
       params:
         app_name: selfservice

--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -15,6 +15,8 @@ outputs:
 caches:
   - path: npm_cache
   - path: cypress_cache
+params:
+  skip_tests: false
 run:
   path: bash
   dir: src
@@ -37,12 +39,17 @@ run:
       npm rebuild node-sass
       npm ci
       npm run compile
-      npm test -- --forbid-only --forbid-pending
 
-      if [ -f "cypress.json" ]; then
-        npm run cypress:server > /dev/null 2>&1 &
-        sleep 3
-        npm run cypress:test
+      if [ "$skip_tests" = true ]; then
+        echo "Skipping tests"
+      else
+        npm test -- --forbid-only --forbid-pending
+
+        if [ -f "cypress.json" ]; then
+          npm run cypress:server > /dev/null 2>&1 &
+          sleep 3
+          npm run cypress:test
+        fi
       fi
 
       cd ..


### PR DESCRIPTION
Split the e2e test into a separate job so we can make it optional and
apply throttling independently to the other tests.

## WHAT ##
When we originally created the node app jobs we wanted to avoid having to build the app more than once because it can take a while. This led us to putting e2e in the same job as the other tests so that the built app could be passed using task input/outputs. We now want to make e2e optional so we need to split it into its own job. Since this won't be run regularly the simplest approach is to build the app for e2e, this also means e2e runs completely independently to the other test jobs - there is no dependency on the unit test job building the app to pass to e2e. A new flag on the `node-build-pr.yml` task will skip the tests if set to true. This means we can use the same task file but avoid running tests when we only want to build it for e2e.

also
```
gds5062:pay-omnibus danworth$ fly validate-pipeline -c ci/pipelines/pr.yml
looks good
```