### PR TITLE
PP-7755 - Deploy nginx-forward-proxy with frontend to prod

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -123,6 +123,13 @@ resources:
       repository: govukpay/docker-nginx-proxy
       variant: release
       <<: *aws_prod_config
+  - name: nginx-forward-proxy-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/nginx-forward-proxy
+      variant: release
+      <<: *aws_prod_config
   - name: ledger-ecr-registry-prod
     type: registry-image-resource-1-1-0
     icon: docker
@@ -201,6 +208,12 @@ groups:
       - deploy-ledger-to-prod
       - smoke-test-ledger-on-prod
       - ledger-pact-tag
+  - name: telegraf
+    jobs:
+      - deploy-toolbox-to-prod
+  - name: nginx-forward-proxy
+    jobs:
+      - deploy-frontend-to-prod
   - name: nginx-proxy
     jobs:
       - deploy-toolbox-to-prod
@@ -451,10 +464,13 @@ jobs:
   - name: deploy-frontend-to-prod
     plan:
       - get: frontend-ecr-registry-prod
+      - get: nginx-forward-proxy-ecr-registry-prod
       - get: pay-infra
       - get: pay-ci
       - load_var: tag
         file: frontend-ecr-registry-prod/tag
+      - load_var: nginx-forward-proxy-image-tag
+        file: nginx-forward-proxy-ecr-registry-prod/tag
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -477,10 +493,35 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
-        params:
-          APP_NAME: frontend
-          <<: *deploy_params
+        config:
+          platform: linux
+          inputs:
+            - name: pay-infra
+          image_resource:
+            type: registry-image
+            source:
+              repository: hashicorp/terraform
+              tag: 0.13.4
+          params:
+            APP_NAME: frontend
+            APP_IMAGE_TAG: ((.:tag))
+            NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx-forward-proxy-image-tag))
+            ACCOUNT: production
+            ENVIRONMENT: production-2
+            AWS_REGION: eu-west-1
+            <<: *aws_assumed_role_creds
+          run:
+            path: /bin/sh
+            args:
+              - -ec
+              - |
+                cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/${APP_NAME}
+                terraform init
+                terraform apply \
+                  -var application_image_tag=${APP_IMAGE_TAG} \
+                  -var forward_proxy_image_tag=${NGINX_FORWARD_PROXY_IMAGE_TAG} \
+                  -var nginx_image_tag='' \
+                  -auto-approve
       - task: wait-for-deploy
         file: pay-ci/ci/tasks/wait-for-deploy.yml
         params:


### PR DESCRIPTION
Description:
- Upon a new nginx-forward-proxy in prod ECR the deploy-to-production pipeline will
deploy nginx-forward-proxy to production along with frontend
- Displays the telegraf group in deploy-to-production pipeline for ease