### PR TITLE
PP-7794 Parse release tags task

### DIFF
--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -1,0 +1,16 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: alpine
+inputs:
+  - name: git-release
+outputs:
+  - name: tags
+run:
+  path: sh
+  args:
+    - -ec
+    - |
+      RELEASE_NUMBER=$(cat git-release/.git/ref | sed 's/alpha_release-//')
+      echo "${RELEASE_NUMBER}-release" > tags/tags


### PR DESCRIPTION
Generic task that takes a git release (assuming it is tagged `alpha_release-XXX`) and writes out a docker tag of form `XXX-release`. We can use input mapping to use this for all our pipelines.