### PR TITLE
PP-7657 Concourse toolbox ECR test pipeline

### DIFF
--- a/ci/pipelines/toolbox-test-ecr.yml
+++ b/ci/pipelines/toolbox-test-ecr.yml
@@ -4,22 +4,17 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-7657-Concourse-toolbox-ECR-test-pipeline
+      branch: master 
       paths:
         - ci/pipelines/toolbox-test-ecr.yml
   # Github Releases
   - name: git-toolbox-pre-release
-    type: github-release
+    type: git
     icon: github
     source: &github-release-source
-      owner: alphagov
-      access_token: ((github-access-token))
-      # Filter on releases that Jenkins has tagged as ready for test-12
-      tag_filter: "alpha_release-(.*)"
-      order_by: version
-      repository: pay-toolbox
-      pre_release: false
-      release: true
+      uri: https://github.com/alphagov/pay-toolbox
+      branch: master
+      tag_regex: "alpha_release-(.*)"
   # ECR registry resource
   - name: ecr-registry-test
     type: dev-registry-image
@@ -96,8 +91,7 @@ jobs:
               echo "Authenticating with Docker Hub..."
               # TODO: use alternative auth method for docker
               echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
-
-              COMMIT_SHA=$(cat git-toolbox-pre-release/commit_sha)
+              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
               docker pull govukpay/toolbox:$COMMIT_SHA
 
               docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
@@ -105,4 +99,4 @@ jobs:
       - put: ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: git-toolbox-pre-release/commit_sha
+          additional_tags: git-toolbox-pre-release/.git/HEAD

--- a/ci/pipelines/toolbox-test-ecr.yml
+++ b/ci/pipelines/toolbox-test-ecr.yml
@@ -1,0 +1,108 @@
+resources:
+  - name: toolbox-test-ecr
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: PP-7657-Concourse-toolbox-ECR-test-pipeline
+      paths:
+        - ci/pipelines/toolbox-test-ecr.yml
+  # Github Releases
+  - name: git-toolbox-pre-release
+    type: github-release
+    icon: github
+    source: &github-release-source
+      owner: alphagov
+      access_token: ((github-access-token))
+      # Filter on releases that Jenkins has tagged as ready for test-12
+      tag_filter: "alpha_release-(.*)"
+      order_by: version
+      repository: pay-toolbox
+      pre_release: false
+      release: true
+  # ECR registry resource
+  - name: ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/toolbox
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+
+resource_types:
+  # Custom resource type - this has been merged to the
+  # https://github.com/concourse/registry-image-resource repo,
+  # however is not yet in a stable release. Using this custom
+  # resource type allows us to support the ECR registry_id parameter
+  # This can be removed once registry_id is in stable release of 'registry-image'.
+  - name: dev-registry-image
+    type: registry-image
+    source:
+      repository: concourse/registry-image-resource
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: dev
+
+jobs:
+  - name: update-toolbox-test-ecr-pipeline
+    plan:
+      - get: toolbox-test-ecr
+        trigger: true
+      - set_pipeline: toolbox-test-ecr
+        file: toolbox-test-ecr/ci/pipelines/toolbox-test-ecr.yml
+  - name: toolbox-test-ecr
+    plan:
+      - get: git-toolbox-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - task: pull-toolbox-from-dockerhub
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          params:
+            DOCKER_USERNAME: ((docker-username))
+            DOCKER_AUTH_TOKEN: ((docker-password))
+          inputs:
+            - name: git-toolbox-pre-release
+          outputs:
+            - name: image
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              source /docker-helpers.sh
+              start_docker
+
+              function cleanup {
+                echo "CLEANUP TRIGGERED"
+                clean_docker
+                stop_docker
+                echo "CLEANUP COMPLETE"
+              }
+
+              trap cleanup EXIT
+
+              echo "Authenticating with Docker Hub..."
+              # TODO: use alternative auth method for docker
+              echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
+
+              COMMIT_SHA=$(cat git-toolbox-pre-release/commit_sha)
+              docker pull govukpay/toolbox:$COMMIT_SHA
+
+              docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
+
+      - put: ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: git-toolbox-pre-release/commit_sha


### PR DESCRIPTION
Adds a new pipeline for pushing Toolbox Docker images to ECR.

- The pipeline checks for new Github releases tagged as `alpha_release-*`
- This triggers a job to pull an image with that commit SHA from Dockerhub, and save it to `image/image.tar`
- The next job then pushes the `image/image.tar` to the ECR repository resource, using the `commit_sha` as the tag.

Environment variables needed:
- `pay_aws_test_account_id` (the same ID is used for the new IAM role and the ECR registry)
- `github-access-token` (already used elsewhere in Pay's Concourse)
- `docker-username` and `docker-password` (already used elsewhere in Pay's Concourse)
- `readonly_secret_access_key` and `readonly_session_token` (provided by Big Concourse)

We've tested the following locally:
- github release trigger with a test tag (Concourse won't pick up older release tags that were created before the resource, [without us specifically checking for them](https://concourse-ci.org/managing-resources.html))
- saving the `$COMMIT_SHA` to a file and using it as the tag when pushing to ECR

Unable to test yet:
- whether the Concourse AWS role can assume our new role to access the Pay test account's ECR (new role hasn't been created yet)
- successfully pushing the image to ECR 

Things for a reviewer to think about:
- Should we refactor the docker pull job into a separate task file?
- Is there a better way of doing the Docker authentication than in a shell script (given we can't seem to use the usual `registry-image` resource to pull an image with a specified tag)?