### PR TITLE
BAU: fix ci-pr-test failures

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1058,7 +1058,6 @@ jobs:
     plan:
     - <<: *get-pull-request
       resource: java-commons-pull-request
-    - <<: *get-ci
     - <<: *put-integration-test-pending-status
       put: java-commons-pull-request
     - task: test
@@ -2081,7 +2080,6 @@ jobs:
     plan:
     - <<: *get-pull-request
       resource: stubs-pull-request
-    - <<: *get-ci
     - <<: *put-test-pending-status
       put: stubs-pull-request
     - task: run tests

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1386,11 +1386,12 @@ jobs:
         outputs:
           - name: pacts
         run:
-          path: sh
+          path: bash
           dir: src
           args:
             - -ec
             - |
+              # shellcheck disable=SC1091
               source /docker-helpers.sh
               start_docker
 
@@ -1409,9 +1410,9 @@ jobs:
                         -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital \
                         -DPACT_BROKER_USERNAME="" \
                         -DPACT_BROKER_PASSWORD="" \
-                        -DPACT_CONSUMER_VERSION=${commit} \
-                        -DPACT_CONSUMER_TAG=${pr} \
-                        -Dpact.provider.version=${commit} \
+                        -DPACT_CONSUMER_VERSION="${commit}" \
+                        -DPACT_CONSUMER_TAG="${pr}" \
+                        -Dpact.provider.version="${commit}" \
                         -DrunConsumerContractTests=true
               cp -R target/pacts/* ../pacts/ || true
 

--- a/ci/tasks/java-package.yml
+++ b/ci/tasks/java-package.yml
@@ -32,6 +32,5 @@ run:
     EOF
 
     mvn --global-settings settings.xml clean package -DskipTests
-    PR_NUMBER="PR-$(cat .git/resource/pr)"
     cd ..
     cp -R src/* build

--- a/ci/tasks/java-tests.yml
+++ b/ci/tasks/java-tests.yml
@@ -34,6 +34,5 @@ run:
     EOF
 
     mvn --global-settings settings.xml clean package
-    PR_NUMBER="PR-$(cat .git/resource/pr)"
     cd ..
     cp -R src/* build

--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -31,10 +31,11 @@ run:
       apt-get -y install ca-certificates wget python libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
       if [[ -f "$(pwd)/scripts/generate-dev-environment.js" ]]; then
-        node $(pwd)/scripts/generate-dev-environment.js local
+        node "$(pwd)/scripts/generate-dev-environment.js" local
       fi
 
-      export CYPRESS_CACHE_FOLDER=$(pwd)/../cypress_cache
+      CYPRESS_CACHE_FOLDER=$(pwd)/../cypress_cache
+      export CYPRESS_CACHE_FOLDER
       npm config set cache ../npm_cache
       npm rebuild node-sass
       npm ci

--- a/ci/tasks/node-build.yml
+++ b/ci/tasks/node-build.yml
@@ -21,7 +21,7 @@ params:
   APP_NAME: app
 
 run:
-  path: sh
+  path: bash
   dir: src
   args:
     - -ec

--- a/ci/tasks/pact-provider-test-preflight-check.yml
+++ b/ci/tasks/pact-provider-test-preflight-check.yml
@@ -15,7 +15,7 @@ outputs:
 caches:
   - path: src/.m2
 run:
-  path: sh
+  path: bash
   args:
     - -ec
     - |

--- a/ci/tasks/pact-provider-verification.yml
+++ b/ci/tasks/pact-provider-verification.yml
@@ -15,7 +15,7 @@ inputs:
 caches:
   - path: test_target/.m2
 run:
-  path: sh
+  path: bash
   args:
     - -ec
     - |

--- a/ci/tasks/publish-pacts.yml
+++ b/ci/tasks/publish-pacts.yml
@@ -11,7 +11,7 @@ params:
   broker_username: ((pact-broker-username))
   broker_password: ((pact-broker-password))
 run:
-  path: sh
+  path: bash
   args:
     - -c
     - |
@@ -24,14 +24,16 @@ run:
       version="$(cat src/.git/resource/head_sha)"
       pr="$(cat src/.git/resource/pr)"
       cd pacts || exit 1
+
+      # shellcheck disable=SC2010
       for pact in $(ls . | grep -v '\-to\-'); do
         provider_name=$(jq .provider.name < "$pact" | tr -d '"')
         curl -v --fail -X PUT -H "Content-Type: application/json" \
         -d@"$pact" \
-        --user ${broker_username}:${broker_password} \
+        --user "${broker_username}":"${broker_password}" \
         https://pay-concourse-pact-broker.cloudapps.digital/pacts/provider/"${provider_name}"/consumer/"${consumer_name}"/version/"${version}"
         
         curl -v --fail -X PUT -H "Content-Type: application/json" \
-        --user ${broker_username}:${broker_password} \
+        --user "${broker_username}":"${broker_password}" \
         https://pay-concourse-pact-broker.cloudapps.digital/pacticipants/"${consumer_name}"/versions/"${version}"/tags/"${pr}"
       done

--- a/ci/tasks/zip-build.yml
+++ b/ci/tasks/zip-build.yml
@@ -10,7 +10,7 @@ outputs:
 params:
   app_name:
 run:
-  path: sh
+  path: bash
   args:
     - -ec
     - |


### PR DESCRIPTION
## What
The `pr-ci/ci-pr-test` job has been failing consistently for some weeks (see [an example failed build](https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/pr-ci/jobs/ci-pr-test/builds/47.1)).

This job has been using [pipecleaner](https://github.com/alphagov/paas-cf/tree/main/tools/pipecleaner#features) to run several checks:
- Concourse's own validation
- Shellcheck on any shell or bash scripts
- Resource check, to flag any unused resources in a job description
- (Pipecleaner can also run Rubocop, but we've disabled that option)

I don't think the repo-renaming itself caused the failures, however we can't check further back as the old `omnibus-pr-test` pipeline no longer exists on Big Concourse.

## How
I've gone by the shellcheck suggestions, and validated those using the [online shellcheck tool](https://www.shellcheck.net/), as my local version of `pipecleaner` wasn't working for some reason. 

I've used `bash` instead of `sh` to resolve most of the errors - we're using for some tasks already, so may as well be consistent.

I added two 'ignores' for shellcheck, in `pr.yml` and `tasks/publish-pacts.yml` - not because they are unfixable, but because they are just time-consuming enough to get bogged down in, and I suspect they're actually are fine in context. I am willing to be persuaded!

## Not included in this PR
I haven't fixed the deprecation warnings - there are a lot of them and this PR is already full of small fiddly changes.