### PR TITLE
PP-7683 - Automatically trigger nginx-forward-proxy Concourse job on new Dockerhub release

### DIFF
--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -544,6 +544,7 @@ jobs:
     plan:
       - get: apps-test-ecr
       - get: nginx-forward-proxy-dockerhub-release
+        trigger: true
         params:
           format: oci
       # Temporarily fetch image from Dockerhub until Concourse can build its own


### PR DESCRIPTION
Description:
- This PR ensures that the nginx-forward-proxy job is triggered automatically on a new docker image release