### PR TITLE
PP-7877 - Update deploy telegraf to staging ECR

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -553,9 +553,6 @@ jobs:
       - get: toolbox-ecr-registry-test
         trigger: true
         passed: [deploy-toolbox]
-      - get: telegraf-ecr-registry-test
-        trigger: true
-        passed: [deploy-toolbox]
       - task: smoke-test-on-test
         config:
           platform: linux
@@ -1928,7 +1925,7 @@ jobs:
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-toolbox]
+        passed: [deploy-toolbox]
       - put: telegraf-ecr-registry-staging
         params:
           image: telegraf-ecr-registry-test/image.tar


### PR DESCRIPTION
Description:
- Since there are no smoke tests testing toolbox specifically what we will have is the pipeline pushing telegraf to staging ECR only if there has been a successful toolbox deployment to test