### PR TITLE
PP-7800 jsify assume role task

### DIFF
--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -443,7 +443,7 @@ jobs:
           AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
           AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
       - load_var: role
-        file: assume-role/assume-role.yml
+        file: assume-role/assume-role.json
         format: json
       - task: deploy-to-test
         config:

--- a/ci/scripts/assume-role.js
+++ b/ci/scripts/assume-role.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const AWS = require('aws-sdk')
+
+const sts = new AWS.STS()
+
+const run = async function run() {
+  const assumeRoleResponse = await sts.assumeRole({
+    RoleArn: process.env.AWS_ROLE_ARN,
+    RoleSessionName: process.env.AWS_ROLE_SESSION_NAME
+  }).promise()
+  const tempCreds = assumeRoleResponse.Credentials
+
+  fs.writeFileSync('assume-role/assume-role.json', JSON.stringify({
+    AWS_ACCESS_KEY_ID: tempCreds.AccessKeyId,
+    AWS_SECRET_ACCESS_KEY: tempCreds.SecretAccessKey,
+    AWS_SESSION_TOKEN: tempCreds.SessionToken
+  }))
+}
+
+run()

--- a/ci/tasks/assume-role.yml
+++ b/ci/tasks/assume-role.yml
@@ -3,34 +3,14 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: amazon/aws-cli
-    tag: '2.0.44'
+    repository: govukpay/node-aws-sdk-runner
+inputs:
+  - name: pay-ci
 outputs:
   - name: assume-role
 params:
   AWS_ROLE_ARN:
   AWS_ROLE_SESSION_NAME:
 run:
-  path: sh
-  args:
-    - -c
-    - |
-      set -eu
-      aws sts assume-role \
-        --role-arn "${AWS_ROLE_ARN}" \
-        --role-session-name "${AWS_ROLE_SESSION_NAME}" \
-      | python -c '
-      import json
-      import re
-      import sys
-
-      creds = json.loads(sys.stdin.read())["Credentials"]
-
-      vars = {}
-      for k, val in creds.items():
-        var_name = re.sub(r"(?<!^)(?=[A-Z])", "_", k).upper()
-        var_name = "AWS_" + var_name
-        vars[var_name] = val
-
-      print json.dumps(vars)
-      ' > assume-role/assume-role.yml
+  path: node
+  args: ['pay-ci/ci/scripts/assume-role.js']


### PR DESCRIPTION
Use node instead of python + bash to do assume role task. Makes it more maintainable, and clearer.