### PR TITLE
PP-7794 split remaining app pipelines #1

### DIFF
--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -25,6 +25,13 @@ resources:
       branch: master
       paths:
         - ci/pipelines/apps-test-ecr.yml
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+      
   # Github Releases
   - name: toolbox-git-release
     type: git
@@ -199,12 +206,17 @@ resources:
     source:
       repository: govukpay/nginx-forward-proxy
       <<: *aws_test_config
-
   - name: toolbox-ecr-registry-staging
     type: dev-registry-image
     icon: docker
     source:
       repository: govukpay/toolbox
+      <<: *aws_staging_config
+  - name: frontend-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/frontend
       <<: *aws_staging_config
 
 
@@ -239,7 +251,10 @@ groups:
       - push-toolbox-to-staging-ecr
   - name: frontend
     jobs:
-      - frontend-image-to-test-ecr
+      - push-frontend-to-test-ecr
+      - deploy-frontend
+      - smoke-test-frontend
+      - push-frontend-to-staging-ecr
   - name: adminusers
     jobs:
       - adminusers-image-to-test-ecr
@@ -278,7 +293,7 @@ definitions:
   - &pull-image-from-dockerhub
     task: pull-image-from-dockerhub
     privileged: true
-    file: apps-test-ecr/ci/tasks/pull-image-from-dockerhub.yml
+    file: pay-ci/ci/tasks/pull-image-from-dockerhub.yml
     params:
       DOCKER_USERNAME: updateThisValue
       DOCKER_AUTH_TOKEN: updateThisValue
@@ -298,7 +313,7 @@ jobs:
         file: apps-test-ecr/ci/pipelines/apps-test-ecr.yml
   - name: push-toolbox-to-test-ecr
     plan:
-      - get: apps-test-ecr
+      - get: pay-ci
       - get: toolbox-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -308,27 +323,13 @@ jobs:
           APP_GIT_DIR: toolbox-git-release
           <<: *docker_credentials
       - task: parse-release-tag
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          inputs:
-            - name: toolbox-git-release
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                RELEASE_NUMBER=$(cat toolbox-git-release/.git/ref | sed 's/alpha_release-//')
-                echo "${RELEASE_NUMBER}-release" > docker_tags/docker_tags.txt
-          outputs:
-            - name: docker_tags
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: toolbox-git-release
       - put: toolbox-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: docker_tags/docker_tags.txt
+          additional_tags: tags/tags
   - name: deploy-toolbox
     plan:
       - get: toolbox-ecr-registry-test
@@ -376,9 +377,9 @@ jobs:
           image: toolbox-ecr-registry-test/image.tar
           additional_tags: toolbox-ecr-registry-test/tag
 
-  - name: frontend-image-to-test-ecr
+  - name: push-frontend-to-test-ecr
     plan:
-      - get: apps-test-ecr
+      - get: pay-ci
       - get: frontend-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -387,10 +388,61 @@ jobs:
           DOCKER_REPOSITORY: govukpay/frontend
           APP_GIT_DIR: frontend-git-release
           <<: *docker_credentials
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: frontend-git-release
       - put: frontend-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: frontend-git-release/.git/HEAD
+          additional_tags: tags/tags
+  - name: deploy-frontend
+    plan:
+      - get: frontend-ecr-registry-test
+        trigger: true
+      - task: deploy-to-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just deployed to test."
+  - name: smoke-test-frontend
+    plan:
+      - get: frontend-ecr-registry-test
+        trigger: true
+        passed: [deploy-frontend]
+      - task: smoke-test-on-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just smoked on test."
+  - name: push-frontend-to-staging-ecr
+    plan:
+      - get: frontend-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-frontend]
+      - put: frontend-ecr-registry-staging
+        params:
+          image: frontend-ecr-registry-test/image.tar
+          additional_tags: frontend-ecr-registry-test/tag
+
   - name: adminusers-image-to-test-ecr
     plan:
       - get: apps-test-ecr

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -230,6 +230,12 @@ resources:
     source:
       repository: govukpay/connector
       <<: *aws_staging_config
+  - name: ledger-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/ledger
+      <<: *aws_staging_config
 
 
 resource_types:
@@ -279,12 +285,15 @@ groups:
       - deploy-connector
       - smoke-test-connector
       - push-connector-to-staging-ecr
+  - name: ledger
+    jobs:
+      - push-ledger-to-test-ecr
+      - deploy-ledger
+      - smoke-test-ledger
+      - push-ledger-to-staging-ecr
   - name: cardid
     jobs:
       - cardid-image-to-test-ecr
-  - name: ledger
-    jobs:
-      - ledger-image-to-test-ecr
   - name: products
     jobs:
       - products-image-to-test-ecr
@@ -592,6 +601,71 @@ jobs:
         params:
           image: connector-ecr-registry-test/image.tar
           additional_tags: connector-ecr-registry-test/tag
+  - name: push-ledger-to-test-ecr
+    plan:
+      - get: pay-ci
+      - get: ledger-git-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/ledger
+          APP_GIT_DIR: ledger-git-release
+          <<: *docker_credentials
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: ledger-git-release
+      - put: ledger-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: tags/tags
+  - name: deploy-ledger
+    plan:
+      - get: ledger-ecr-registry-test
+        trigger: true
+      - task: deploy-to-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just deployed to test."
+  - name: smoke-test-ledger
+    plan:
+      - get: ledger-ecr-registry-test
+        trigger: true
+        passed: [deploy-ledger]
+      - task: smoke-test-on-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just smoked on test."
+  - name: push-ledger-to-staging-ecr
+    plan:
+      - get: ledger-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-ledger]
+      - put: ledger-ecr-registry-staging
+        params:
+          image: ledger-ecr-registry-test/image.tar
+          additional_tags: ledger-ecr-registry-test/tag
 
   - name: cardid-image-to-test-ecr
     plan:
@@ -643,22 +717,6 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: cardid-git-release/.git/HEAD
-
-  - name: ledger-image-to-test-ecr
-    plan:
-      - get: apps-test-ecr
-      - get: ledger-git-release
-        trigger: true
-      # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - <<: *pull-image-from-dockerhub
-        params:
-          DOCKER_REPOSITORY: govukpay/ledger
-          APP_GIT_DIR: ledger-git-release
-          <<: *docker_credentials
-      - put: ledger-ecr-registry-test
-        params:
-          image: image/image.tar
-          additional_tags: ledger-git-release/.git/HEAD
   - name: products-image-to-test-ecr
     plan:
       - get: apps-test-ecr

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -224,6 +224,12 @@ resources:
     source:
       repository: govukpay/adminusers
       <<: *aws_staging_config
+  - name: connector-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/connector
+      <<: *aws_staging_config
 
 
 resource_types:
@@ -267,12 +273,15 @@ groups:
       - deploy-adminusers
       - smoke-test-adminusers
       - push-adminusers-to-staging-ecr
+  - name: connector
+    jobs:
+      - push-connector-to-test-ecr
+      - deploy-connector
+      - smoke-test-connector
+      - push-connector-to-staging-ecr
   - name: cardid
     jobs:
       - cardid-image-to-test-ecr
-  - name: connector
-    jobs:
-      - connector-image-to-test-ecr
   - name: ledger
     jobs:
       - ledger-image-to-test-ecr
@@ -518,6 +527,72 @@ jobs:
           image: adminusers-ecr-registry-test/image.tar
           additional_tags: adminusers-ecr-registry-test/tag
 
+  - name: push-connector-to-test-ecr
+    plan:
+      - get: pay-ci
+      - get: connector-git-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/connector
+          APP_GIT_DIR: connector-git-release
+          <<: *docker_credentials
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: connector-git-release
+      - put: connector-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: tags/tags
+  - name: deploy-connector
+    plan:
+      - get: connector-ecr-registry-test
+        trigger: true
+      - task: deploy-to-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just deployed to test."
+  - name: smoke-test-connector
+    plan:
+      - get: connector-ecr-registry-test
+        trigger: true
+        passed: [deploy-connector]
+      - task: smoke-test-on-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just smoked on test."
+  - name: push-connector-to-staging-ecr
+    plan:
+      - get: connector-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-connector]
+      - put: connector-ecr-registry-staging
+        params:
+          image: connector-ecr-registry-test/image.tar
+          additional_tags: connector-ecr-registry-test/tag
+
   - name: cardid-image-to-test-ecr
     plan:
       - get: apps-test-ecr
@@ -568,21 +643,7 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: cardid-git-release/.git/HEAD
-  - name: connector-image-to-test-ecr
-    plan:
-      - get: apps-test-ecr
-      - get: connector-git-release
-        trigger: true
-      # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - <<: *pull-image-from-dockerhub
-        params:
-          DOCKER_REPOSITORY: govukpay/connector
-          APP_GIT_DIR: connector-git-release
-          <<: *docker_credentials
-      - put: connector-ecr-registry-test
-        params:
-          image: image/image.tar
-          additional_tags: connector-git-release/.git/HEAD
+
   - name: ledger-image-to-test-ecr
     plan:
       - get: apps-test-ecr

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -218,6 +218,12 @@ resources:
     source:
       repository: govukpay/frontend
       <<: *aws_staging_config
+  - name: adminusers-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      <<: *aws_staging_config
 
 
 resource_types:
@@ -257,7 +263,10 @@ groups:
       - push-frontend-to-staging-ecr
   - name: adminusers
     jobs:
-      - adminusers-image-to-test-ecr
+      - push-adminusers-to-test-ecr
+      - deploy-adminusers
+      - smoke-test-adminusers
+      - push-adminusers-to-staging-ecr
   - name: cardid
     jobs:
       - cardid-image-to-test-ecr
@@ -443,9 +452,9 @@ jobs:
           image: frontend-ecr-registry-test/image.tar
           additional_tags: frontend-ecr-registry-test/tag
 
-  - name: adminusers-image-to-test-ecr
+  - name: push-adminusers-to-test-ecr
     plan:
-      - get: apps-test-ecr
+      - get: pay-ci
       - get: adminusers-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -454,10 +463,61 @@ jobs:
           DOCKER_REPOSITORY: govukpay/adminusers
           APP_GIT_DIR: adminusers-git-release
           <<: *docker_credentials
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: adminusers-git-release
       - put: adminusers-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: adminusers-git-release/.git/HEAD
+          additional_tags: tags/tags
+  - name: deploy-adminusers
+    plan:
+      - get: adminusers-ecr-registry-test
+        trigger: true
+      - task: deploy-to-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just deployed to test."
+  - name: smoke-test-adminusers
+    plan:
+      - get: adminusers-ecr-registry-test
+        trigger: true
+        passed: [deploy-adminusers]
+      - task: smoke-test-on-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just smoked on test."
+  - name: push-adminusers-to-staging-ecr
+    plan:
+      - get: adminusers-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-adminusers]
+      - put: adminusers-ecr-registry-staging
+        params:
+          image: adminusers-ecr-registry-test/image.tar
+          additional_tags: adminusers-ecr-registry-test/tag
+
   - name: cardid-image-to-test-ecr
     plan:
       - get: apps-test-ecr

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -236,6 +236,12 @@ resources:
     source:
       repository: govukpay/ledger
       <<: *aws_staging_config
+  - name: products-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/products
+      <<: *aws_staging_config
 
 
 resource_types:
@@ -291,12 +297,15 @@ groups:
       - deploy-ledger
       - smoke-test-ledger
       - push-ledger-to-staging-ecr
+  - name: products
+    jobs:
+      - push-products-to-test-ecr
+      - deploy-products
+      - smoke-test-products
+      - push-products-to-staging-ecr
   - name: cardid
     jobs:
       - cardid-image-to-test-ecr
-  - name: products
-    jobs:
-      - products-image-to-test-ecr
   - name: products-ui
     jobs:
       - products-ui-image-to-test-ecr
@@ -666,6 +675,71 @@ jobs:
         params:
           image: ledger-ecr-registry-test/image.tar
           additional_tags: ledger-ecr-registry-test/tag
+  - name: push-products-to-test-ecr
+    plan:
+      - get: pay-ci
+      - get: products-git-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/products
+          APP_GIT_DIR: products-git-release
+          <<: *docker_credentials
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: products-git-release
+      - put: products-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: tags/tags
+  - name: deploy-products
+    plan:
+      - get: products-ecr-registry-test
+        trigger: true
+      - task: deploy-to-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just deployed to test."
+  - name: smoke-test-products
+    plan:
+      - get: products-ecr-registry-test
+        trigger: true
+        passed: [deploy-products]
+      - task: smoke-test-on-test
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                echo "Imagine we just smoked on test."
+  - name: push-products-to-staging-ecr
+    plan:
+      - get: products-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-products]
+      - put: products-ecr-registry-staging
+        params:
+          image: products-ecr-registry-test/image.tar
+          additional_tags: products-ecr-registry-test/tag
 
   - name: cardid-image-to-test-ecr
     plan:
@@ -717,21 +791,6 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: cardid-git-release/.git/HEAD
-  - name: products-image-to-test-ecr
-    plan:
-      - get: apps-test-ecr
-      - get: products-git-release
-        trigger: true
-      # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - <<: *pull-image-from-dockerhub
-        params:
-          DOCKER_REPOSITORY: govukpay/products
-          APP_GIT_DIR: products-git-release
-          <<: *docker_credentials
-      - put: products-ecr-registry-test
-        params:
-          image: image/image.tar
-          additional_tags: products-git-release/.git/HEAD
   - name: products-ui-image-to-test-ecr
     plan:
       - get: apps-test-ecr


### PR DESCRIPTION
Splits frontend, connector, ledger, adminusers and products pipelines as per pattern established by toolbox. Results have been applied so you can look at concourse to see if things look right