### PR TITLE
BAU Trigger ledger pipeline on new image

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1437,6 +1437,7 @@ jobs:
   - name: deploy-ledger-to-prod
     plan:
       - get: ledger-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
       - get: telegraf-ecr-registry-prod
       - get: pay-infra

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1685,6 +1685,7 @@ jobs:
   - name: deploy-ledger-to-staging
     plan:
       - get: ledger-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
       - get: telegraf-ecr-registry-staging
       - get: pay-infra


### PR DESCRIPTION
Trigger ledger pipeline when new image pushed to relevant repo in staging and prod. As per ADR https://docs.google.com/document/d/1oJ347kiaB_tBp-Q_7iZ1NC-xv-uQLz4etoyqI90IKVs/edit#, ledger should be a continuously deployed thing.