### PR TITLE
PP-7877 - Push telegraf to ECR production

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -204,6 +204,12 @@ resources:
       repository: govukpay/telegraf
       variant: release
       <<: *aws_staging_config
+  - name: telegraf-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/telegraf
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -277,6 +283,9 @@ groups:
       - smoke-test-ledger-on-staging
       - ledger-pact-tag
       - push-ledger-to-production-ecr
+  - name: telegraf
+    jobs:
+      - push-telegraf-to-production-ecr
 
 jobs:
   - name: update-deploy-to-staging-pipeline
@@ -1049,3 +1058,14 @@ jobs:
         params:
           image: ledger-ecr-registry-staging/image.tar
           additional_tags: ledger-ecr-registry-staging/tag
+  - name: push-telegraf-to-production-ecr
+    plan:
+      - get: telegraf-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [deploy-toolbox-to-staging]
+      - put: telegraf-ecr-registry-prod
+        params:
+          image: telegraf-ecr-registry-staging/image.tar
+          additional_tags: telegraf-ecr-registry-staging/tag


### PR DESCRIPTION
Description:
- This PR adds a job which pushes the telegraf image to ECR production only when Toolbox is deployed successfully to the staging environment
- With @oswaldquek @mrlumbu 