### PR TITLE
PP-7683 apps into test ECR

### DIFF
--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -58,44 +58,9 @@ jobs:
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - task: pull-image-from-dockerhub
         privileged: true
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          params:
-            DOCKER_USERNAME: ((docker-username))
-            DOCKER_AUTH_TOKEN: ((docker-password))
-            DOCKER_REPOSITORY: govukpay/toolbox
-          inputs:
-            - name: git-app-pre-release
-          outputs:
-            - name: image
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              source /docker-helpers.sh
-              start_docker
-
-              function cleanup {
-                echo "CLEANUP TRIGGERED"
-                clean_docker
-                stop_docker
-                echo "CLEANUP COMPLETE"
-              }
-
-              trap cleanup EXIT
-
-              echo "Authenticating with Docker Hub..."
-              # TODO: use alternative auth method for docker
-              echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
-              COMMIT_SHA=$(cat git-app-pre-release/.git/HEAD)
-              docker pull $DOCKER_REPOSITORY:$COMMIT_SHA
-
-              docker save $DOCKER_REPOSITORY:$COMMIT_SHA --output image/image.tar
+        file: ci/ci/tasks/pull-image-from-dockerhub.yml
+        params:
+          DOCKER_REPOSITORY: govukpay/toolbox
 
       - put: ecr-registry-test
         params:

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -51,6 +51,28 @@ groups:
   - name: toolbox
     jobs:
       - toolbox-image-to-test-ecr
+  - name: frontend
+    jobs:
+      - frontend-image-to-test-ecr
+
+definitions:
+  - &pull-image-from-dockerhub
+    task: pull-image-from-dockerhub
+    privileged: true
+    file: toolbox-test-ecr/ci/tasks/pull-image-from-dockerhub.yml
+    params:
+      DOCKER_USERNAME: updateThisValue
+      DOCKER_AUTH_TOKEN: updateThisValue
+      DOCKER_REPOSITORY: updateThisValue
+  - &put-ecr-registry-test
+    put: ecr-registry-test
+    params:
+      image: image/image.tar
+      additional_tags: git-app-pre-release/.git/HEAD
+
+docker_credentials: &docker_credentials
+  DOCKER_USERNAME: ((docker-username))
+  DOCKER_AUTH_TOKEN: ((docker-password))
 
 jobs:
   - name: update-apps-test-ecr-pipeline
@@ -65,14 +87,19 @@ jobs:
       - get: git-app-pre-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - task: pull-image-from-dockerhub
-        privileged: true
-        file: toolbox-test-ecr/ci/tasks/pull-image-from-dockerhub.yml
+      - <<: *pull-image-from-dockerhub
         params:
-          DOCKER_USERNAME: ((docker-username))
-          DOCKER_AUTH_TOKEN: ((docker-password))
           DOCKER_REPOSITORY: govukpay/toolbox
-      - put: ecr-registry-test
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: frontend-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
         params:
-          image: image/image.tar
-          additional_tags: git-app-pre-release/.git/HEAD
+          DOCKER_REPOSITORY: govukpay/frontend
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -167,7 +167,7 @@ definitions:
     put: ecr-registry-test
     params:
       image: image/image.tar
-      additional_tags: git-app-pre-release/.git/HEAD
+      additional_tags: updateThisValue
 
 docker_credentials: &docker_credentials
   DOCKER_USERNAME: ((docker-username))
@@ -192,6 +192,9 @@ jobs:
           APP_GIT_DIR: toolbox-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: toolbox-git-release/.git/HEAD
   - name: frontend-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -204,6 +207,9 @@ jobs:
           APP_GIT_DIR: frontend-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: frontend-git-release/.git/HEAD
   - name: adminusers-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -216,6 +222,9 @@ jobs:
           APP_GIT_DIR: adminusers-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: adminusers-git-release/.git/HEAD
   - name: cardid-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -228,6 +237,9 @@ jobs:
           APP_GIT_DIR: cardid-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: cardid-git-release/.git/HEAD
   - name: connector-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -240,6 +252,9 @@ jobs:
           APP_GIT_DIR: connector-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: connector-git-release/.git/HEAD
   - name: ledger-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -252,6 +267,9 @@ jobs:
           APP_GIT_DIR: ledger-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: ledger-git-release/.git/HEAD
   - name: products-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -264,6 +282,9 @@ jobs:
           APP_GIT_DIR: products-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: products-git-release/.git/HEAD
   - name: products-ui-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -276,6 +297,9 @@ jobs:
           APP_GIT_DIR: products-ui-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: products-ui-git-release/.git/HEAD
   - name: publicapi-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -288,6 +312,9 @@ jobs:
           APP_GIT_DIR: publicapi-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: publicapi-git-release/.git/HEAD
   - name: publicauth-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -300,6 +327,9 @@ jobs:
           APP_GIT_DIR: publicauth-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: publicauth-git-release/.git/HEAD
   - name: selfservice-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
@@ -312,3 +342,6 @@ jobs:
           APP_GIT_DIR: selfservice-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: selfservice-git-release/.git/HEAD

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -248,7 +248,7 @@ resource_types:
 groups:
   - name: pipeline-meta-update
     jobs:
-      - update-toolbox-test-ecr-pipeline
+      - update-apps-test-ecr-pipeline
   - name: toolbox
     jobs:
       - toolbox-image-to-test-ecr
@@ -305,9 +305,9 @@ jobs:
         trigger: true
       - set_pipeline: apps-test-ecr
         file: apps-test-ecr/ci/pipelines/apps-test-ecr.yml
-  - name: toolbox-test-ecr
+  - name: toolbox-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: toolbox-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -322,7 +322,7 @@ jobs:
           additional_tags: toolbox-git-release/.git/HEAD
   - name: frontend-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: frontend-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -337,7 +337,7 @@ jobs:
           additional_tags: frontend-git-release/.git/HEAD
   - name: adminusers-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: adminusers-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -352,7 +352,7 @@ jobs:
           additional_tags: adminusers-git-release/.git/HEAD
   - name: cardid-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: cardid-git-release
         trigger: true
         params:
@@ -402,7 +402,7 @@ jobs:
           additional_tags: cardid-git-release/.git/HEAD
   - name: connector-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: connector-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -417,7 +417,7 @@ jobs:
           additional_tags: connector-git-release/.git/HEAD
   - name: ledger-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: ledger-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -432,7 +432,7 @@ jobs:
           additional_tags: ledger-git-release/.git/HEAD
   - name: products-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: products-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -447,7 +447,7 @@ jobs:
           additional_tags: products-git-release/.git/HEAD
   - name: products-ui-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: products-ui-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -462,7 +462,7 @@ jobs:
           additional_tags: products-ui-git-release/.git/HEAD
   - name: publicapi-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: publicapi-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -477,7 +477,7 @@ jobs:
           additional_tags: publicapi-git-release/.git/HEAD
   - name: publicauth-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: publicauth-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -492,7 +492,7 @@ jobs:
           additional_tags: publicauth-git-release/.git/HEAD
   - name: selfservice-image-to-test-ecr
     plan:
-      - get: toolbox-test-ecr
+      - get: apps-test-ecr
       - get: selfservice-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -8,7 +8,7 @@ resources:
       paths:
         - ci/pipelines/apps-test-ecr.yml
   # Github Releases
-  - name: git-toolbox-pre-release
+  - name: git-app-pre-release
     type: git
     icon: github
     source: &github-release-source
@@ -53,10 +53,10 @@ jobs:
         file: apps-test-ecr/ci/pipelines/apps-test-ecr.yml
   - name: toolbox-test-ecr
     plan:
-      - get: git-toolbox-pre-release
+      - get: git-app-pre-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - task: pull-toolbox-from-dockerhub
+      - task: pull-image-from-dockerhub
         privileged: true
         config:
           platform: linux
@@ -67,8 +67,9 @@ jobs:
           params:
             DOCKER_USERNAME: ((docker-username))
             DOCKER_AUTH_TOKEN: ((docker-password))
+            DOCKER_REPOSITORY: govukpay/toolbox
           inputs:
-            - name: git-toolbox-pre-release
+            - name: git-app-pre-release
           outputs:
             - name: image
           run:
@@ -91,12 +92,12 @@ jobs:
               echo "Authenticating with Docker Hub..."
               # TODO: use alternative auth method for docker
               echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
-              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
-              docker pull govukpay/toolbox:$COMMIT_SHA
+              COMMIT_SHA=$(cat git-app-pre-release/.git/HEAD)
+              docker pull $DOCKER_REPOSITORY:$COMMIT_SHA
 
-              docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
+              docker save $DOCKER_REPOSITORY:$COMMIT_SHA --output image/image.tar
 
       - put: ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: git-toolbox-pre-release/.git/HEAD
+          additional_tags: git-app-pre-release/.git/HEAD

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -4,7 +4,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master 
+      branch: PP-7683-apps-test-ecr
       paths:
         - ci/pipelines/apps-test-ecr.yml
   # Github Releases

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -86,12 +86,142 @@ resources:
       branch: master
       tag_regex: "alpha_release-(.*)"
 
-  # ECR registry resource
-  - name: ecr-registry-test
+# ECR registry resources
+  - name: toolbox-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/toolbox
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: frontend-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/frontend
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: adminusers-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: cardid-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/cardid
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: connector-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/connector
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: ledger-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/ledger
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: products-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/products
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: products-ui-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/products-ui
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: publicapi-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/publicapi
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: publicauth-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/publicauth
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  - name: selfservice-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/selfservice
       aws_access_key_id: ((readonly_access_key_id))
       aws_secret_access_key: ((readonly_secret_access_key))
       aws_session_token: ((readonly_session_token))
@@ -163,11 +293,6 @@ definitions:
       DOCKER_AUTH_TOKEN: updateThisValue
       DOCKER_REPOSITORY: updateThisValue
       APP_GIT_DIR: updateThisValue
-  - &put-ecr-registry-test
-    put: ecr-registry-test
-    params:
-      image: image/image.tar
-      additional_tags: updateThisValue
 
 docker_credentials: &docker_credentials
   DOCKER_USERNAME: ((docker-username))
@@ -191,7 +316,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/toolbox
           APP_GIT_DIR: toolbox-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: toolbox-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: toolbox-git-release/.git/HEAD
@@ -206,7 +331,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/frontend
           APP_GIT_DIR: frontend-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: frontend-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: frontend-git-release/.git/HEAD
@@ -221,7 +346,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/adminusers
           APP_GIT_DIR: adminusers-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: adminusers-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: adminusers-git-release/.git/HEAD
@@ -236,7 +361,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/cardid
           APP_GIT_DIR: cardid-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: cardid-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: cardid-git-release/.git/HEAD
@@ -251,7 +376,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/connector
           APP_GIT_DIR: connector-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: connector-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: connector-git-release/.git/HEAD
@@ -266,7 +391,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/ledger
           APP_GIT_DIR: ledger-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: ledger-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: ledger-git-release/.git/HEAD
@@ -281,7 +406,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/products
           APP_GIT_DIR: products-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: products-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: products-git-release/.git/HEAD
@@ -296,7 +421,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/products-ui
           APP_GIT_DIR: products-ui-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: products-ui-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: products-ui-git-release/.git/HEAD
@@ -311,7 +436,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/publicapi
           APP_GIT_DIR: publicapi-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: publicapi-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: publicapi-git-release/.git/HEAD
@@ -326,7 +451,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/publicauth
           APP_GIT_DIR: publicauth-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: publicauth-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: publicauth-git-release/.git/HEAD
@@ -341,7 +466,7 @@ jobs:
           DOCKER_REPOSITORY: govukpay/selfservice
           APP_GIT_DIR: selfservice-git-release
           <<: *docker_credentials
-      - <<: *put-ecr-registry-test
+      - put: selfservice-ecr-registry-test
         params:
           image: image/image.tar
           additional_tags: selfservice-git-release/.git/HEAD

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -54,6 +54,33 @@ groups:
   - name: frontend
     jobs:
       - frontend-image-to-test-ecr
+  - name: adminusers
+    jobs:
+      - adminusers-image-to-test-ecr
+  - name: cardid
+    jobs:
+      - cardid-image-to-test-ecr
+  - name: connector
+    jobs:
+      - connector-image-to-test-ecr
+  - name: ledger
+    jobs:
+      - ledger-image-to-test-ecr
+  - name: products
+    jobs:
+      - products-image-to-test-ecr
+  - name: products-ui
+    jobs:
+      - products-ui-image-to-test-ecr
+  - name: publicapi
+    jobs:
+      - publicapi-image-to-test-ecr
+  - name: publicauth
+    jobs:
+      - publicauth-image-to-test-ecr
+  - name: selfservice
+    jobs:
+      - selfservice-image-to-test-ecr
 
 definitions:
   - &pull-image-from-dockerhub
@@ -101,5 +128,104 @@ jobs:
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/frontend
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: adminusers-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/adminusers
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: cardid-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/cardid
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: connector-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/connector
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: ledger-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/ledger
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: products-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/products
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: products-ui-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/products-ui
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: publicapi-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/publicapi
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: publicauth-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/publicauth
+          <<: *docker_credentials
+      - <<: *put-ecr-registry-test
+  - name: selfservice-image-to-test-ecr
+    plan:
+      - get: toolbox-test-ecr
+      - get: git-app-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/selfservice
           <<: *docker_credentials
       - <<: *put-ecr-registry-test

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -53,13 +53,16 @@ jobs:
         file: apps-test-ecr/ci/pipelines/apps-test-ecr.yml
   - name: toolbox-test-ecr
     plan:
+      - get: toolbox-test-ecr
       - get: git-app-pre-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - task: pull-image-from-dockerhub
         privileged: true
-        file: ci/ci/tasks/pull-image-from-dockerhub.yml
+        file: toolbox-test-ecr/ci/tasks/pull-image-from-dockerhub.yml
         params:
+          DOCKER_USERNAME: ((docker-username))
+          DOCKER_AUTH_TOKEN: ((docker-password))
           DOCKER_REPOSITORY: govukpay/toolbox
 
       - put: ecr-registry-test

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -44,6 +44,14 @@ resource_types:
       password: ((docker-password))
       tag: dev
 
+groups:
+  - name: pipeline-meta-update
+    jobs:
+      - update-toolbox-test-ecr-pipeline
+  - name: toolbox
+    jobs:
+      - toolbox-image-to-test-ecr
+
 jobs:
   - name: update-apps-test-ecr-pipeline
     plan:
@@ -64,7 +72,6 @@ jobs:
           DOCKER_USERNAME: ((docker-username))
           DOCKER_AUTH_TOKEN: ((docker-password))
           DOCKER_REPOSITORY: govukpay/toolbox
-
       - put: ecr-registry-test
         params:
           image: image/image.tar

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -1,10 +1,20 @@
+aws_config: &aws_config
+  aws_access_key_id: ((readonly_access_key_id))
+  aws_secret_access_key: ((readonly_secret_access_key))
+  aws_session_token: ((readonly_session_token))
+  # Need to create the role for the concourse user to assume in the test account
+  aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+  # Hardcode the test account registry ID for now. Needs to be a string, not a number
+  aws_ecr_registry_id: "((pay_aws_test_account_id))"
+  aws_region: eu-west-1
+
 resources:
   - name: apps-test-ecr
     type: git
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-7683-apps-test-ecr
+      branch: master
       paths:
         - ci/pipelines/apps-test-ecr.yml
   # Github Releases
@@ -92,144 +102,67 @@ resources:
     icon: docker
     source:
       repository: govukpay/toolbox
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: frontend-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/frontend
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: adminusers-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/adminusers
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: cardid-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/cardid
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: connector-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/connector
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: ledger-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/ledger
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: products-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/products
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: products-ui-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/products-ui
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: publicapi-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/publicapi
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: publicauth-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/publicauth
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
   - name: selfservice-ecr-registry-test
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/selfservice
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
+      <<: *aws_config
 
 resource_types:
   # Custom resource type - this has been merged to the

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -8,13 +8,84 @@ resources:
       paths:
         - ci/pipelines/apps-test-ecr.yml
   # Github Releases
-  - name: git-app-pre-release
+  - name: toolbox-git-release
     type: git
     icon: github
-    source: &github-release-source
+    source:
       uri: https://github.com/alphagov/pay-toolbox
       branch: master
       tag_regex: "alpha_release-(.*)"
+  - name: frontend-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-frontend
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: adminusers-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-adminusers
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: cardid-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-cardid
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: connector-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-connector
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: ledger-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ledger
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: products-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-products
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: products-ui-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-productsui
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: publicauth-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-publicauth
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: publicapi-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-publicapi
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - name: selfservice-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-selfservice
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+
   # ECR registry resource
   - name: ecr-registry-test
     type: dev-registry-image
@@ -91,6 +162,7 @@ definitions:
       DOCKER_USERNAME: updateThisValue
       DOCKER_AUTH_TOKEN: updateThisValue
       DOCKER_REPOSITORY: updateThisValue
+      APP_GIT_DIR: updateThisValue
   - &put-ecr-registry-test
     put: ecr-registry-test
     params:
@@ -111,121 +183,132 @@ jobs:
   - name: toolbox-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: toolbox-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/toolbox
+          APP_GIT_DIR: toolbox-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: frontend-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: frontend-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/frontend
+          APP_GIT_DIR: frontend-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: adminusers-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: adminusers-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/adminusers
+          APP_GIT_DIR: adminusers-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: cardid-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: cardid-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/cardid
+          APP_GIT_DIR: cardid-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: connector-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: connector-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/connector
+          APP_GIT_DIR: connector-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: ledger-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: ledger-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/ledger
+          APP_GIT_DIR: ledger-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: products-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: products-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/products
+          APP_GIT_DIR: products-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: products-ui-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: products-ui-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/products-ui
+          APP_GIT_DIR: products-ui-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: publicapi-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: publicapi-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/publicapi
+          APP_GIT_DIR: publicapi-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: publicauth-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: publicauth-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/publicauth
+          APP_GIT_DIR: publicauth-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test
   - name: selfservice-image-to-test-ecr
     plan:
       - get: toolbox-test-ecr
-      - get: git-app-pre-release
+      - get: selfservice-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:
           DOCKER_REPOSITORY: govukpay/selfservice
+          APP_GIT_DIR: selfservice-git-release
           <<: *docker_credentials
       - <<: *put-ecr-registry-test

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -355,6 +355,41 @@ jobs:
       - get: toolbox-test-ecr
       - get: cardid-git-release
         trigger: true
+        params:
+          submodules: none
+      - task: update-submodule
+        config:
+          container_limits: {}
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          inputs:
+            - name: cardid-git-release
+          params:
+            GH_ACCESS_TOKEN: ((github-access-token))
+          outputs:
+            - name: cardid-git-release
+          run:
+            path: bash
+            dir: cardid-git-release
+            args:
+              - -ec
+              - |
+                # cardid-data submodule's url is defined as ssh yet concourse
+                # is using oauth. Furthermore we need to avoid the password
+                # prompt from the git cli. Therefore rewrite the url for https
+                # and add the token. The risk of setting the token in the url is
+                # mitigated since these files are not committed, the container is ephemeral
+                # and anyone with access to read the files could read the token from
+                # environment variable. Furthermore we redact the token from the
+                # files after the update.
+                sed -i "s/git@github.com:/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+                git submodule init -q data
+                git submodule update data
+                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
+                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         params:

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -61,7 +61,7 @@ resources:
     type: git
     icon: github
     source:
-      uri: https://github.com/alphagov/pay-productsui
+      uri: https://github.com/alphagov/pay-products-ui
       branch: master
       tag_regex: "alpha_release-(.*)"
   - name: publicauth-git-release

--- a/ci/tasks/pull-image-from-dockerhub.yml
+++ b/ci/tasks/pull-image-from-dockerhub.yml
@@ -10,16 +10,27 @@ params:
   APP_GIT_DIR: AppName
 inputs:
   - name: toolbox-git-release
+    optional: true
   - name: frontend-git-release
+    optional: true
   - name: adminusers-git-release
+    optional: true
   - name: cardid-git-release
+    optional: true
   - name: connector-git-release
+    optional: true
   - name: ledger-git-release
+    optional: true
   - name: products-git-release
+    optional: true
   - name: products-ui-git-release
+    optional: true
   - name: publicapi-git-release
+    optional: true
   - name: publicauth-git-release
+    optional: true
   - name: selfservice-git-release
+    optional: true
 outputs:
   - name: image
 run:

--- a/ci/tasks/pull-image-from-dockerhub.yml
+++ b/ci/tasks/pull-image-from-dockerhub.yml
@@ -7,8 +7,19 @@ params:
   DOCKER_USERNAME: DockerhubUsername
   DOCKER_AUTH_TOKEN: DockerhubAuthToken
   DOCKER_REPOSITORY: DockerhubRepositoryName
+  APP_GIT_DIR: AppName
 inputs:
-  - name: git-app-pre-release
+  - name: toolbox-git-release
+  - name: frontend-git-release
+  - name: adminusers-git-release
+  - name: cardid-git-release
+  - name: connector-git-release
+  - name: ledger-git-release
+  - name: products-git-release
+  - name: products-ui-git-release
+  - name: publicapi-git-release
+  - name: publicauth-git-release
+  - name: selfservice-git-release
 outputs:
   - name: image
 run:
@@ -31,7 +42,7 @@ run:
       echo "Authenticating with Docker Hub..."
       # TODO: use alternative auth method for docker
       echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
-      COMMIT_SHA=$(cat git-app-pre-release/.git/HEAD)
+      COMMIT_SHA=$(cat $APP_GIT_DIR/.git/HEAD)
       docker pull $DOCKER_REPOSITORY:$COMMIT_SHA
 
       docker save $DOCKER_REPOSITORY:$COMMIT_SHA --output image/image.tar

--- a/ci/tasks/pull-image-from-dockerhub.yml
+++ b/ci/tasks/pull-image-from-dockerhub.yml
@@ -4,8 +4,8 @@ image_resource:
   source:
     repository: govukpay/concourse-runner
 params:
-  DOCKER_USERNAME: ((docker-username))
-  DOCKER_AUTH_TOKEN: ((docker-password))
+  DOCKER_USERNAME: DockerhubUsername
+  DOCKER_AUTH_TOKEN: DockerhubAuthToken
   DOCKER_REPOSITORY: DockerhubRepositoryName
 inputs:
   - name: git-app-pre-release

--- a/ci/tasks/pull-image-from-dockerhub.yml
+++ b/ci/tasks/pull-image-from-dockerhub.yml
@@ -1,0 +1,37 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/concourse-runner
+params:
+  DOCKER_USERNAME: ((docker-username))
+  DOCKER_AUTH_TOKEN: ((docker-password))
+  DOCKER_REPOSITORY: DockerhubRepositoryName
+inputs:
+  - name: git-app-pre-release
+outputs:
+  - name: image
+run:
+  path: /bin/bash
+  args:
+    - -ec
+    - |
+      source /docker-helpers.sh
+      start_docker
+
+      function cleanup {
+        echo "CLEANUP TRIGGERED"
+        clean_docker
+        stop_docker
+        echo "CLEANUP COMPLETE"
+      }
+
+      trap cleanup EXIT
+
+      echo "Authenticating with Docker Hub..."
+      # TODO: use alternative auth method for docker
+      echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
+      COMMIT_SHA=$(cat git-app-pre-release/.git/HEAD)
+      docker pull $DOCKER_REPOSITORY:$COMMIT_SHA
+
+      docker save $DOCKER_REPOSITORY:$COMMIT_SHA --output image/image.tar


### PR DESCRIPTION
TODO:
- ~we have duplicated the ECR registry resource for each repo, this could probably be DRYer~
- ~ci/pipelines/toolbox-test-ecr.yml could be renamed but we'll do that later for ease of reviewing just now.~
- ~revert https://github.com/alphagov/pay-ci/pull/363/commits/9e837183aa45cbbe9f25de92d6c7f47dc6e26be0 to put the meta job branch back to `master`~

Used the group formatting to combine all the app tasks into one pipeline, as per the pr-ci pipeline.

Pulling the pay-cardid repo is a special case in that it has a private submodule. To get the repo we have ignored the submodules when pulling:

```
      - get: cardid-git-release
        trigger: true
        params:
          submodules: none
```
And then updated the repo in a separate task akin to https://github.com/alphagov/pay-ci/blob/master/ci/pipelines/pr.yml#L1253-L1286.