### PR TITLE
PP-7877 - Fix authentication error with production ECR

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -114,6 +114,8 @@ resources:
     icon: docker
     source:
       repository: govukpay/telegraf
+      variant: release
+      <<: *aws_prod_config
   - name: ledger-ecr-registry-prod
     type: registry-image-resource-1-1-0
     icon: docker
@@ -126,7 +128,8 @@ resources:
     icon: docker
     source:
       repository: govukpay/publicapi
-
+      variant: release
+      <<: *aws_prod_config
 
 resource_types:
   - name: registry-image-resource-1-1-0


### PR DESCRIPTION
Description:
- Some production ECR resources were missing the role configuration which caused an authentication error when checking.
- Toolbox should only check for `*-release` Telegraf variants as that is what the docker images are tagged with