### PR TITLE
PP-7908 Check for downgrade

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -636,6 +636,29 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
+      - task: check-release-versions
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "test-12-fargate"
+            APP_NAME: "toolbox"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+            TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
+            NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/check-release-versions.js
       - task: deploy-to-test
         file: pay-ci/ci/tasks/deploy-app.yml
         params:

--- a/ci/scripts/check-release-versions.js
+++ b/ci/scripts/check-release-versions.js
@@ -1,0 +1,71 @@
+const AWS = require('aws-sdk')
+const ecs = new AWS.ECS()
+
+async function getService (appName, clusterName) {
+  try {
+    const params = {
+      services: [appName],
+      cluster: clusterName
+    }
+    const describeServices = await ecs.describeServices(params).promise()
+    return describeServices.services.find(service => service.status === 'ACTIVE')
+  } catch (err) {
+    throw new Error(`Error fetching service: ${err.message}`)
+  }
+}
+
+async function getTaskDefinitionDetails (taskDefinitionName) {
+  try {
+    const { taskDefinition } = await ecs.describeTaskDefinition({ taskDefinition: taskDefinitionName }).promise()
+    return taskDefinition
+  } catch (err) {
+    throw new Error(`Error fetching task definition details: ${err.message}`)
+  }
+}
+
+function checkReleaseVersion (containerName, tagToBeDeployed, currentContainerDefinitions) {
+  const currentImage = currentContainerDefinitions.find(container => container.name === containerName).image
+  const currentRelease = Number(currentImage.split(':')[1].split('-')[0])
+  const releaseToBeDeployed = Number(tagToBeDeployed.split('-')[0])
+  if (releaseToBeDeployed < currentRelease) {
+    throw new Error(`
+        You are trying to deploy release  ${releaseToBeDeployed} of ${containerName} 
+        which is older than the current release ${currentRelease}. Bailing out.
+        If you need to deploy this version please deploy manually using terraform.`)
+  }
+}
+
+async function run () {
+  const {
+    CLUSTER_NAME,
+    APP_NAME,
+    APPLICATION_IMAGE_TAG,
+    TELEGRAF_IMAGE_TAG,
+    NGINX_IMAGE_TAG,
+    NGINX_FORWARD_PROXY_IMAGE_TAG
+  } = process.env
+
+  try {
+    const service = await getService(APP_NAME, CLUSTER_NAME)
+    if (!service) {
+      throw new Error(`failed to find active service for ${APP_NAME}`)
+    }
+
+    const { containerDefinitions } = await getTaskDefinitionDetails(service.taskDefinition)
+    if (!containerDefinitions) {
+      throw new Error('failed to get task definition details')
+    }
+
+    checkReleaseVersion(APP_NAME, APPLICATION_IMAGE_TAG, containerDefinitions)
+    checkReleaseVersion('telegraf', TELEGRAF_IMAGE_TAG, containerDefinitions)
+    checkReleaseVersion('nginx', NGINX_IMAGE_TAG, containerDefinitions)
+    if (NGINX_FORWARD_PROXY_IMAGE_TAG) {
+      checkReleaseVersion('nginx-forward-proxy', NGINX_FORWARD_PROXY_IMAGE_TAG, containerDefinitions)
+    }
+  } catch (err) {
+    console.log(err.message)
+    process.exit(1)
+  }
+}
+
+run()


### PR DESCRIPTION
In our current Jenkins pipelines we have a check that
stops devs accidentally deploying an old version of an
app. This `check-release-versions` task achieves same thing
on Concourse - it checks the version to be deployed of each
container in a task definition, and makes sure it is the
same as or newer than currently deployed version.

There is no mechanism to override this at the moment -
if override is needed devs will need to deploy the thing
manually from laptop.

https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-toolbox/builds/209