### PR TITLE
PP-7800 wait for deploy

### DIFF
--- a/ci/docker/node-aws-sdk-runner/Dockerfile
+++ b/ci/docker/node-aws-sdk-runner/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:12.20.1-alpine3.12@sha256:e63dd88799eeccf4f2869963bf79fb2aa7fa24aacf22ef9d6603c0c3ee7f4a07
+
+RUN npm install aws-sdk
+

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -434,6 +434,18 @@ jobs:
       - get: toolbox-ecr-registry-test
         trigger: true
       - get: pay-infra
+      - get: pay-ci
+
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+
+      - load_var: role
+        file: assume-role/assume-role.yml
+        format: json
+
       - task: deploy-to-test
         config:
           platform: linux
@@ -445,29 +457,15 @@ jobs:
             source:
               repository: govukpay/terraform-runner
           params:
-            AWS_ACCESS_KEY_ID: ((readonly_access_key_id))
-            AWS_SECRET_ACCESS_KEY: ((readonly_secret_access_key))
-            AWS_SESSION_TOKEN: ((readonly_session_token))
-            AWS_ASSUME_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-            AWS_REGISTRY_ID: "((pay_aws_test_account_id))"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
             AWS_REGION: eu-west-1
-            AWS_PAGER: ""
-            AWS_DEFAULT_OUTPUT: text
           run:
             path: /bin/bash
             args:
               - -ec
               - |
-                assumed_role=($(aws sts assume-role \
-                       --role-arn $AWS_ASSUME_ROLE_ARN \
-                       --role-session-name ecr-test-session \
-                       --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-                       ) )
-
-                export AWS_ACCESS_KEY_ID=${assumed_role[0]}
-                export AWS_SECRET_ACCESS_KEY=${assumed_role[1]}
-                export AWS_SESSION_TOKEN=${assumed_role[2]}
-
                 application_image_tag=$(cat toolbox-ecr-registry-test/tag)
 
                 cd pay-infra/provisioning/terraform/deployments/test/test-12/microservices_v2/toolbox
@@ -480,6 +478,19 @@ jobs:
                   -var nginx_image_tag='' \
                   -auto-approve
 
+      - task: wait-for-deploy
+        config:
+          inputs:
+            - name: pay-ci
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/wait-for-deploy.js
   - name: smoke-test-toolbox
     plan:
       - get: toolbox-ecr-registry-test

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -435,17 +435,16 @@ jobs:
         trigger: true
       - get: pay-infra
       - get: pay-ci
-
+      - load_var: tag
+        file: toolbox-ecr-registry-test/tag
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
           AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
           AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
-
       - load_var: role
         file: assume-role/assume-role.yml
         format: json
-
       - task: deploy-to-test
         config:
           platform: linux
@@ -455,29 +454,25 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/terraform-runner
+              repository: hashicorp/terraform
+              tag: 0.13.4
           params:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
             AWS_REGION: eu-west-1
+            TAG: ((.:tag))
           run:
-            path: /bin/bash
+            path: /bin/sh
             args:
               - -ec
               - |
-                application_image_tag=$(cat toolbox-ecr-registry-test/tag)
-
                 cd pay-infra/provisioning/terraform/deployments/test/test-12/microservices_v2/toolbox
                 terraform init
-                terraform plan \
-                  -var application_image_tag=$application_image_tag \
-                  -var nginx_image_tag=''
                 terraform apply \
-                  -var application_image_tag=$application_image_tag \
+                  -var application_image_tag=${TAG} \
                   -var nginx_image_tag='' \
                   -auto-approve
-
       - task: wait-for-deploy
         config:
           inputs:
@@ -487,6 +482,11 @@ jobs:
             type: registry-image
             source:
               repository: govukpay/node-aws-sdk-runner
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_REGION: eu-west-1
           run:
             path: node
             args:

--- a/ci/scripts/wait-for-deploy.js
+++ b/ci/scripts/wait-for-deploy.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const AWS = require("aws-sdk")
+const ecs = new AWS.ECS()
+const MAX_RETRIES = 120
+const CHECK_INTERVAL = 5000
+
+const describeServices = async function describeServices() {
+  const params = {
+    services: ['toolbox'],
+    cluster: 'test-12-fargate'
+  };
+  return await ecs.describeServices(params).promise()
+}
+
+const run = async function run() {
+  let uncompletedDeployments
+  let counter = 0
+  const deploymentChecker = setInterval(async () => {
+    counter++
+    if (counter === MAX_RETRIES) {
+      console.log(`Deployment did not complete after ${MAX_RETRIES*CHECK_INTERVAL} seconds.`)
+      process.exitCode = 1
+      clearInterval(deploymentChecker)
+    }
+    const data = await describeServices()
+    uncompletedDeployments = data.services[0].deployments
+      .filter(deployment => deployment.rolloutState !== 'COMPLETED')
+    if (uncompletedDeployments.length === 0) {
+      console.log('Deployment successful')
+      clearInterval(deploymentChecker)
+    } else {
+      const {taskDefinition, rolloutState, rolloutStateReason, desiredCount, pendingCount, runningCount} = uncompletedDeployments[0]
+      if (rolloutState === 'FAILED') {
+        console.log(
+          `Deployment failed.
+           Reason ${rolloutStateReason}`
+        )
+        process.exitCode = 1
+        clearInterval(deploymentChecker)
+      }
+      if (rolloutState === 'IN_PROGRESS' && counter === 1) {
+        console.log(
+          `Deploying task definition: ${taskDefinition}
+           Current status: ${rolloutState}
+           Desired count: ${desiredCount}
+           Pending count: ${pendingCount}
+           Running count: ${runningCount}`
+        )
+      }
+     }
+  }, CHECK_INTERVAL)
+}
+
+run()

--- a/ci/tasks/assume-role.yml
+++ b/ci/tasks/assume-role.yml
@@ -1,0 +1,36 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: amazon/aws-cli
+    tag: '2.0.44'
+outputs:
+  - name: assume-role
+params:
+  AWS_ROLE_ARN:
+  AWS_ROLE_SESSION_NAME:
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      set -eu
+      aws sts assume-role \
+        --role-arn "${AWS_ROLE_ARN}" \
+        --role-session-name "${AWS_ROLE_SESSION_NAME}" \
+      | python -c '
+      import json
+      import re
+      import sys
+
+      creds = json.loads(sys.stdin.read())["Credentials"]
+
+      vars = {}
+      for k, val in creds.items():
+        var_name = re.sub(r"(?<!^)(?=[A-Z])", "_", k).upper()
+        var_name = "AWS_" + var_name
+        vars[var_name] = val
+
+      print json.dumps(vars)
+      ' > assume-role/assume-role.yml


### PR DESCRIPTION
Adds task to wait for successful ECS deployment using a node script. We have factored out the `assume-role` task and used `load_var` to use the role in both deployment  and waiting tasks (thanks to @rjbaker for this).
See commit s for more detail.