### PR TITLE
PP-7887: Check Canary is in a startable state

### DIFF
--- a/ci/scripts/run_smoke_test.js
+++ b/ci/scripts/run_smoke_test.js
@@ -67,8 +67,6 @@ async function run () {
     process.exit(1)
   }
 
-  const startedAt = Date.now()
-
   if (canaryStatus === 'wait') {
     // Wait 60 secs and continue
     console.log('Canary is not in a startable state. Wait 60s before starting.')
@@ -78,6 +76,8 @@ async function run () {
       console.log(error)
     }
   }
+
+  const startedAt = Date.now()
 
   try {
     console.log('Starting Canary')

--- a/ci/scripts/run_smoke_test.js
+++ b/ci/scripts/run_smoke_test.js
@@ -4,13 +4,18 @@ const AWS = require('aws-sdk')
 const synthetics = new AWS.Synthetics()
 const s3 = new AWS.S3()
 const CHECK_INTERVAL = 5000
+const CANARY_TIMEOUT = 60000
 const { SMOKE_TEST_NAME } = process.env
 
 async function describeCanariesLastRun () {
   return synthetics.describeCanariesLastRun({}).promise()
 }
 
-function runCanary () {
+async function getCanary () {
+  return synthetics.getCanary({ Name: SMOKE_TEST_NAME }).promise()
+}
+
+function startCanary () {
   console.log(`Starting canary: ${SMOKE_TEST_NAME}`)
   // 'startCanary' should run it once then stop, according to its schedule config in terraform
   return synthetics.startCanary({ Name: SMOKE_TEST_NAME }).promise()
@@ -28,14 +33,65 @@ async function getS3Objects (splitLocation, prefix) {
   return s3.listObjects({ Bucket: splitLocation[0], Prefix: prefix }).promise()
 }
 
+function checkIfCanaryIsInStartableState (canary) {
+  const canaryStatus = canary.Canary.Status.State
+  switch (canaryStatus) {
+    case 'CREATING':
+    case 'STARTED':
+    case 'RUNNING':
+    case 'UPDATING':
+    case 'STOPPING':
+      return 'wait'
+    case 'STOPPED':
+      console.log('Canary is ready to start')
+      return 'ready'
+    case 'DELETING':
+    case 'ERROR':
+      throw new Error(`Unable to start canary in state ${canaryStatus}`)
+  }
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 async function run () {
-  const startedAt = Date.now()
+  // Assume the canary is ready for now
+  let canaryStatus = 'ready'
+
   try {
-    await runCanary()
+    const canary = await getCanary()
+    canaryStatus = checkIfCanaryIsInStartableState(canary)
   } catch (error) {
-    console.error(error)
-    process.exitCode = 1
-    return
+    console.log(error)
+    process.exit(1)
+  }
+
+  const startedAt = Date.now()
+
+  if (canaryStatus === 'wait') {
+    // Wait 60 secs and continue
+    console.log('Canary is not in a startable state. Wait 60s before starting.')
+    try {
+      await sleep(CANARY_TIMEOUT)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  try {
+    console.log('Starting Canary')
+    await startCanary()
+  } catch (error) {
+    if (error.code === 'ConflictException') {
+      // Ignore subsequent ConflictExceptions, as we've already waited for a
+      // previous run to complete above.
+      // If the Canary has been started again by another process, use its results.
+      console.log('Canary is already running for this deploy')
+    } else {
+      console.log(error)
+      process.exit(1)
+    }
   }
 
   const deploymentChecker = setInterval(async () => {


### PR DESCRIPTION
When running our post-deploy smoke tests, if second app is also being deployed, and the smoke tests are already running, the `startCanary` command will fail with a 409 Conflict error.

Ideally we want the Canary to be in status STOPPED, so we can be confident that our forthcoming run will test the just-deployed app. This script adds a check on the Canary's current status, and happily proceeds if the status is STOPPED.

If the status is DELETING or ERROR, something bad has happened to our Canary and we probably shouldn't run it - raise an error.

If the status is anything else (eg RUNNING, STARTED, UPDATING) then waiting for a minute or so should bring the Canary into the STOPPED state. Our Canaries currently take way less than 60s to run and/or update, so this is fairly generous and should cover most cases. After waiting, we can call `startCanary` as normal.

Here's what this scenario looks like in Concourse (note the 60s gap in the timestamp):

![concourse-smoke-test-wait](https://user-images.githubusercontent.com/3492540/112334985-c231a480-8cb3-11eb-84bc-316364509e1c.png)

If the `StartCanary` command still fails with a conflict after 60s, then it's likely to be conflicting with a fresh run (maybe triggered by a third app deploy!). However this run will have started *after* our deploy, so it's fine to use the result. If the canary fails for any other reason, the script errors.

There's an edge case where the same canary is still running after 60s, and its results are based on the previous deploy. Given long-running canaries should time out and fail anyway, this doesn't feel like a big risk. We'll address this case and improve the error handling in a future story.



[AWS error reference for StartCanary](https://docs.aws.amazon.com/AmazonSynthetics/latest/APIReference/API_StartCanary.html)
