### PR TITLE
PP-7877 - Show deploy-toolbox and deploy-toolbox-to-staging in telegraf group

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -287,6 +287,7 @@ groups:
       - push-ledger-to-production-ecr
   - name: telegraf
     jobs:
+      - deploy-toolbox-to-staging
       - push-telegraf-to-production-ecr
 
 jobs:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -446,6 +446,7 @@ groups:
     jobs:
       - unit-test-telegraf
       - build-and-push-telegraf-to-test-ecr
+      - deploy-toolbox
       - push-telegraf-to-staging-ecr
 
 definitions:


### PR DESCRIPTION
Description:
- Since the telegraf image will be deployed to both staging and production ECR conditional on passing the deploy-toolbox
and deploy-toolbox-staging jobs it makes sense to display it in the UI for clarity