### PR TITLE
PP-7889 Notifications on test pipeline for deploys, smoke tests, and pact tagging

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -53,6 +53,16 @@ deploy_params: &deploy_params
   ACCOUNT: test
   ENVIRONMENT: test-12
 
+snippet_params_all_versions: &snippet_params_all_versions
+  ENV: test-12
+  APP_IMAGE_TAG: ((.:tag))
+  TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
+  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+
+snippet_params_app_version: &snippet_params_app_version
+  ENV: test-12
+  APP_IMAGE_TAG: ((.:tag))
+
 
 resources:
   - name: deploy-to-test-pipeline-definition
@@ -613,10 +623,7 @@ jobs:
         params:
           APP_NAME: toolbox
           ACTION_NAME: Deployment
-          ENV: test-12
-          APP_IMAGE_TAG: ((.:tag))
-          TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
-          NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+          <<: *snippet_params_all_versions
       - load_var: success_snippet
         file: snippet/success
       - load_var: failure_snippet
@@ -710,6 +717,14 @@ jobs:
         file: nginx-forward-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: frontend
+          ACTION_NAME: Deployment
+          NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -743,6 +758,8 @@ jobs:
           APP_NAME: frontend
           NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: smoke-test-frontend
     plan:
@@ -831,6 +848,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: adminusers
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -862,6 +886,9 @@ jobs:
         params:
           APP_NAME: adminusers
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: adminusers-db-migration
     plan:
       - get: pay-ci
@@ -988,6 +1015,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: connector
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1019,6 +1053,9 @@ jobs:
         params:
           APP_NAME: connector
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: connector-db-migration
     plan:
       - get: pay-ci
@@ -1144,6 +1181,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: ledger
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1175,6 +1219,9 @@ jobs:
         params:
           APP_NAME: ledger
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: smoke-test-ledger
     plan:
       - get: ledger-ecr-registry-test
@@ -1302,6 +1349,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: products
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1333,6 +1387,9 @@ jobs:
         params:
           APP_NAME: products
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: products-db-migration
     plan:
       - get: pay-ci
@@ -1458,6 +1515,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: products-ui
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1489,6 +1553,9 @@ jobs:
         params:
           APP_NAME: products-ui
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: smoke-test-products-ui
     plan:
       - get: products-ui-ecr-registry-test
@@ -1574,6 +1641,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: publicapi
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1605,6 +1679,9 @@ jobs:
         params:
           APP_NAME: publicapi
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: smoke-test-publicapi
     plan:
       - get: publicapi-ecr-registry-test
@@ -1690,6 +1767,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: publicauth
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1708,6 +1792,9 @@ jobs:
         params:
           APP_NAME: publicauth
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: publicauth-db-migration
     plan:
       - get: pay-ci
@@ -1810,6 +1897,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: selfservice
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1841,6 +1935,9 @@ jobs:
         params:
           APP_NAME: selfservice
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: smoke-test-selfservice
     plan:
       - get: selfservice-ecr-registry-test
@@ -1962,6 +2059,13 @@ jobs:
         file: nginx-proxy-ecr-registry-test/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: cardid
+          ACTION_NAME: Deployment
+          <<: *snippet_params_all_versions
+      - load_var: success_snippet
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1980,6 +2084,9 @@ jobs:
         params:
           APP_NAME: cardid
           <<: *wait_for_deploy_params
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: smoke-test-cardid
     plan:
       - get: cardid-ecr-registry-test

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -21,6 +21,22 @@ aws_assumed_role_creds: &aws_assumed_role_creds
   AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
   AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
+put_success_slack_notification: &put_success_slack_notification
+  on_success:
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-activity'
+      text: "((.:success_snippet)) \n\n
+            Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  
+put_failure_slack_notification: &put_failure_slack_notification
+  on_failure:
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-activity'
+      text: "((.:failure_snippet)) \n\n
+            Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  
 
 wait_for_deploy_params: &wait_for_deploy_params
   <<: *aws_assumed_role_creds
@@ -52,7 +68,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: PP-7889-test-pipeline-notifications-all-the-things
 
   # Github Releases
   - name: telegraf-git-release
@@ -578,11 +594,8 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-toolbox
     plan:
-      - get: toolbox-git-release
-        passed: [push-toolbox-to-test-ecr]
       - get: toolbox-ecr-registry-test
         trigger: true
-        passed: [push-toolbox-to-test-ecr]
       - get: telegraf-ecr-registry-test
         trigger: true
       - get: nginx-proxy-ecr-registry-test
@@ -595,45 +608,19 @@ jobs:
         file: telegraf-ecr-registry-test/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-test/tag
-      - load_var: git_tag
-        file: toolbox-git-release/.git/ref
-      - task: create-messages
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: alpine
-          params:
-            APP_NAME: toolbox
-            APP_GIT_TAG: ((.:git_tag)
-            TELEGRAF_GIT_TAG: ((.:telegraf_image_tag)
-          outputs:
-            - name: message
-          run:
-            path: sh
-            args:
-              - -c
-              - |
-                cat <<EOT >> message/success
-                :green-circle: Deployment of ${APP_NAME} was successful :tada:
-
-                Versions:
-                  toolbox: https://github.com/alphagov/pay-${APP_NAME}/releases/tag/${APP_GIT_TAG}
-                  telegraf: https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_GIT_TAG}
-                EOT
-
-                cat <<EOT >> message/failure
-                :red_circle: Deployment of ${APP_NAME} failed
-
-                Versions:
-                toolbox: https://github.com/alphagov/pay-${APP_NAME}/releases/tag/${APP_GIT_TAG}
-                telegraf: https://github.com/alphagov/pay-telegraf/releases/tag/((.:telegraf_image_tag))
-                EOT
-      - load_var: success_message
-        file: message/success
-      - load_var: failure_message
-        file: message/failure
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: toolbox
+          ACTION_NAME: Deployment
+          ENV: test-12
+          APP_IMAGE_TAG: ((.:tag))
+          TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
+          NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -652,19 +639,8 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
-    on_success:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-activity'
-        text: "((.:success_message)) \n\n
-              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
-    on_failure:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-announce'
-        text: "((.:failure_message)) \n\n
-              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
-
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: smoke-test-toolbox
     plan:
@@ -682,13 +658,14 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+
   - name: push-toolbox-to-staging-ecr
     plan:
       - get: toolbox-ecr-registry-test
+        passed: [smoke-test-toolbox]
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-toolbox]
       - put: toolbox-ecr-registry-staging
         params:
           image: toolbox-ecr-registry-test/image.tar
@@ -792,7 +769,7 @@ jobs:
         trigger: true
       - load_var: application_image_tag
         file: frontend-ecr-registry-test/tag
-      - get: pay-ci  
+      - get: pay-ci
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -55,13 +55,13 @@ deploy_params: &deploy_params
 
 snippet_params_all_versions: &snippet_params_all_versions
   ENV: test-12
-  APP_IMAGE_TAG: ((.:tag))
+  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
   TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
   NGINX_IMAGE_TAG: ((.:nginx_image_tag))
 
 snippet_params_app_version: &snippet_params_app_version
   ENV: test-12
-  APP_IMAGE_TAG: ((.:tag))
+  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
 
 
 resources:
@@ -78,7 +78,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-7889-test-pipeline-notifications-all-the-things
+      branch: master
 
   # Github Releases
   - name: telegraf-git-release
@@ -655,7 +655,7 @@ jobs:
         trigger: true
         passed: [deploy-toolbox]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: toolbox-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -786,7 +786,7 @@ jobs:
         trigger: true
         passed: [deploy-frontend]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: frontend-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -978,7 +978,7 @@ jobs:
         trigger: true
         passed: [deploy-adminusers]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -1171,7 +1171,7 @@ jobs:
         trigger: true
         passed: [deploy-connector]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -1323,7 +1323,7 @@ jobs:
         trigger: true
         passed: [deploy-ledger]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: connector-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -1556,7 +1556,7 @@ jobs:
         trigger: true
         passed: [deploy-products]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: ledger-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -1707,7 +1707,7 @@ jobs:
         trigger: true
         passed: [deploy-products-ui]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: products-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -1858,7 +1858,7 @@ jobs:
         trigger: true
         passed: [deploy-publicapi]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: publicapi-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -2036,7 +2036,7 @@ jobs:
         trigger: true
         passed: [deploy-publicauth]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: publicauth-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -2157,7 +2157,7 @@ jobs:
         trigger: true
         passed: [deploy-selfservice]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
@@ -2332,7 +2332,7 @@ jobs:
         trigger: true
         passed: [deploy-cardid]
       - get: pay-ci
-      - load_var: tag
+      - load_var: application_image_tag
         file: cardid-ecr-registry-test/tag
       - task: create-success-and-failure-snippets
         file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -655,6 +655,18 @@ jobs:
         trigger: true
         passed: [deploy-toolbox]
       - get: pay-ci
+      - load_var: tag
+        file: toolbox-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: toolbox
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -665,6 +677,8 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-toolbox-to-staging-ecr
     plan:
@@ -769,6 +783,18 @@ jobs:
         trigger: true
         passed: [deploy-frontend]
       - get: pay-ci
+      - load_var: tag
+        file: frontend-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: frontend
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -779,6 +805,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: frontend-pact-tag
     plan:
       - get: frontend-ecr-registry-test
@@ -935,6 +964,18 @@ jobs:
         trigger: true
         passed: [deploy-adminusers]
       - get: pay-ci
+      - load_var: tag
+        file: adminusers-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: adminusers
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -945,6 +986,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
 
   - name: adminusers-pact-tag
     plan:
@@ -1102,6 +1146,18 @@ jobs:
         trigger: true
         passed: [deploy-connector]
       - get: pay-ci
+      - load_var: tag
+        file: adminusers-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: adminusers
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1112,6 +1168,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
 
   - name: connector-pact-tag
     plan:
@@ -1228,6 +1287,18 @@ jobs:
         trigger: true
         passed: [deploy-ledger]
       - get: pay-ci
+      - load_var: tag
+        file: connector-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: connector
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1238,6 +1309,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
 
   - name: ledger-pact-tag
     plan:
@@ -1436,6 +1510,18 @@ jobs:
         trigger: true
         passed: [deploy-products]
       - get: pay-ci
+      - load_var: tag
+        file: ledger-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: ledger
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1446,6 +1532,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
 
   - name: products-pact-tag
     plan:
@@ -1562,6 +1651,18 @@ jobs:
         trigger: true
         passed: [deploy-products-ui]
       - get: pay-ci
+      - load_var: tag
+        file: products-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: products
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1572,6 +1673,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
 
   - name: products-ui-pact-tag
     plan:
@@ -1688,6 +1792,18 @@ jobs:
         trigger: true
         passed: [deploy-publicapi]
       - get: pay-ci
+      - load_var: tag
+        file: publicapi-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: publicapi
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1698,6 +1814,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
 
   - name: publicapi-pact-tag
     plan:
@@ -1841,6 +1960,18 @@ jobs:
         trigger: true
         passed: [deploy-publicauth]
       - get: pay-ci
+      - load_var: tag
+        file: publicauth-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: publicauth
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1851,6 +1982,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: push-publicauth-to-staging-ecr
     plan:
       - get: publicauth-ecr-registry-test
@@ -1944,6 +2078,18 @@ jobs:
         trigger: true
         passed: [deploy-selfservice]
       - get: pay-ci
+      - load_var: tag
+        file: adminusers-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: selfservice
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1954,6 +2100,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
 
   - name: selfservice-pact-tag
     plan:
@@ -2093,6 +2242,18 @@ jobs:
         trigger: true
         passed: [deploy-cardid]
       - get: pay-ci
+      - load_var: tag
+        file: cardid-ecr-registry-test/tag
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: cardid
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2103,6 +2264,9 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: push-cardid-to-staging-ecr
     plan:
       - get: cardid-ecr-registry-test

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -33,7 +33,7 @@ put_failure_slack_notification: &put_failure_slack_notification
   on_failure:
     put: slack-notification
     params:
-      channel: '#govuk-pay-activity'
+      channel: '#govuk-pay-announce'
       text: "((.:failure_snippet)) \n\n
             Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
   
@@ -739,6 +739,9 @@ jobs:
           NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -892,6 +895,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1082,6 +1088,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1271,6 +1280,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1461,6 +1473,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1649,6 +1664,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1797,6 +1815,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1945,6 +1966,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2090,6 +2114,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -2275,6 +2302,9 @@ jobs:
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
       - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -816,6 +816,12 @@ jobs:
       - load_var: application_image_tag
         file: frontend-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: frontend
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -829,6 +835,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: frontend
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-frontend-to-staging-ecr
     plan:
@@ -998,6 +1006,12 @@ jobs:
       - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: adminusers
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1011,6 +1025,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: adminusers
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-adminusers-to-staging-ecr
     plan:
@@ -1180,6 +1196,12 @@ jobs:
       - load_var: application_image_tag
         file: connector-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: connector
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1193,6 +1215,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: connector
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-connector-to-staging-ecr
     plan:
@@ -1312,7 +1336,6 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
-
   - name: ledger-pact-tag
     plan:
       - get: ledger-ecr-registry-test
@@ -1321,6 +1344,12 @@ jobs:
       - load_var: application_image_tag
         file: ledger-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: ledger
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1334,6 +1363,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: ledger
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-ledger-to-staging-ecr
     plan:
@@ -1535,7 +1566,6 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
-
   - name: products-pact-tag
     plan:
       - get: products-ecr-registry-test
@@ -1544,6 +1574,12 @@ jobs:
       - load_var: application_image_tag
         file: products-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: products
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1557,6 +1593,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: products
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-products-to-staging-ecr
     plan:
@@ -1676,7 +1714,6 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
-
   - name: products-ui-pact-tag
     plan:
       - get: products-ui-ecr-registry-test
@@ -1685,6 +1722,12 @@ jobs:
       - load_var: application_image_tag
         file: products-ui-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: products-ui
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1698,6 +1741,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: products-ui
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-products-ui-to-staging-ecr
     plan:
@@ -1817,7 +1862,6 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
-
   - name: publicapi-pact-tag
     plan:
       - get: publicapi-ecr-registry-test
@@ -1826,6 +1870,12 @@ jobs:
       - load_var: application_image_tag
         file: publicapi-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: publicapi
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -1839,6 +1889,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: publicapi
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-publicapi-to-staging-ecr
     plan:
@@ -2112,6 +2164,12 @@ jobs:
       - load_var: application_image_tag
         file: selfservice-ecr-registry-test/tag
       - get: pay-ci
+      - task: create-success-and-failure-snippets
+        file: pay-ci/ci/tasks/create-success-and-failure-snippets.yml
+        params:
+          APP_NAME: selfservice
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -2125,6 +2183,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: selfservice
           PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
 
   - name: push-selfservice-to-staging-ecr
     plan:

--- a/ci/tasks/create-success-and-failure-snippets.yml
+++ b/ci/tasks/create-success-and-failure-snippets.yml
@@ -20,13 +20,16 @@ run:
     - -c
     - |
       cat <<EOT >> snippet/success
+      THIS MESSAGE RELATES TO FARGATE - IGNORE UNLESS WORKING ON MIGRATION
       :green-circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} was successful :tada:
       Version details:
       EOT
 
       cat <<EOT >> snippet/failure
+      THIS MESSAGE RELATES TO FARGATE - IGNORE UNLESS WORKING ON MIGRATION
       :red_circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} failed
       Version details:
+
       EOT
 
       APP_RELEASE_NUMBER=$(echo $APP_IMAGE_TAG| sed 's/-release//')
@@ -46,3 +49,5 @@ run:
       [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
       echo "nginx forward proxy: https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}" | \
       tee -a snippet/* || true
+
+

--- a/ci/tasks/create-success-and-failure-snippets.yml
+++ b/ci/tasks/create-success-and-failure-snippets.yml
@@ -1,0 +1,48 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+params:
+  APP_NAME:
+  ACTION_NAME:
+  ENV:
+  APP_IMAGE_TAG:
+  TELEGRAF_IMAGE_TAG:
+  NGINX_IMAGE_TAG:
+  NGINX_FORWARD_PROXY_IMAGE_TAG:
+outputs:
+  - name: snippet
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      cat <<EOT >> snippet/success
+      :green-circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} was successful :tada:
+      Version details:
+      EOT
+
+      cat <<EOT >> snippet/failure
+      :red_circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} failed
+      Version details:
+      EOT
+
+      APP_RELEASE_NUMBER=$(echo $APP_IMAGE_TAG| sed 's/-release//')
+      echo "${APP_NAME}: https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}" | \
+      tee -a snippet/* || true
+
+      [ -n "${NGINX_IMAGE_TAG}" ] && \
+      NGINX_RELEASE_NUMBER=$(echo $NGINX_IMAGE_TAG| sed 's/-release//') &&\
+      echo "nginx proxy: https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}" | \
+      tee -a snippet/* ||  true
+
+
+      [ -n "${TELEGRAF_IMAGE_TAG}" ] && \
+      echo "telegraf: https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_IMAGE_TAG}" | \
+      tee -a snippet/* || true
+
+      [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
+      echo "nginx forward proxy: https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}" | \
+      tee -a snippet/* || true

--- a/ci/tasks/create-success-and-failure-snippets.yml
+++ b/ci/tasks/create-success-and-failure-snippets.yml
@@ -8,7 +8,7 @@ params:
   APP_NAME:
   ACTION_NAME:
   ENV:
-  APP_IMAGE_TAG:
+  APPLICATION_IMAGE_TAG:
   TELEGRAF_IMAGE_TAG:
   NGINX_IMAGE_TAG:
   NGINX_FORWARD_PROXY_IMAGE_TAG:
@@ -22,22 +22,23 @@ run:
       cat <<EOT >> snippet/success
       THIS MESSAGE RELATES TO FARGATE - IGNORE UNLESS WORKING ON MIGRATION
       :green-circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} was successful :tada:
+
       Version details:
       EOT
 
       cat <<EOT >> snippet/failure
       THIS MESSAGE RELATES TO FARGATE - IGNORE UNLESS WORKING ON MIGRATION
       :red_circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} failed
-      Version details:
 
+      Version details:
       EOT
 
-      APP_RELEASE_NUMBER=$(echo $APP_IMAGE_TAG| sed 's/-release//')
+      APP_RELEASE_NUMBER=$(echo ${APPLICATION_IMAGE_TAG} | sed 's/-release//')
       echo "${APP_NAME}: https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}" | \
       tee -a snippet/* || true
 
       [ -n "${NGINX_IMAGE_TAG}" ] && \
-      NGINX_RELEASE_NUMBER=$(echo $NGINX_IMAGE_TAG| sed 's/-release//') &&\
+      NGINX_RELEASE_NUMBER=$(echo ${NGINX_IMAGE_TAG} | sed 's/-release//') &&\
       echo "nginx proxy: https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}" | \
       tee -a snippet/* ||  true
 


### PR DESCRIPTION
Add success and failure notifications to all deployments, smoke tests and pact tag jobs on test pipeline.
I have extracted a task to create success and failure snippets that I think is reasonably readable and self explanatory.

For deployment notifications we can tell people about versions of all the things deployed which is probably useful.

For smoke tests and pact tags we only have the version of the app (no sidecar versions) so we just include that in notification.

At present this will send all successes to `govuk-pay-activity` and all failures to `govuk-pay-announce`. I have caveated all notifications as only FAO migration team, but I think good to start sending failures to a visible channel, both for migration team to be aware, and to start to get wider team used to this whole thing.

Example of success notification: https://gds.slack.com/archives/CEBPUR2JE/p1616588487009600
from this build https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-connector/builds/39

<img width="710" alt="Screenshot 2021-03-24 at 12 34 08" src="https://user-images.githubusercontent.com/1420504/112311145-49275280-8c9d-11eb-924f-c1304c1baf7b.png">
