### PR TITLE
PP-7887: Add pay-ci resource to smoke tests

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -328,6 +328,7 @@ jobs:
       - get: selfservice-ecr-registry-prod
         trigger: true
         passed: [deploy-selfservice-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -406,6 +407,7 @@ jobs:
       - get: connector-ecr-registry-prod
         trigger: true
         passed: [deploy-connector-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -502,6 +504,7 @@ jobs:
       - get: toolbox-ecr-registry-prod
         trigger: true
         passed: [deploy-toolbox-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -564,6 +567,7 @@ jobs:
       - get: frontend-ecr-registry-prod
         trigger: true
         passed: [deploy-frontend-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -642,6 +646,7 @@ jobs:
       - get: adminusers-ecr-registry-prod
         trigger: true
         passed: [deploy-adminusers-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -720,6 +725,7 @@ jobs:
       - get: products-ecr-registry-prod
         trigger: true
         passed: [deploy-products-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -798,6 +804,7 @@ jobs:
       - get: products-ui-ecr-registry-prod
         trigger: true
         passed: [deploy-products-ui-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -863,6 +870,7 @@ jobs:
       - get: publicauth-ecr-registry-prod
         trigger: true
         passed: [deploy-publicauth-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -907,6 +915,7 @@ jobs:
       - get: cardid-ecr-registry-prod
         trigger: true
         passed: [deploy-cardid-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -963,6 +972,7 @@ jobs:
       - get: publicapi-ecr-registry-prod
         trigger: true
         passed: [deploy-publicapi-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1040,6 +1050,7 @@ jobs:
       - get: ledger-ecr-registry-prod
         trigger: true
         passed: [deploy-ledger-to-prod]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -635,6 +635,7 @@ jobs:
       - get: toolbox-ecr-registry-staging
         trigger: true
         passed: [deploy-toolbox-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -710,6 +711,7 @@ jobs:
       - get: nginx-forward-proxy-ecr-registry-staging
         trigger: true
         passed: [deploy-frontend-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -800,6 +802,7 @@ jobs:
       - get: adminusers-ecr-registry-staging
         trigger: true
         passed: [deploy-adminusers-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -889,6 +892,7 @@ jobs:
       - get: products-ecr-registry-staging
         trigger: true
         passed: [deploy-products-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -978,6 +982,7 @@ jobs:
       - get: products-ui-ecr-registry-staging
         trigger: true
         passed: [deploy-products-ui-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1054,6 +1059,7 @@ jobs:
       - get: publicauth-ecr-registry-staging
         trigger: true
         passed: [deploy-publicauth-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1109,6 +1115,7 @@ jobs:
       - get: cardid-ecr-registry-staging
         trigger: true
         passed: [deploy-cardid-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1177,6 +1184,7 @@ jobs:
       - get: publicapi-ecr-registry-staging
         trigger: true
         passed: [deploy-publicapi-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1266,6 +1274,7 @@ jobs:
       - get: ledger-ecr-registry-staging
         trigger: true
         passed: [deploy-ledger-to-staging]
+      - get: pay-ci
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:


### PR DESCRIPTION
Fixes an oversight - this was included in the `deploy-to-test` pipeline but not the equivalent staging or production pipelines.