### PR TITLE
PP-7834: Scripts to get git sha for a release tag

### DIFF
--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:12.20.1-alpine3.12@sha256:e63dd88799eeccf4f2869963bf79fb2aa7fa24aacf22ef9d6603c0c3ee7f4a07
 
 RUN npm install aws-sdk
+RUN npm install @octokit/rest
 

--- a/ci/pipelines/apps-test-ecr.yml
+++ b/ci/pipelines/apps-test-ecr.yml
@@ -326,6 +326,7 @@ groups:
       - push-frontend-to-test-ecr
       - deploy-frontend
       - smoke-test-frontend
+      - frontend-pact-tag
       - push-frontend-to-staging-ecr
   - name: adminusers
     jobs:
@@ -560,13 +561,26 @@ jobs:
               - -ec
               - |
                 echo "Imagine we just smoked on test."
+  - name: frontend-pact-tag
+    plan:
+      - get: frontend-ecr-registry-test
+        passed: [smoke-test-frontend]
+        trigger: true
+      - load_var: tag
+        file: frontend-ecr-registry-test/tag
+      - get: pay-ci  
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: frontend
+          TAG: ((.:tag))
   - name: push-frontend-to-staging-ecr
     plan:
       - get: frontend-ecr-registry-test
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-frontend]
+        passed: [frontend-pact-tag]
       - put: frontend-ecr-registry-staging
         params:
           image: frontend-ecr-registry-test/image.tar

--- a/ci/scripts/get-git-sha-for-release-tag.js
+++ b/ci/scripts/get-git-sha-for-release-tag.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const { Octokit } = require('@octokit/rest');
+const octokit = new Octokit()
+const { TAG: imageTag, APP_NAME: appName} = process.env
+
+async function run() {
+  const gitTag = `alpha_release-${imageTag}`.replace('-release','')
+  const refResult = await octokit.git.getRef({owner: 'alphagov', repo: `pay-${appName}`, ref: `tags/${gitTag}`})
+  const tagSha = refResult.data.object.sha
+  const tagResult = await octokit.git.getTag({owner: 'alphagov', repo: 'pay-frontend', tag_sha: `${tagSha}`})
+
+  console.log(`git sha: ${tagResult.data.object.sha}`)
+  fs.writeFileSync('git-sha/git-sha', tagResult.data.object.sha)
+}
+
+run()

--- a/ci/tasks/get-git-sha-for-release-tag.yml
+++ b/ci/tasks/get-git-sha-for-release-tag.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/node-runner
+params:
+  APP_NAME:
+  TAG: #eg 1339-release
+inputs:
+  - name: pay-ci
+outputs:
+  - name: git-sha
+run:
+  path: node
+  args: ['pay-ci/ci/scripts/get-git-sha-for-release-tag.js']


### PR DESCRIPTION
In order to tag a pact with something (eg "test-fargate"), we need the version
which is the git commit sha of the release tag.

In line with the agreed practice of writing scripts in node, we have decided to
make use of a github node api. To this end we have added the `octokit/rest` npm
library to our node-aws-sdk-runner and renamed it to node-runner.

Example successful build: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/apps-test-ecr/jobs/frontend-pact-tag/builds/3