### PR TITLE
PP-6944 Add ledger's pact provider job to input of build time record

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1433,7 +1433,8 @@ jobs:
     - <<: *get-pull-request
       resource: ledger-pull-request
       passed: [ledger-unit-test, ledger-integration-test,
-        ledger-pact-provider-test, ledger-consumer-pact-test]
+        ledger-pact-provider-test, ledger-consumer-pact-test,
+        ledger-pact-provider-verification]
     - <<: *send-pr-build-time
 
   - <<: *job-definition


### PR DESCRIPTION
Wait until `ledger-pact-provider-verification` has completed before
recording the pr build time.