### PR TITLE
PP-7687 Frontend staging pipeline

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -14,6 +14,22 @@ definitions:
     TAG: ((.:tag))
     ACCOUNT: staging
     ENVIRONMENT: staging-2
+    
+  aws_production_config: &aws_production_config
+    aws_access_key_id: ((readonly_access_key_id))
+    aws_secret_access_key: ((readonly_secret_access_key))
+    aws_session_token: ((readonly_session_token))
+    aws_role_arn: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+    aws_ecr_registry_id: "((pay_aws_prod_account_id))"
+    aws_region: eu-west-1
+  
+  aws_staging_config: &aws_staging_config
+    aws_access_key_id: ((readonly_access_key_id))
+    aws_secret_access_key: ((readonly_secret_access_key))
+    aws_session_token: ((readonly_session_token))
+    aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+    aws_ecr_registry_id: "((pay_aws_staging_account_id))"
+    aws_region: eu-west-1
 
 resources:
   - name: deploy-to-staging-pipeline-definition
@@ -38,29 +54,32 @@ resources:
       branch: master
       username: alphagov-pay-ci
       password: ((github-access-token))
-  - name: toolbox-ecr-registry-prod
-    type: registry-image-resource-1-1-0
-    icon: docker
-    source:
-      repository: govukpay/toolbox
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      aws_role_arn: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
-      aws_ecr_registry_id: "((pay_aws_prod_account_id))"
-      aws_region: eu-west-1
   - name: toolbox-ecr-registry-staging
     type: registry-image-resource-1-1-0
     icon: docker
     source:
       repository: govukpay/toolbox
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
-      aws_ecr_registry_id: "((pay_aws_staging_account_id))"
-      aws_region: eu-west-1
       variant: release
+      <<: *aws_staging_config
+  - name: toolbox-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/toolbox
+      <<: *aws_production_config
+  - name: frontend-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/frontend
+      variant: release
+      <<: *aws_staging_config
+  - name: frontend-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/frontend
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -77,6 +96,12 @@ groups:
       - deploy-toolbox-to-staging
       - smoke-test-toolbox-on-staging
       - push-toolbox-to-production-ecr
+  - name: frontend
+    jobs:
+      - deploy-frontend-to-staging
+      - smoke-test-frontend-on-staging
+      - frontend-pact-tag
+      - push-frontend-to-production-ecr
 jobs:
   - name: update-deploy-to-staging-pipeline
     plan:
@@ -141,4 +166,80 @@ jobs:
         params:
           image: toolbox-ecr-registry-staging/image.tar
           additional_tags: toolbox-ecr-registry-staging/tag
-      
+
+  - name: deploy-frontend-to-staging
+    plan:
+      - get: frontend-ecr-registry-staging
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: tag
+        file: frontend-ecr-registry-staging/tag
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-staging
+        file: pay-ci/ci/tasks/deploy-app.yml
+        params:
+          APP_NAME: frontend
+          <<: *deploy_params
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: frontend
+          <<: *wait_for_deploy_params
+
+  - name: smoke-test-frontend-on-staging
+    plan:
+      - get: frontend-ecr-registry-staging
+        trigger: true
+        passed: [deploy-frontend-to-staging]
+      - task: smoke-test-on-staging
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on staging."
+  - name: frontend-pact-tag
+    plan:
+      - get: frontend-ecr-registry-staging
+        passed: [smoke-test-frontend-on-staging]
+        trigger: true
+      - load_var: tag
+        file: frontend-ecr-registry-staging/tag
+      - get: pay-ci
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: frontend
+          TAG: ((.:tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: frontend
+          PACT_TAG: staging-fargate
+  - name: push-frontend-to-production-ecr
+    plan:
+      - get: frontend-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [frontend-pact-tag]
+      - put: frontend-ecr-registry-prod
+        params:
+          image: frontend-ecr-registry-staging/image.tar
+          additional_tags: frontend-ecr-registry-staging/tag


### PR DESCRIPTION
Very similar to test.
No pact compatibility check as that can only be added once all apps are being pact tagged.
Removed trigger from `deploy-frontend-to-staging` job - this will be manually triggered for time being as it is in CDE (see https://docs.google.com/document/d/1oJ347kiaB_tBp-Q_7iZ1NC-xv-uQLz4etoyqI90IKVs)