### PR TITLE
[PP-7703] (b) Refactored ECR Test Pipeline

### DIFF
--- a/ci/pipelines/test-ecr-push.yml
+++ b/ci/pipelines/test-ecr-push.yml
@@ -1,0 +1,186 @@
+definitions:
+  # ECR Test Registry Definition
+  # Use <<: *ecr-test-registry and update the name and source/repository as
+  # necessary.
+  - &ecr-test-registry
+    name: change-me
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/change-me
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+      tag: ready-staging
+  - &git-pre-relrease
+    name: change-me
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-toolbox
+      branch: master
+      tag_regex: "alpha_release-(.*)"
+  - &concourse-runner-image-resource
+    platform: linux
+    image_resource:
+      type: registry-image
+      source:
+        repository: govukpay/concourse-runner
+
+resource_types:
+  # Custom resource type - this has been merged to the
+  # https://github.com/concourse/registry-image-resource repo,
+  # however is not yet in a stable release. Using this custom
+  # resource type allows us to support the ECR registry_id parameter
+  # This can be removed once registry_id is in stable release of 'registry-image'.
+  - name: dev-registry-image
+    type: registry-image
+    source:
+      repository: concourse/registry-image-resource
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: dev
+
+resources:
+  # Pay CI Repo - For Self Updates
+  - name: ci-repo-update
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master 
+      paths:
+        - ci/pipelines/test-ecr-push.yml
+  # Github Releases
+  - <<: *git-pre-relrease
+    name: git-toolbox-pre-release
+    source:
+      uri: https://github.com/alphagov/pay-toolbox
+  # ECR Registries
+  - <<: *ecr-test-registry
+    name: ecr-test-registry-toolbox
+    source:
+      repository: govukpay/toolbox
+
+groups:
+  - name: ci
+    jobs:
+      - ci-repo-update
+  - name: toolbox
+    jobs:
+      - ecr-test-push-toolbox
+      - ecr-test-deploy-toolbox
+      - ecr-test-smoke-toolbox
+      - ecr-test-retag-toolbox
+
+jobs:
+  - name: ci-repo-update
+    plan:
+      - get: ci-repo-update
+        trigger: true
+      - set_pipeline: ci-repo-update
+        file: ci-repo-update/ci/pipelines/test-ecr-push.yml
+  - name: ecr-test-push-toolbox
+    plan:
+      - get: git-toolbox-pre-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - task: pull-toolbox-from-dockerhub
+        privileged: true
+        config:
+          <<: *concourse-runner-image-resource
+          params:
+            DOCKER_USERNAME: ((docker-username))
+            DOCKER_AUTH_TOKEN: ((docker-password))
+          inputs:
+            - name: git-toolbox-pre-release
+          outputs:
+            - name: image
+            - name: docker_tags
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              source /docker-helpers.sh
+              start_docker
+
+              function cleanup {
+                echo "CLEANUP TRIGGERED"
+                clean_docker
+                stop_docker
+                echo "CLEANUP COMPLETE"
+              }
+
+              trap cleanup EXIT
+
+              echo "Authenticating with Docker Hub..."
+              # TODO: use alternative auth method for docker
+              echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
+              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
+              docker pull govukpay/toolbox:$COMMIT_SHA
+
+              docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
+
+              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
+              GIT_TAG=$(cat git-toolbox-pre-release/.git/ref)
+              echo "$COMMIT_SHA $GIT_TAG" > docker_tags/docker_tags.txt
+      - put: ecr-test-registry-toolbox
+        params:
+          image: image/image.tar
+          additional_tags: docker_tags/docker_tags.txt
+  - name: ecr-test-deploy-toolbox
+    plan:
+      - get: git-toolbox-pre-release
+        passed: [ecr-test-push-toolbox]
+        trigger: true
+      - task: deploy-toolbox-to-test
+        config:
+          <<: *concourse-runner-image-resource
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just deployed to test."
+  - name: ecr-test-smoke-toolbox
+    plan:
+      - get: git-toolbox-pre-release
+        passed: [ecr-test-deploy-toolbox]
+        trigger: true
+      - task: run-smoke-test
+        config:
+          <<: *concourse-runner-image-resource
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on test."
+  - name: ecr-test-retag-toolbox
+    plan:
+      - get: git-toolbox-pre-release
+        passed: [ecr-test-smoke-toolbox]
+        trigger: true
+      - task: combine-passing-tags
+        config:
+          <<: *concourse-runner-image-resource
+          inputs:
+            - name: git-toolbox-pre-release
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
+              GIT_TAG=$(cat git-toolbox-pre-release/.git/ref)
+              echo "$COMMIT_SHA $GIT_TAG ready-staging" > docker_tags/docker_tags.txt
+          outputs:
+            - name: docker_tags
+      - put: ecr-test-registry-toolbox
+        params:
+          image: image/image.tar
+          additional_tags: docker_tags/docker_tags.txt

--- a/ci/pipelines/toolbox-deploy-ecr.yml
+++ b/ci/pipelines/toolbox-deploy-ecr.yml
@@ -1,20 +1,4 @@
 resources:
-  - name: toolbox-deploy-ecr
-    type: git
-    icon: github
-    source:
-      uri: https://github.com/alphagov/pay-ci
-      branch: master 
-      paths:
-        - ci/pipelines/toolbox-deploy-ecr.yml
-  # Github Releases
-  - name: git-toolbox-staging-release
-    type: git
-    icon: github
-    source: &github-release-source
-      uri: https://github.com/alphagov/pay-toolbox
-      branch: master
-      tag_regex: "alpha_staging-2-(.*)"
   # ECR Test registry resource
   - name: ecr-registry-test
     type: dev-registry-image
@@ -29,6 +13,7 @@ resources:
       # Hardcode the test account registry ID for now. Needs to be a string, not a number
       aws_ecr_registry_id: "((pay_aws_test_account_id))"
       aws_region: eu-west-1
+      tag: ready-staging
   # ECR Staging registry resource
   - name: ecr-registry-staging
     type: dev-registry-image
@@ -59,58 +44,90 @@ resource_types:
       tag: dev
 
 jobs:
-  - name: update-toolbox-test-ecr-pipeline
+  - name: toolbox-staging-approval
     plan:
-      - get: toolbox-deploy-ecr
+      - get: ecr-registry-test
         trigger: true
-      - set_pipeline: toolbox-deploy-ecr
-        file: toolbox-test-ecr/ci/pipelines/toolbox-test-ecr.yml
-  - name: toolbox-staging-ecr
-    plan:
-      - get: git-toolbox-staging-release
-        trigger: true
-      # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - task: pull-toolbox-from-ecr-test
-        privileged: true
+        params:
+          format: oci
+      - task: pull-tags-from-ecr
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: amazon/aws-cli
+          params:
+            AWS_ACCESS_KEY_ID: ((test_readonly_access_key_id))
+            AWS_SECRET_ACCESS_KEY: ((test_readonly_secret_access_key))
+            AWS_SESSION_TOKEN: ((test_readonly_session_token))
+            AWS_REGION: eu-west-1
+            AWS_PAGER: ""
+            AWS_DEFAULT_OUTPUT: text
+          inputs:
+            - name: ecr-registry-test
+          outputs:
+            - name: docker_tags
+          run:
+            path: /bin/sh
+            args:
+            - -ec
+            - | 
+              DIGEST=$(cat ecr-registry-test/digest)
+              /usr/local/bin/aws ecr list-images \
+              --repository-name govukpay/toolbox \
+              --query "imageIds[?imageDigest=='$DIGEST'][imageTag]" \
+              | tr '\n' ' ' > docker_tags/tags.txt
+      - put: ecr-registry-staging
+        params:
+          image: ecr-registry-test/image.tar
+          additional_tags: docker_tags/tags.txt
+      - task: deploy-to-staging
         config:
           platform: linux
           image_resource:
             type: registry-image
             source:
               repository: govukpay/concourse-runner
-          params:
-            DOCKER_USERNAME: ((docker-username))
-            DOCKER_AUTH_TOKEN: ((docker-password))
-          inputs:
-            - name: git-toolbox-staging-release
-          outputs:
-            - name: image
           run:
             path: /bin/bash
             args:
             - -ec
             - |
-              source /docker-helpers.sh
-              start_docker
-
-              function cleanup {
-                echo "CLEANUP TRIGGERED"
-                clean_docker
-                stop_docker
-                echo "CLEANUP COMPLETE"
-              }
-
-              trap cleanup EXIT
-
-              echo "Authenticating with Docker Hub..."
-              # TODO: use alternative auth method for docker
-              echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
-              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
-              docker pull govukpay/toolbox:$COMMIT_SHA
-
-              docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
-
+              echo "Imagine we just deployed to staging."
+      - task: smoke-test-on-staging
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on staging."
+      - task: set-passing-tags
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          inputs:
+          - name: docker_tags
+          outputs:
+          - name: docker_tags
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              CONCAT_TAGS="$(cat docker_tags/tags.txt | sed 's/ready-staging/ready-production/g' )"
+              echo $CONCAT_TAGS > docker_tags/tags.txt
       - put: ecr-registry-staging
         params:
-          image: image/image.tar
-          additional_tags: git-toolbox-pre-release/.git/HEAD
+          image: ecr-registry-test/image.tar
+          additional_tags: docker_tags/tags.txt
+      

--- a/ci/pipelines/toolbox-deploy-ecr.yml
+++ b/ci/pipelines/toolbox-deploy-ecr.yml
@@ -1,0 +1,102 @@
+resources:
+  - name: toolbox-deploy-ecr
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master 
+      paths:
+        - ci/pipelines/toolbox-deploy-ecr.yml
+  # Github Releases
+  - name: git-toolbox-staging-release
+    type: git
+    icon: github
+    source: &github-release-source
+      uri: https://github.com/alphagov/pay-toolbox
+      branch: master
+      tag_regex: "alpha_staging-2-(.*)"
+  # ECR registry resource
+  - name: ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/toolbox
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the test account
+      aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_staging_account_id))"
+      aws_region: eu-west-1
+
+resource_types:
+  # Custom resource type - this has been merged to the
+  # https://github.com/concourse/registry-image-resource repo,
+  # however is not yet in a stable release. Using this custom
+  # resource type allows us to support the ECR registry_id parameter
+  # This can be removed once registry_id is in stable release of 'registry-image'.
+  - name: dev-registry-image
+    type: registry-image
+    source:
+      repository: concourse/registry-image-resource
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: dev
+
+jobs:
+  - name: update-toolbox-test-ecr-pipeline
+    plan:
+      - get: toolbox-deploy-ecr
+        trigger: true
+      - set_pipeline: toolbox-deploy-ecr
+        file: toolbox-test-ecr/ci/pipelines/toolbox-test-ecr.yml
+  - name: toolbox-staging-ecr
+    plan:
+      - get: git-toolbox-staging-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - task: pull-toolbox-from-dockerhub
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          params:
+            DOCKER_USERNAME: ((docker-username))
+            DOCKER_AUTH_TOKEN: ((docker-password))
+          inputs:
+            - name: git-toolbox-staging-release
+          outputs:
+            - name: image
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              source /docker-helpers.sh
+              start_docker
+
+              function cleanup {
+                echo "CLEANUP TRIGGERED"
+                clean_docker
+                stop_docker
+                echo "CLEANUP COMPLETE"
+              }
+
+              trap cleanup EXIT
+
+              echo "Authenticating with Docker Hub..."
+              # TODO: use alternative auth method for docker
+              echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
+              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
+              docker pull govukpay/toolbox:$COMMIT_SHA
+
+              docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
+
+      - put: ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: git-toolbox-pre-release/.git/HEAD

--- a/ci/pipelines/toolbox-deploy-ecr.yml
+++ b/ci/pipelines/toolbox-deploy-ecr.yml
@@ -15,7 +15,7 @@ resources:
       uri: https://github.com/alphagov/pay-toolbox
       branch: master
       tag_regex: "alpha_staging-2-(.*)"
-  # ECR registry resource
+  # ECR Test registry resource
   - name: ecr-registry-test
     type: dev-registry-image
     icon: docker
@@ -25,8 +25,22 @@ resources:
       aws_secret_access_key: ((readonly_secret_access_key))
       aws_session_token: ((readonly_session_token))
       # Need to create the role for the concourse user to assume in the test account
-      aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
       # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+  # ECR Staging registry resource
+  - name: ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/toolbox
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      # Need to create the role for the concourse user to assume in the staging account
+      aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+      # Hardcode the staging account registry ID for now. Needs to be a string, not a number
       aws_ecr_registry_id: "((pay_aws_staging_account_id))"
       aws_region: eu-west-1
 
@@ -56,7 +70,7 @@ jobs:
       - get: git-toolbox-staging-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - task: pull-toolbox-from-dockerhub
+      - task: pull-toolbox-from-ecr-test
         privileged: true
         config:
           platform: linux
@@ -96,7 +110,7 @@ jobs:
 
               docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
 
-      - put: ecr-registry-test
+      - put: ecr-registry-staging
         params:
           image: image/image.tar
           additional_tags: git-toolbox-pre-release/.git/HEAD

--- a/ci/pipelines/toolbox-staging-ecr.yml
+++ b/ci/pipelines/toolbox-staging-ecr.yml
@@ -65,7 +65,7 @@ jobs:
       #       - -ec
       #       - |
       #         cat "[profile default]" > .aws/config
-      - task: pull-tags-from-ecr
+      - task: pull-tags-from-ecr-registry-test
         config:
           platform: linux
           image_resource:
@@ -142,7 +142,7 @@ jobs:
             - -ec
             - |
               echo "Imagine we just smoked on staging."
-      - task: set-passing-tags
+      - task: set-ready-for-production-tags
         config:
           platform: linux
           image_resource:

--- a/ci/pipelines/toolbox-staging-ecr.yml
+++ b/ci/pipelines/toolbox-staging-ecr.yml
@@ -50,21 +50,6 @@ jobs:
         trigger: true
         params:
           format: oci
-      # - task: prepare-aws-config
-      #   config:
-      #     platform: linux
-      #     image_resource:
-      #       type: registry-image
-      #       source:
-      #         repository: govukpay/concourse-runner
-      #     outputs:
-      #       - name: .aws
-      #     run:
-      #       path: /bin/bash
-      #       args:
-      #       - -ec
-      #       - |
-      #         cat "[profile default]" > .aws/config
       - task: pull-tags-from-ecr-registry-test
         config:
           platform: linux

--- a/ci/pipelines/toolbox-staging-ecr.yml
+++ b/ci/pipelines/toolbox-staging-ecr.yml
@@ -80,7 +80,6 @@ jobs:
               --role-arn $AWS_ASSUME_ROLE_ARN \
               --role-session-name ecr-test-session \
               --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-              --output text \
               ) )
 
               export AWS_ACCESS_KEY_ID=${assumed_role[0]}

--- a/ci/pipelines/toolbox-staging-ecr.yml
+++ b/ci/pipelines/toolbox-staging-ecr.yml
@@ -50,6 +50,21 @@ jobs:
         trigger: true
         params:
           format: oci
+      # - task: prepare-aws-config
+      #   config:
+      #     platform: linux
+      #     image_resource:
+      #       type: registry-image
+      #       source:
+      #         repository: govukpay/concourse-runner
+      #     outputs:
+      #       - name: .aws
+      #     run:
+      #       path: /bin/bash
+      #       args:
+      #       - -ec
+      #       - |
+      #         cat "[profile default]" > .aws/config
       - task: pull-tags-from-ecr
         config:
           platform: linux
@@ -58,9 +73,11 @@ jobs:
             source:
               repository: amazon/aws-cli
           params:
-            AWS_ACCESS_KEY_ID: ((test_readonly_access_key_id))
-            AWS_SECRET_ACCESS_KEY: ((test_readonly_secret_access_key))
-            AWS_SESSION_TOKEN: ((test_readonly_session_token))
+            AWS_ACCESS_KEY_ID: ((readonly_access_key_id))
+            AWS_SECRET_ACCESS_KEY: ((readonly_secret_access_key))
+            AWS_SESSION_TOKEN: ((readonly_session_token))
+            AWS_ASSUME_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+            AWS_REGISTRY_ID: "((pay_aws_test_account_id))"
             AWS_REGION: eu-west-1
             AWS_PAGER: ""
             AWS_DEFAULT_OUTPUT: text
@@ -74,7 +91,24 @@ jobs:
             - -ec
             - | 
               DIGEST=$(cat ecr-registry-test/digest)
-              /usr/local/bin/aws ecr list-images \
+              assumed_role=($(aws sts assume-role \
+              --role-arn $AWS_ASSUME_ROLE_ARN \
+              --role-session-name ecr-test-session \
+              --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+              --output text \
+              ) )
+
+              export AWS_ACCESS_KEY_ID=${assumed_role[0]}
+              export AWS_SECRET_ACCESS_KEY=${assumed_role[1]}
+              export AWS_SESSION_TOKEN=${assumed_role[2]}
+
+              aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile ecr-test-session
+              aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile ecr-test-session
+              aws configure set aws_session_token $AWS_SESSION_TOKEN --profile ecr-test-session
+
+              aws ecr list-images \
+              --profile ecr-test-session \
+              --registry-id $AWS_REGISTRY_ID \
               --repository-name govukpay/toolbox \
               --query "imageIds[?imageDigest=='$DIGEST'][imageTag]" \
               | tr '\n' ' ' > docker_tags/tags.txt

--- a/ci/pipelines/toolbox-staging-ecr.yml
+++ b/ci/pipelines/toolbox-staging-ecr.yml
@@ -156,8 +156,7 @@ jobs:
             args:
             - -ec
             - |
-              CONCAT_TAGS="$(cat docker_tags/tags.txt | sed 's/ready-staging/ready-production/g' )"
-              echo $CONCAT_TAGS > docker_tags/tags.txt
+              sed -i'' 's/ready-staging/ready-production/g' docker_tags/tags.txt
       - put: ecr-registry-staging
         params:
           image: ecr-registry-test/image.tar

--- a/ci/pipelines/toolbox-staging-ecr.yml
+++ b/ci/pipelines/toolbox-staging-ecr.yml
@@ -1,4 +1,12 @@
 resources:
+  - name: toolbox-staging-ecr
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master 
+      paths:
+        - ci/pipelines/toolbox-test-ecr.yml
   # ECR Test registry resource
   - name: ecr-registry-test
     type: dev-registry-image
@@ -44,6 +52,12 @@ resource_types:
       tag: dev
 
 jobs:
+  - name: update-toolbox-staging-ecr-pipeline
+    plan:
+      - get: toolbox-staging-ecr
+        trigger: true
+      - set_pipeline: toolbox-staging-ecr
+        file: toolbox-staging-ecr/ci/pipelines/toolbox-staging-ecr.yml
   - name: toolbox-staging-approval
     plan:
       - get: ecr-registry-test

--- a/ci/pipelines/toolbox-staging-ecr.yml
+++ b/ci/pipelines/toolbox-staging-ecr.yml
@@ -16,9 +16,7 @@ resources:
       aws_access_key_id: ((readonly_access_key_id))
       aws_secret_access_key: ((readonly_secret_access_key))
       aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the test account
       aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      # Hardcode the test account registry ID for now. Needs to be a string, not a number
       aws_ecr_registry_id: "((pay_aws_test_account_id))"
       aws_region: eu-west-1
       tag: ready-staging
@@ -31,9 +29,7 @@ resources:
       aws_access_key_id: ((readonly_access_key_id))
       aws_secret_access_key: ((readonly_secret_access_key))
       aws_session_token: ((readonly_session_token))
-      # Need to create the role for the concourse user to assume in the staging account
       aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
-      # Hardcode the staging account registry ID for now. Needs to be a string, not a number
       aws_ecr_registry_id: "((pay_aws_staging_account_id))"
       aws_region: eu-west-1
 

--- a/ci/pipelines/toolbox-test-ecr.yml
+++ b/ci/pipelines/toolbox-test-ecr.yml
@@ -100,3 +100,53 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: git-toolbox-pre-release/.git/HEAD
+      - task: deploy-to-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just deployed to test."
+      - task: smoke-test-on-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on test."
+      - task: combine-passing-tags
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          inputs:
+            - name: git-toolbox-pre-release
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              CONCAT_TAGS="$(cat git-toolbox-pre-release/.git/HEAD) ready-staging"
+              echo "Contents of CONCAT_TAGS: $CONCAT_TAGS"
+              ls -alh
+              echo $CONCAT_TAGS > docker_tags/docker_tags.txt
+          outputs:
+            - name: docker_tags
+      - put: ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: docker_tags/docker_tags.txt

--- a/ci/pipelines/toolbox-test-ecr.yml
+++ b/ci/pipelines/toolbox-test-ecr.yml
@@ -141,8 +141,6 @@ jobs:
             - -ec
             - |
               CONCAT_TAGS="$(cat git-toolbox-pre-release/.git/HEAD) ready-staging"
-              echo "Contents of CONCAT_TAGS: $CONCAT_TAGS"
-              ls -alh
               echo $CONCAT_TAGS > docker_tags/docker_tags.txt
           outputs:
             - name: docker_tags

--- a/ci/pipelines/toolbox-test-ecr.yml
+++ b/ci/pipelines/toolbox-test-ecr.yml
@@ -71,6 +71,7 @@ jobs:
             - name: git-toolbox-pre-release
           outputs:
             - name: image
+            - name: docker_tags
           run:
             path: /bin/bash
             args:
@@ -96,10 +97,13 @@ jobs:
 
               docker save govukpay/toolbox:$COMMIT_SHA --output image/image.tar
 
+              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
+              GIT_TAG=$(cat git-toolbox-pre-release/.git/ref)
+              echo "$COMMIT_SHA $GIT_TAG" > docker_tags/docker_tags.txt
       - put: ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: git-toolbox-pre-release/.git/HEAD
+          additional_tags: docker_tags/docker_tags.txt
       - task: deploy-to-test
         config:
           platform: linux
@@ -140,8 +144,9 @@ jobs:
             args:
             - -ec
             - |
-              CONCAT_TAGS="$(cat git-toolbox-pre-release/.git/HEAD) ready-staging"
-              echo $CONCAT_TAGS > docker_tags/docker_tags.txt
+              COMMIT_SHA=$(cat git-toolbox-pre-release/.git/HEAD)
+              GIT_TAG=$(cat git-toolbox-pre-release/.git/ref)
+              echo "$COMMIT_SHA $GIT_TAG ready-staging" > docker_tags/docker_tags.txt
           outputs:
             - name: docker_tags
       - put: ecr-registry-test


### PR DESCRIPTION
## What?
This has been split out from the original branch `PP-7703-add-staging-ecr-deployment` (located here: https://github.com/alphagov/pay-ci/pull/362)

This refactors the "ECR Toolbox Test" Pipeline into a combination of reusable definitions, basic Concourse Groups as well as splitting out the (placeholder) tests into separate jobs.