### PR TITLE
PP-7755 - Deploy frontend to staging on new nginx-forward-proxy

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -223,6 +223,19 @@ resources:
     source:
       repository: govukpay/docker-nginx-proxy
       <<: *aws_production_config
+  - name: nginx-forward-proxy-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/nginx-forward-proxy
+      variant: release
+      <<: *aws_staging_config
+  - name: nginx-forward-proxy-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/nginx-forward-proxy
+      <<: *aws_production_config
 
 resource_types:
   - name: registry-image-resource-1-1-0
@@ -306,6 +319,11 @@ groups:
     jobs:
       - deploy-toolbox-to-staging
       - push-nginx-proxy-to-production-ecr
+  - name: nginx-forward-proxy
+    jobs:
+      - deploy-frontend-to-staging
+      - smoke-test-frontend-on-staging
+      - push-nginx-forward-proxy-to-production-ecr
 
 jobs:
   - name: update-deploy-to-staging-pipeline
@@ -589,10 +607,13 @@ jobs:
   - name: deploy-frontend-to-staging
     plan:
       - get: frontend-ecr-registry-staging
+      - get: nginx-forward-proxy-ecr-registry-staging
       - get: pay-infra
       - get: pay-ci
       - load_var: tag
         file: frontend-ecr-registry-staging/tag
+      - load_var: nginx-forward-proxy-image-tag
+        file: nginx-forward-proxy-ecr-registry-staging/tag
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -615,10 +636,35 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
-        params:
-          APP_NAME: frontend
-          <<: *deploy_params
+        config:
+          platform: linux
+          inputs:
+            - name: pay-infra
+          image_resource:
+            type: registry-image
+            source:
+              repository: hashicorp/terraform
+              tag: 0.13.4
+          params:
+            APP_NAME: frontend
+            APP_IMAGE_TAG: ((.:tag))
+            NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx-forward-proxy-image-tag))
+            ACCOUNT: staging
+            ENVIRONMENT: staging-2
+            AWS_REGION: eu-west-1
+            <<: *aws_assumed_role_creds
+          run:
+            path: /bin/sh
+            args:
+              - -ec
+              - |
+                cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/${APP_NAME}
+                terraform init
+                terraform apply \
+                  -var application_image_tag=${APP_IMAGE_TAG} \
+                  -var forward_proxy_image_tag=${NGINX_FORWARD_PROXY_IMAGE_TAG} \
+                  -var nginx_image_tag='' \
+                  -auto-approve
       - task: wait-for-deploy
         file: pay-ci/ci/tasks/wait-for-deploy.yml
         params:
@@ -627,6 +673,9 @@ jobs:
   - name: smoke-test-frontend-on-staging
     plan:
       - get: frontend-ecr-registry-staging
+        trigger: true
+        passed: [deploy-frontend-to-staging]
+      - get: nginx-forward-proxy-ecr-registry-staging
         trigger: true
         passed: [deploy-frontend-to-staging]
       - task: smoke-test-on-staging
@@ -1254,3 +1303,14 @@ jobs:
         params:
           image: nginx-proxy-ecr-registry-staging/image.tar
           additional_tags: nginx-proxy-ecr-registry-staging/tag
+  - name: push-nginx-forward-proxy-to-production-ecr
+    plan:
+      - get: nginx-forward-proxy-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-frontend-on-staging]
+      - put: nginx-forward-proxy-ecr-registry-prod
+        params:
+          image: nginx-forward-proxy-ecr-registry-staging/image.tar
+          additional_tags: nginx-forward-proxy-ecr-registry-staging/tag

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -341,7 +341,13 @@ resources:
     source:
       repository: govukpay/docker-nginx-proxy
       <<: *aws_staging_config
-
+  - name: nginx-forward-proxy-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/nginx-forward-proxy
+      variant: release
+      <<: *aws_staging_config
 
 resource_types:
   # Custom resource type - this has been merged to the
@@ -1963,7 +1969,7 @@ jobs:
           format: oci
         trigger: true
         passed: [smoke-test-frontend]
-      - put: nginx-proxy-ecr-registry-staging
+      - put: nginx-forward-proxy-ecr-registry-staging
         params:
           image: nginx-forward-proxy-ecr-registry-test/image.tar
           additional_tags: nginx-forward-proxy-ecr-registry-test/tag


### PR DESCRIPTION
Description:
- This PR modifies the deploy-to-staging pipeline so when a new nginx-forward-proxy image appears in
staging ECR it will deploy frontend to staging and upon successful completion of frontend smoke tests
it will deploy the image to production nginx-forward-proxy ECR
- Fixes the error in deploy-to-test pipeline where push-nginx-forward-proxy actually pushed to nginx-proxy ECR
instead of nginx-forward-proxy ECR