### PR TITLE
PP-7889 Notify success and failure of toolbox test deployments

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -348,6 +348,12 @@ resources:
       repository: govukpay/nginx-forward-proxy
       variant: release
       <<: *aws_staging_config
+  - name: slack-notification
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-notification-secret))
+
+
 
 resource_types:
   # Custom resource type - this has been merged to the
@@ -367,7 +373,11 @@ resource_types:
     source:
       repository: concourse/registry-image-resource
       tag: "1.1.0"
-
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
 groups:
   - name: update-deploy-to-test-pipeline
     jobs:
@@ -512,8 +522,11 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-toolbox
     plan:
+      - get: toolbox-git-release
+        passed: [push-toolbox-to-test-ecr]
       - get: toolbox-ecr-registry-test
         trigger: true
+        passed: [push-toolbox-to-test-ecr]
       - get: telegraf-ecr-registry-test
         trigger: true
       - get: nginx-proxy-ecr-registry-test
@@ -526,6 +539,45 @@ jobs:
         file: telegraf-ecr-registry-test/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-test/tag
+      - load_var: git_tag
+        file: toolbox-git-release/.git/ref
+      - task: create-messages
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: alpine
+          params:
+            APP_NAME: toolbox
+            APP_GIT_TAG: ((.:git_tag)
+            TELEGRAF_GIT_TAG: ((.:telegraf_image_tag)
+          outputs:
+            - name: message
+          run:
+            path: sh
+            args:
+              - -c
+              - |
+                cat <<EOT >> message/success
+                :green-circle: Deployment of ${APP_NAME} was successful :tada:
+
+                Versions:
+                  toolbox: https://github.com/alphagov/pay-${APP_NAME}/releases/tag/${APP_GIT_TAG}
+                  telegraf: https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_GIT_TAG}
+                EOT
+
+                cat <<EOT >> message/failure
+                :red_circle: Deployment of ${APP_NAME} failed
+
+                Versions:
+                toolbox: https://github.com/alphagov/pay-${APP_NAME}/releases/tag/${APP_GIT_TAG}
+                telegraf: https://github.com/alphagov/pay-telegraf/releases/tag/((.:telegraf_image_tag))
+                EOT
+      - load_var: success_message
+        file: message/success
+      - load_var: failure_message
+        file: message/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -574,6 +626,20 @@ jobs:
           ENVIRONMENT: test-12
           AWS_REGION: eu-west-1
           <<: *aws_assumed_role_creds
+    on_success:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-activity'
+        text: "((.:success_message)) \n\n
+              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+    on_failure:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-announce'
+        text: "((.:failure_message)) \n\n
+              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+
+
   - name: smoke-test-toolbox
     plan:
       - get: toolbox-ecr-registry-test


### PR DESCRIPTION
Couple of funny looking things:
The message is partly comprised of a bit written to a file and then loaded to a variable. This allows us to move the task that creates the messages to a task file, parameterise etc.
The other bit of the message (the build information) is stuck on the end in the `on_{success,failure}` handlers. This is because Concourse only exposes build information in resources https://stackoverflow.com/a/40939590 so if this were appended to the message in the create messages task, all the env vars would evaluate to an empty string.
Success goes to `govuk-pay-activity`, failure to `govuk-pay-announce` as discussed in story notes.

Example of success being sent https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-toolbox/builds/169
Example of success message: https://gds.slack.com/archives/CEBPUR2JE/p1616166796010200

Example of failure being sent https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-toolbox/builds/170

Example failure message: https://gds.slack.com/archives/CEBPUR2JE/p1616167252010800 (nb have fixed the :red_circle: emoji)