### PR TITLE
PP-7128: Bootstrap performance testing AWS account

### DIFF
--- a/terraform/performance-account/iam.tf
+++ b/terraform/performance-account/iam.tf
@@ -1,0 +1,23 @@
+module "richard_baker_admin" {
+  source              = "git::ssh://git@github.com/alphagov/tech-ops-private.git//reliability-engineering/terraform/modules/gds-user-role/"
+  email               = "richard.baker@digital.cabinet-office.gov.uk"
+  role_suffix         = "admin"
+  iam_policy_arns     = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  restrict_to_gds_ips = true
+}
+
+module "dan_worth_admin" {
+  source              = "git::ssh://git@github.com/alphagov/tech-ops-private.git//reliability-engineering/terraform/modules/gds-user-role/"
+  email               = "dan.worth@digital.cabinet-office.gov.uk"
+  role_suffix         = "admin"
+  iam_policy_arns     = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  restrict_to_gds_ips = true
+}
+
+module "rory_malcolm_admin" {
+  source              = "git::ssh://git@github.com/alphagov/tech-ops-private.git//reliability-engineering/terraform/modules/gds-user-role/"
+  email               = "rory.malcolm@digital.cabinet-office.gov.uk"
+  role_suffix         = "admin"
+  iam_policy_arns     = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  restrict_to_gds_ips = true
+}

--- a/terraform/performance-account/site.tf
+++ b/terraform/performance-account/site.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 0.12"
+
+  # Comment out when bootstrapping
+  backend "s3" {
+    bucket = "govuk-pay-performance-tfstate"
+    key    = "account.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+provider "aws" {
+  version = "~> 3.0"
+  region  = "eu-west-1"
+}
+
+module "state_bucket" {
+  source      = "../modules/state-bucket"
+  bucket_name = "govuk-pay-performance-tfstate"
+}
+
+module "cyber_security_audit_role" {
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=720885a9769c40942ff30b32179e1fad18f2ca10"
+
+  chain_account_id = "988997429095"
+}


### PR DESCRIPTION
Adds a Terraform module to manage state bucket and IAM roles allowing access to performance testing AWS account.