### PR TITLE
PP-7686 Rename test and staging pipelines

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -16,14 +16,14 @@ definitions:
     ENVIRONMENT: staging-2
 
 resources:
-  - name: toolbox-staging-deploy-config
+  - name: deploy-to-staging-pipeline-definition
     type: git
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
       branch: master 
       paths:
-        - ci/pipelines/toolbox-staging-deploy.yml
+        - ci/pipelines/deploy-to-staging.yml
   - name: pay-ci
     type: git
     icon: github
@@ -69,21 +69,21 @@ resource_types:
       repository: concourse/registry-image-resource
       tag: "1.1.0"
 groups:
-  - name: pipeline-meta-update
+  - name: update-deploy-to-staging-pipeline
     jobs:
-      - update-toolbox-staging-ecr-pipeline
+      - update-deploy-to-staging-pipeline
   - name: toolbox
     jobs:
       - deploy-toolbox-to-staging
       - smoke-test-toolbox-on-staging
       - push-toolbox-to-production-ecr
 jobs:
-  - name: update-toolbox-staging-ecr-pipeline
+  - name: update-deploy-to-staging-pipeline
     plan:
-      - get: toolbox-staging-deploy-config
+      - get: deploy-to-staging-pipeline-definition
         trigger: true
-      - set_pipeline: toolbox-staging-deploy-config
-        file: toolbox-staging-deploy-config/ci/pipelines/toolbox-staging-deploy.yml
+      - set_pipeline: deploy-to-staging
+        file: deploy-to-staging-pipeline-definition/ci/pipelines/deploy-to-staging.yml
   - name: deploy-toolbox-to-staging
     plan:
       - get: toolbox-ecr-registry-staging

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -35,14 +35,14 @@ deploy_params: &deploy_params
 
 
 resources:
-  - name: apps-test-ecr
+  - name: deploy-to-test-pipeline-definition
     type: git
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
       branch: master
       paths:
-        - ci/pipelines/apps-test-ecr.yml
+        - ci/pipelines/deploy-to-test.yml
   - name: pay-ci
     type: git
     icon: github
@@ -330,9 +330,9 @@ resource_types:
       tag: "1.1.0"
 
 groups:
-  - name: pipeline-meta-update
+  - name: update-deploy-to-test-pipeline
     jobs:
-      - update-apps-test-ecr-pipeline
+      - update-deploy-to-test-pipeline
   - name: toolbox
     jobs:
       - push-toolbox-to-test-ecr
@@ -430,12 +430,12 @@ docker_credentials: &docker_credentials
   DOCKER_AUTH_TOKEN: ((docker-password))
 
 jobs:
-  - name: update-apps-test-ecr-pipeline
+  - name: update-deploy-to-test-pipeline
     plan:
-      - get: apps-test-ecr
+      - get: deploy-to-test-pipeline-definition
         trigger: true
-      - set_pipeline: apps-test-ecr
-        file: apps-test-ecr/ci/pipelines/apps-test-ecr.yml
+      - set_pipeline: deploy-to-test
+        file: deploy-to-test-pipeline-definition/ci/pipelines/deploy-to-test.yml
   - name: push-toolbox-to-test-ecr
     plan:
       - get: pay-ci
@@ -1580,7 +1580,7 @@ jobs:
           additional_tags: cardid-ecr-registry-test/tag
   - name: nginx-proxy-image-to-test-ecr
     plan:
-      - get: apps-test-ecr
+      - get: pay-ci
       - get: nginx-proxy-git-release
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
@@ -1595,7 +1595,7 @@ jobs:
           additional_tags: nginx-proxy-git-release/.git/HEAD
   - name: nginx-forward-proxy-image-to-test-ecr
     plan:
-      - get: apps-test-ecr
+      - get: pay-ci
       - get: nginx-forward-proxy-dockerhub-release
         trigger: true
         params:


### PR DESCRIPTION
Rename to `deploy-to-{test,staging}` as per authoritative slack poll. Pipelines have been renamed - this just updates filenames, job names and resource references