### PR TITLE
PP-7887 Trigger smoke tests for toolbox post-deploy

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -23,6 +23,59 @@ definitions:
     aws_ecr_registry_id: "((pay_aws_prod_account_id))"
     aws_region: eu-west-1
 
+  # Separate tasks for each combination of scenario/environment
+  smoke-test-run-all-on-production: &smoke-test-run-all-on-production
+    limit: 4
+    steps:
+      - task: run_create_card_payment_sandbox-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_sandbox_prod"
+      - task: run_create_card_payment_smartpay-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_smartpay_prod"
+      - task: run_create_card_payment_worldpay_with_3ds-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds_prod"
+      - task: run_create_card_payment_worldpay_with_3ds2-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2_prod"
+      - task: run_create_card_payment_worldpay_with_3ds2_exemption-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2ex_prod"
+      - task: run_create_card_payment_worldpay_without_3ds-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_prod"
+      - task: run_cancel_card_payment_sandbox-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "cancel_sandbox_prod"
+      - task: run_use_payment_link_sandbox-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "pymntlnk_sandbox_prod"
+
 resources:
   - name: deploy-to-prod-pipeline-definition
     type: git
@@ -257,19 +310,16 @@ jobs:
       - get: selfservice-ecr-registry-prod
         trigger: true
         passed: [deploy-selfservice-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: selfservice-pact-tag
     plan:
       - get: selfservice-ecr-registry-prod
@@ -335,19 +385,16 @@ jobs:
       - get: connector-ecr-registry-prod
         trigger: true
         passed: [deploy-connector-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: connector-pact-tag
     plan:
       - get: connector-ecr-registry-prod
@@ -434,19 +481,16 @@ jobs:
       - get: toolbox-ecr-registry-prod
         trigger: true
         passed: [deploy-toolbox-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
 
   - name: deploy-frontend-to-prod
     plan:
@@ -492,19 +536,16 @@ jobs:
       - get: frontend-ecr-registry-prod
         trigger: true
         passed: [deploy-frontend-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: frontend-pact-tag
     plan:
       - get: frontend-ecr-registry-prod
@@ -570,19 +611,16 @@ jobs:
       - get: adminusers-ecr-registry-prod
         trigger: true
         passed: [deploy-adminusers-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: adminusers-pact-tag
     plan:
       - get: adminusers-ecr-registry-prod
@@ -648,19 +686,16 @@ jobs:
       - get: products-ecr-registry-prod
         trigger: true
         passed: [deploy-products-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: products-pact-tag
     plan:
       - get: products-ecr-registry-prod
@@ -726,19 +761,16 @@ jobs:
       - get: products-ui-ecr-registry-prod
         trigger: true
         passed: [deploy-products-ui-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: products-ui-pact-tag
     plan:
       - get: products-ui-ecr-registry-prod
@@ -791,19 +823,16 @@ jobs:
       - get: publicauth-ecr-registry-prod
         trigger: true
         passed: [deploy-publicauth-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
 
   - name: deploy-cardid-to-prod
     plan:
@@ -835,19 +864,16 @@ jobs:
       - get: cardid-ecr-registry-prod
         trigger: true
         passed: [deploy-cardid-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: deploy-publicapi-to-prod
     plan:
       - get: publicapi-ecr-registry-prod
@@ -891,19 +917,16 @@ jobs:
       - get: publicapi-ecr-registry-prod
         trigger: true
         passed: [deploy-publicapi-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: publicapi-pact-tag
     plan:
       - get: publicapi-ecr-registry-prod
@@ -969,19 +992,16 @@ jobs:
       - get: ledger-ecr-registry-prod
         trigger: true
         passed: [deploy-ledger-to-prod]
-      - task: smoke-test-on-prod
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on prod."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
   - name: ledger-pact-tag
     plan:
       - get: ledger-ecr-registry-prod

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -31,6 +31,59 @@ definitions:
     aws_ecr_registry_id: "((pay_aws_staging_account_id))"
     aws_region: eu-west-1
 
+  # Separate tasks for each combination of scenario/environment
+  smoke-test-run-all-on-staging: &smoke-test-run-all-on-staging
+    limit: 4
+    steps:
+      - task: run_create_card_payment_sandbox-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_sandbox_stag"
+      - task: run_create_card_payment_smartpay-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_smartpay_stag"
+      - task: run_create_card_payment_worldpay_with_3ds-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds_stag"
+      - task: run_create_card_payment_worldpay_with_3ds2-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2_stag"
+      - task: run_create_card_payment_worldpay_with_3ds2_exemption-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2ex_stag"
+      - task: run_create_card_payment_worldpay_without_3ds-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_stag"
+      - task: run_cancel_card_payment_sandbox-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "cancel_sandbox_stag"
+      - task: run_use_payment_link_sandbox-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "pymntlnk_sandbox_stag"
+
 resources:
   - name: deploy-to-staging-pipeline-definition
     type: git
@@ -377,19 +430,17 @@ jobs:
       - get: selfservice-ecr-registry-staging
         trigger: true
         passed: [deploy-selfservice-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: selfservice-pact-tag
     plan:
       - get: selfservice-ecr-registry-staging
@@ -467,19 +518,16 @@ jobs:
       - get: connector-ecr-registry-staging
         trigger: true
         passed: [deploy-connector-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: connector-pact-tag
     plan:
       - get: connector-ecr-registry-staging
@@ -579,19 +627,16 @@ jobs:
       - get: toolbox-ecr-registry-staging
         trigger: true
         passed: [deploy-toolbox-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: push-toolbox-to-production-ecr
     plan:
       - get: toolbox-ecr-registry-staging
@@ -678,19 +723,16 @@ jobs:
       - get: nginx-forward-proxy-ecr-registry-staging
         trigger: true
         passed: [deploy-frontend-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: frontend-pact-tag
     plan:
       - get: frontend-ecr-registry-staging
@@ -768,19 +810,16 @@ jobs:
       - get: adminusers-ecr-registry-staging
         trigger: true
         passed: [deploy-adminusers-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: adminusers-pact-tag
     plan:
       - get: adminusers-ecr-registry-staging
@@ -857,19 +896,16 @@ jobs:
       - get: products-ecr-registry-staging
         trigger: true
         passed: [deploy-products-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: products-pact-tag
     plan:
       - get: products-ecr-registry-staging
@@ -946,19 +982,16 @@ jobs:
       - get: products-ui-ecr-registry-staging
         trigger: true
         passed: [deploy-products-ui-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: products-ui-pact-tag
     plan:
       - get: products-ui-ecr-registry-staging
@@ -1022,19 +1055,16 @@ jobs:
       - get: publicauth-ecr-registry-staging
         trigger: true
         passed: [deploy-publicauth-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: push-publicauth-to-production-ecr
     plan:
       - get: publicauth-ecr-registry-staging
@@ -1077,19 +1107,16 @@ jobs:
       - get: cardid-ecr-registry-staging
         trigger: true
         passed: [deploy-cardid-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: push-cardid-to-production-ecr
     plan:
       - get: cardid-ecr-registry-staging
@@ -1145,19 +1172,16 @@ jobs:
       - get: publicapi-ecr-registry-staging
         trigger: true
         passed: [deploy-publicapi-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: publicapi-pact-tag
     plan:
       - get: publicapi-ecr-registry-staging
@@ -1235,19 +1259,16 @@ jobs:
       - get: ledger-ecr-registry-staging
         trigger: true
         passed: [deploy-ledger-to-staging]
-      - task: smoke-test-on-staging
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-            - -ec
-            - |
-              echo "Imagine we just smoked on staging."
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
   - name: ledger-pact-tag
     plan:
       - get: ledger-ecr-registry-staging

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -479,6 +479,58 @@ definitions:
       DOCKER_AUTH_TOKEN: updateThisValue
       DOCKER_REPOSITORY: updateThisValue
       APP_GIT_DIR: updateThisValue
+  # Separate tasks for each combination of scenario/environment
+  - &smoke-test-run-all-on-test
+    limit: 4
+    steps:
+      - task: run_create_card_payment_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_sandbox_test"
+      - task: run_create_card_payment_smartpay-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_smartpay_test"
+      - task: run_create_card_payment_worldpay_with_3ds-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds_test"
+      - task: run_create_card_payment_worldpay_with_3ds2-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2_test"
+      - task: run_create_card_payment_worldpay_with_3ds2_exemption-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2ex_test"
+      - task: run_create_card_payment_worldpay_without_3ds-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_test"
+      - task: run_cancel_card_payment_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "cancel_sandbox_test"
+      - task: run_use_payment_link_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "pymntlnk_sandbox_test"
 
 docker_credentials: &docker_credentials
   DOCKER_USERNAME: ((docker-username))
@@ -579,19 +631,17 @@ jobs:
       - get: toolbox-ecr-registry-test
         trigger: true
         passed: [deploy-toolbox]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
   - name: push-toolbox-to-staging-ecr
     plan:
       - get: toolbox-ecr-registry-test
@@ -701,19 +751,17 @@ jobs:
       - get: nginx-forward-proxy-ecr-registry-test
         trigger: true
         passed: [deploy-frontend]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
   - name: frontend-pact-tag
     plan:
       - get: frontend-ecr-registry-test
@@ -851,19 +899,17 @@ jobs:
       - get: adminusers-ecr-registry-test
         trigger: true
         passed: [deploy-adminusers]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
 
   - name: adminusers-pact-tag
     plan:
@@ -1002,19 +1048,17 @@ jobs:
       - get: connector-ecr-registry-test
         trigger: true
         passed: [deploy-connector]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
 
   - name: connector-pact-tag
     plan:
@@ -1112,19 +1156,17 @@ jobs:
       - get: ledger-ecr-registry-test
         trigger: true
         passed: [deploy-ledger]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
 
   - name: ledger-pact-tag
     plan:
@@ -1304,19 +1346,17 @@ jobs:
       - get: products-ecr-registry-test
         trigger: true
         passed: [deploy-products]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
 
   - name: products-pact-tag
     plan:
@@ -1414,19 +1454,17 @@ jobs:
       - get: products-ui-ecr-registry-test
         trigger: true
         passed: [deploy-products-ui]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
 
   - name: products-ui-pact-tag
     plan:
@@ -1524,19 +1562,17 @@ jobs:
       - get: publicapi-ecr-registry-test
         trigger: true
         passed: [deploy-publicapi]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
 
   - name: publicapi-pact-tag
     plan:
@@ -1661,19 +1697,17 @@ jobs:
       - get: publicauth-ecr-registry-test
         trigger: true
         passed: [deploy-publicauth]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
   - name: push-publicauth-to-staging-ecr
     plan:
       - get: publicauth-ecr-registry-test
@@ -1748,19 +1782,17 @@ jobs:
       - get: selfservice-ecr-registry-test
         trigger: true
         passed: [deploy-selfservice]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
 
   - name: selfservice-pact-tag
     plan:
@@ -1881,19 +1913,17 @@ jobs:
       - get: cardid-ecr-registry-test
         trigger: true
         passed: [deploy-cardid]
-      - task: smoke-test-on-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                echo "Imagine we just smoked on test."
+      - get: pay-ci
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
   - name: push-cardid-to-staging-ecr
     plan:
       - get: cardid-ecr-registry-test

--- a/ci/scripts/run_smoke_test.js
+++ b/ci/scripts/run_smoke_test.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const AWS = require('aws-sdk')
+const synthetics = new AWS.Synthetics()
+const s3 = new AWS.S3()
+const CHECK_INTERVAL = 5000
+const { SMOKE_TEST_NAME } = process.env
+
+async function describeCanariesLastRun () {
+  return synthetics.describeCanariesLastRun({}).promise()
+}
+
+function runCanary () {
+  console.log(`Starting canary: ${SMOKE_TEST_NAME}`)
+  // 'startCanary' should run it once then stop, according to its schedule config in terraform
+  return synthetics.startCanary({ Name: SMOKE_TEST_NAME }).promise()
+}
+
+function prettyPrintRunReport (runReport) {
+  console.log(`Name: ${runReport.Name}`)
+  console.log(`Status: ${runReport.Status.State}`)
+  if (runReport.Status.State === 'FAILED') {
+    console.log(`Failure Reason: ${runReport.Status.StateReason}`)
+  }
+}
+
+async function getS3Objects (splitLocation, prefix) {
+  return s3.listObjects({ Bucket: splitLocation[0], Prefix: prefix }).promise()
+}
+
+async function run () {
+  const startedAt = Date.now()
+  try {
+    await runCanary()
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 1
+    return
+  }
+
+  const deploymentChecker = setInterval(async () => {
+    const data = await describeCanariesLastRun()
+    const result = data.CanariesLastRun.find(run => run.CanaryName === SMOKE_TEST_NAME)
+    const state = result.LastRun.Status.State
+    if (result.LastRun.Timeline.Completed < startedAt) {
+      console.log('waiting for test to finish')
+    } else if (state === 'PASSED') {
+      prettyPrintRunReport(result.LastRun)
+      clearInterval(deploymentChecker)
+    } else if (state === 'FAILED') {
+      prettyPrintRunReport(result.LastRun)
+      console.log('\n===FAILURE LOGS==============================================\n')
+      const splitLocation = result.LastRun.ArtifactS3Location.split('/')
+      const prefix = splitLocation.slice(1, splitLocation.size).reduce((a, b) => a + '/' + b)
+      console.log(`${prefix}${splitLocation[0]}`)
+
+      // Check failure details from S3 bucket
+      try {
+        const s3Objects = await getS3Objects(splitLocation, prefix)
+        const logFile = s3Objects.Contents.filter(obj => obj.Key.includes('.txt')).map(obj => obj.Key)[0]
+        const logStream = s3.getObject({ Bucket: splitLocation[0], Key: logFile }).createReadStream()
+        logStream.on('readable', () => {
+          console.log(`${logStream.read()}`)
+        })
+      } catch (error) {
+        console.log(error)
+      }
+      console.log('\n============================================================\n')
+
+      process.exitCode = 1
+      clearInterval(deploymentChecker)
+    }
+  }, CHECK_INTERVAL)
+}
+
+run()

--- a/ci/tasks/run-smoke-test.yml
+++ b/ci/tasks/run-smoke-test.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/node-aws-sdk-runner
+inputs:
+  - name: pay-ci
+outputs:
+  - name: smoke-test-results
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:
+  AWS_REGION:
+  SMOKE_TEST_NAME:
+run:
+  path: node
+  args: ['pay-ci/ci/scripts/run_smoke_test.js']


### PR DESCRIPTION
- Adds a generic task for running smoke tests, given a SMOKE_TEST_NAME corresponding to the name of the canary (this is likely to change in the near future)
- Adds the NodeJS script to trigger the canary via the AWS SDK (lifted entirely from @danworth and @rorymalcolm's [spike branch](https://github.com/alphagov/pay-ci/compare/PP-7670_spike_aws_canary), with a little tweaking for linting and error handling)
- Replaces the dummy smoke test steps with the steps to assume the trigger role for the deploy account, and call the NodeJS script for each scenario with the correct variables. 
 
Note that not all the Canaries are available yet in the AWS deploy account, only `card_payment_test` and `card_payment_staging`.

The new Concourse pipeline variable `pay_aws_deploy_account_id` has been added to the pay-dev and pay-deploy teams already.

**NOTE**: Not ready for merging yet - waiting for the Canaries to be available