### PR TITLE
PP-7877 - Add jq package to runner to run telegraf bash unit tests

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
   git \
   python3 \
   ca-certificates \
+  jq \
   # dockerd dependencies
   iptables \
   util-linux 


### PR DESCRIPTION
Description:
- Running bash unit tests with the govukpay/concourse-runner requires the jq package to be present