### PR TITLE
PP-7688 add more staging deployments

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -106,6 +106,19 @@ resources:
     source:
       repository: govukpay/products
       <<: *aws_production_config
+  - name: products-ui-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/products-ui
+      variant: release
+      <<: *aws_staging_config
+  - name: products-ui-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/products-ui
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -140,6 +153,13 @@ groups:
       - smoke-test-products-on-staging
       - products-pact-tag
       - push-products-to-production-ecr
+  - name: products-ui
+    jobs:
+      - deploy-products-ui-to-staging
+      - smoke-test-products-ui-on-staging
+      - products-ui-pact-tag
+      - push-products-ui-to-production-ecr
+      
 jobs:
   - name: update-deploy-to-staging-pipeline
     plan:
@@ -355,6 +375,7 @@ jobs:
         params:
           image: adminusers-ecr-registry-staging/image.tar
           additional_tags: adminusers-ecr-registry-staging/tag
+          
   - name: deploy-products-to-staging
     plan:
       - get: products-ecr-registry-staging
@@ -430,3 +451,79 @@ jobs:
         params:
           image: products-ecr-registry-staging/image.tar
           additional_tags: products-ecr-registry-staging/tag
+          
+  - name: deploy-products-ui-to-staging
+    plan:
+      - get: products-ui-ecr-registry-staging
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: tag
+        file: products-ui-ecr-registry-staging/tag
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-staging
+        file: pay-ci/ci/tasks/deploy-app.yml
+        params:
+          APP_NAME: products-ui
+          <<: *deploy_params
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: products-ui
+          <<: *wait_for_deploy_params
+  - name: smoke-test-products-ui-on-staging
+    plan:
+      - get: products-ui-ecr-registry-staging
+        trigger: true
+        passed: [deploy-products-ui-to-staging]
+      - task: smoke-test-on-staging
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on staging."
+  - name: products-ui-pact-tag
+    plan:
+      - get: products-ui-ecr-registry-staging
+        passed: [smoke-test-products-ui-on-staging]
+        trigger: true
+      - load_var: tag
+        file: products-ui-ecr-registry-staging/tag
+      - get: pay-ci
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: products-ui
+          TAG: ((.:tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: products-ui
+          PACT_TAG: staging-fargate
+  - name: push-products-ui-to-production-ecr
+    plan:
+      - get: products-ui-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [products-ui-pact-tag]
+      - put: products-ui-ecr-registry-prod
+        params:
+          image: products-ui-ecr-registry-staging/image.tar
+          additional_tags: products-ui-ecr-registry-staging/tag

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -132,6 +132,19 @@ resources:
     source:
       repository: govukpay/publicauth
       <<: *aws_production_config
+  - name: cardid-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/cardid
+      variant: release
+      <<: *aws_staging_config
+  - name: cardid-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/cardid
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -177,6 +190,11 @@ groups:
       - deploy-publicauth-to-staging
       - smoke-test-publicauth-on-staging
       - push-publicauth-to-production-ecr
+  - name: cardid
+    jobs:
+      - deploy-cardid-to-staging
+      - smoke-test-cardid-on-staging
+      - push-cardid-to-production-ecr
       
 jobs:
   - name: update-deploy-to-staging-pipeline
@@ -595,8 +613,63 @@ jobs:
         params:
           format: oci
         trigger: true
-        passed: [publicauth-pact-tag]
+        passed: [smoke-test-publicauth-on-staging]
       - put: publicauth-ecr-registry-prod
         params:
           image: publicauth-ecr-registry-staging/image.tar
           additional_tags: publicauth-ecr-registry-staging/tag
+
+  - name: deploy-cardid-to-staging
+    plan:
+      - get: cardid-ecr-registry-staging
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: tag
+        file: cardid-ecr-registry-staging/tag
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-staging
+        file: pay-ci/ci/tasks/deploy-app.yml
+        params:
+          APP_NAME: cardid
+          <<: *deploy_params
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: cardid
+          <<: *wait_for_deploy_params
+  - name: smoke-test-cardid-on-staging
+    plan:
+      - get: cardid-ecr-registry-staging
+        trigger: true
+        passed: [deploy-cardid-to-staging]
+      - task: smoke-test-on-staging
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on staging."
+  - name: push-cardid-to-production-ecr
+    plan:
+      - get: cardid-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-cardid-on-staging]
+      - put: cardid-ecr-registry-prod
+        params:
+          image: cardid-ecr-registry-staging/image.tar
+          additional_tags: cardid-ecr-registry-staging/tag

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -93,6 +93,19 @@ resources:
     source:
       repository: govukpay/adminusers
       <<: *aws_production_config
+  - name: products-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/products
+      variant: release
+      <<: *aws_staging_config
+  - name: products-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/products
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -121,6 +134,12 @@ groups:
       - smoke-test-adminusers-on-staging
       - adminusers-pact-tag
       - push-adminusers-to-production-ecr
+  - name: products
+    jobs:
+      - deploy-products-to-staging
+      - smoke-test-products-on-staging
+      - products-pact-tag
+      - push-products-to-production-ecr
 jobs:
   - name: update-deploy-to-staging-pipeline
     plan:
@@ -336,3 +355,78 @@ jobs:
         params:
           image: adminusers-ecr-registry-staging/image.tar
           additional_tags: adminusers-ecr-registry-staging/tag
+  - name: deploy-products-to-staging
+    plan:
+      - get: products-ecr-registry-staging
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: tag
+        file: products-ecr-registry-staging/tag
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-staging
+        file: pay-ci/ci/tasks/deploy-app.yml
+        params:
+          APP_NAME: products
+          <<: *deploy_params
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: products
+          <<: *wait_for_deploy_params
+  - name: smoke-test-products-on-staging
+    plan:
+      - get: products-ecr-registry-staging
+        trigger: true
+        passed: [deploy-products-to-staging]
+      - task: smoke-test-on-staging
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on staging."
+  - name: products-pact-tag
+    plan:
+      - get: products-ecr-registry-staging
+        passed: [smoke-test-products-on-staging]
+        trigger: true
+      - load_var: tag
+        file: products-ecr-registry-staging/tag
+      - get: pay-ci
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: products
+          TAG: ((.:tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: products
+          PACT_TAG: staging-fargate
+  - name: push-products-to-production-ecr
+    plan:
+      - get: products-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [products-pact-tag]
+      - put: products-ecr-registry-prod
+        params:
+          image: products-ecr-registry-staging/image.tar
+          additional_tags: products-ecr-registry-staging/tag

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -80,6 +80,19 @@ resources:
     source:
       repository: govukpay/frontend
       <<: *aws_production_config
+  - name: adminusers-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      variant: release
+      <<: *aws_staging_config
+  - name: adminusers-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -102,6 +115,12 @@ groups:
       - smoke-test-frontend-on-staging
       - frontend-pact-tag
       - push-frontend-to-production-ecr
+  - name: adminusers
+    jobs:
+      - deploy-adminusers-to-staging
+      - smoke-test-adminusers-on-staging
+      - adminusers-pact-tag
+      - push-adminusers-to-production-ecr
 jobs:
   - name: update-deploy-to-staging-pipeline
     plan:
@@ -109,6 +128,7 @@ jobs:
         trigger: true
       - set_pipeline: deploy-to-staging
         file: deploy-to-staging-pipeline-definition/ci/pipelines/deploy-to-staging.yml
+        
   - name: deploy-toolbox-to-staging
     plan:
       - get: toolbox-ecr-registry-staging
@@ -135,7 +155,6 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
-
   - name: smoke-test-toolbox-on-staging
     plan:
       - get: toolbox-ecr-registry-staging
@@ -154,7 +173,6 @@ jobs:
             - -ec
             - |
               echo "Imagine we just smoked on staging."
-
   - name: push-toolbox-to-production-ecr
     plan:
       - get: toolbox-ecr-registry-staging
@@ -192,7 +210,6 @@ jobs:
         params:
           APP_NAME: frontend
           <<: *wait_for_deploy_params
-
   - name: smoke-test-frontend-on-staging
     plan:
       - get: frontend-ecr-registry-staging
@@ -243,3 +260,79 @@ jobs:
         params:
           image: frontend-ecr-registry-staging/image.tar
           additional_tags: frontend-ecr-registry-staging/tag
+          
+  - name: deploy-adminusers-to-staging
+    plan:
+      - get: adminusers-ecr-registry-staging
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: tag
+        file: adminusers-ecr-registry-staging/tag
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-staging
+        file: pay-ci/ci/tasks/deploy-app.yml
+        params:
+          APP_NAME: adminusers
+          <<: *deploy_params
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: adminusers
+          <<: *wait_for_deploy_params
+  - name: smoke-test-adminusers-on-staging
+    plan:
+      - get: adminusers-ecr-registry-staging
+        trigger: true
+        passed: [deploy-adminusers-to-staging]
+      - task: smoke-test-on-staging
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on staging."
+  - name: adminusers-pact-tag
+    plan:
+      - get: adminusers-ecr-registry-staging
+        passed: [smoke-test-adminusers-on-staging]
+        trigger: true
+      - load_var: tag
+        file: adminusers-ecr-registry-staging/tag
+      - get: pay-ci
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: adminusers
+          TAG: ((.:tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: adminusers
+          PACT_TAG: staging-fargate
+  - name: push-adminusers-to-production-ecr
+    plan:
+      - get: adminusers-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [adminusers-pact-tag]
+      - put: adminusers-ecr-registry-prod
+        params:
+          image: adminusers-ecr-registry-staging/image.tar
+          additional_tags: adminusers-ecr-registry-staging/tag

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -119,6 +119,19 @@ resources:
     source:
       repository: govukpay/products-ui
       <<: *aws_production_config
+  - name: publicauth-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/publicauth
+      variant: release
+      <<: *aws_staging_config
+  - name: publicauth-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/publicauth
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -159,6 +172,11 @@ groups:
       - smoke-test-products-ui-on-staging
       - products-ui-pact-tag
       - push-products-ui-to-production-ecr
+  - name: publicauth
+    jobs:
+      - deploy-publicauth-to-staging
+      - smoke-test-publicauth-on-staging
+      - push-publicauth-to-production-ecr
       
 jobs:
   - name: update-deploy-to-staging-pipeline
@@ -527,3 +545,58 @@ jobs:
         params:
           image: products-ui-ecr-registry-staging/image.tar
           additional_tags: products-ui-ecr-registry-staging/tag
+          
+  - name: deploy-publicauth-to-staging
+    plan:
+      - get: publicauth-ecr-registry-staging
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: tag
+        file: publicauth-ecr-registry-staging/tag
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-staging
+        file: pay-ci/ci/tasks/deploy-app.yml
+        params:
+          APP_NAME: publicauth
+          <<: *deploy_params
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: publicauth
+          <<: *wait_for_deploy_params
+  - name: smoke-test-publicauth-on-staging
+    plan:
+      - get: publicauth-ecr-registry-staging
+        trigger: true
+        passed: [deploy-publicauth-to-staging]
+      - task: smoke-test-on-staging
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          run:
+            path: /bin/bash
+            args:
+            - -ec
+            - |
+              echo "Imagine we just smoked on staging."
+  - name: push-publicauth-to-production-ecr
+    plan:
+      - get: publicauth-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [publicauth-pact-tag]
+      - put: publicauth-ecr-registry-prod
+        params:
+          image: publicauth-ecr-registry-staging/image.tar
+          additional_tags: publicauth-ecr-registry-staging/tag


### PR DESCRIPTION
Adds deployment pipelines for adminusers, products and products-ui (with pact tagging) and cardid and publicauth. Follows exact same pattern established by toolbox and frontend