### PR TITLE
BAU Remove e2e pending status for DD-Frontend

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -2043,12 +2043,6 @@ jobs:
         put: directdebit-frontend-pull-request
     - <<: *put-test-success-status
       put: directdebit-frontend-pull-request
-    - <<: *put-card-e2e-pending-status
-      put: directdebit-frontend-pull-request
-    - <<: *build-docker-image
-      params:
-        app_name: directdebit-frontend
-    - <<: *get-all-docker-images
 
   - <<: *job-definition
     name: ci-pr-test


### PR DESCRIPTION
It seems e2e was removed for DD-Frontend because we're not currently
pursuing DirectDebit and DirectDebit e2e wasn't fully implemented.
However it was still sending a pending status for e2e and pulling the
containers. This removes it to complete the removal.