### PR TITLE
PP-7755 Test new versions of nginx with toolbox deploy

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -246,6 +246,7 @@ resources:
     type: dev-registry-image
     icon: docker
     source:
+      variant: release
       repository: govukpay/docker-nginx-proxy
       <<: *aws_test_config
   - name: nginx-forward-proxy-ecr-registry-test
@@ -332,6 +333,12 @@ resources:
     icon: docker
     source:
       repository: govukpay/telegraf
+      <<: *aws_staging_config
+  - name: nginx-proxy-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/docker-nginx-proxy
       <<: *aws_staging_config
 
 
@@ -439,7 +446,9 @@ groups:
       - push-cardid-to-staging-ecr
   - name: nginx-proxy
     jobs:
-      - nginx-proxy-image-to-test-ecr
+      - push-nginx-proxy-to-test-ecr
+      - deploy-toolbox
+      - push-nginx-proxy-to-staging-ecr
   - name: nginx-forward-proxy
     jobs:
       - build-and-push-nginx-forward-proxy-to-test-ecr
@@ -496,6 +505,8 @@ jobs:
       - get: toolbox-ecr-registry-test
         trigger: true
       - get: telegraf-ecr-registry-test
+        trigger: true
+      - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: pay-infra
       - get: pay-ci
@@ -1849,7 +1860,7 @@ jobs:
         params:
           image: cardid-ecr-registry-test/image.tar
           additional_tags: cardid-ecr-registry-test/tag
-  - name: nginx-proxy-image-to-test-ecr
+  - name: push-nginx-proxy-to-test-ecr
     plan:
       - get: pay-ci
       - get: nginx-proxy-git-release
@@ -1860,10 +1871,26 @@ jobs:
           DOCKER_REPOSITORY: govukpay/docker-nginx-proxy
           APP_GIT_DIR: nginx-proxy-git-release
           <<: *docker_credentials
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: nginx-proxy-git-release
       - put: nginx-proxy-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: nginx-proxy-git-release/.git/HEAD
+          additional_tags: tags/tags
+  - name: push-nginx-proxy-to-staging-ecr
+    plan:
+      - get: pay-ci
+      - get: nginx-proxy-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [deploy-toolbox]
+      - put: nginx-proxy-ecr-registry-staging
+        params:
+          image: nginx-proxy-ecr-registry-test/image.tar
+          additional_tags: nginx-proxy-ecr-registry-test/tag
   - name: build-and-push-nginx-forward-proxy-to-test-ecr
     plan:
       - get: pay-ci


### PR DESCRIPTION
As with other sidecars, on new version of nginx proxy then deplo the new version as by passing in new version to toolbox deploy, and only push the new image to staging once that deploy has succeeded.

See https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test?group=nginx-proxy