### PR TITLE
PP-7683: Fix file location

### DIFF
--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -220,7 +220,7 @@ definitions:
   - &pull-image-from-dockerhub
     task: pull-image-from-dockerhub
     privileged: true
-    file: toolbox-test-ecr/ci/tasks/pull-image-from-dockerhub.yml
+    file: apps-test-ecr/ci/tasks/pull-image-from-dockerhub.yml
     params:
       DOCKER_USERNAME: updateThisValue
       DOCKER_AUTH_TOKEN: updateThisValue


### PR DESCRIPTION
pull-image-from-dockerhub.yml is located in the apps-test-ecr directory as
specified by the apps-test-ecr resource.

This fixes the error
```
unknown artifact source: 'toolbox-test-ecr' in task config file path 'toolbox-test-ecr/ci/tasks/pull-image-from-dockerhub.yml'
```
(see https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/apps-test-ecr/jobs/products-ui-image-to-test-ecr/builds/10)