### PR TITLE
BAU: Condense slack notifications

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -39,7 +39,7 @@ definitions:
     params:
       channel: '#govuk-pay-announce'
       text: "((.:start_snippet)) \n\n
-            Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+            <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
   put_success_slack_notification_p1: &put_success_slack_notification_p1
     on_success:
@@ -47,7 +47,7 @@ definitions:
       params:
         channel: '#govuk-pay-announce'
         text: "((.:success_snippet)) \n\n
-              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+              <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
   put_success_slack_notification: &put_success_slack_notification
     on_success:
@@ -62,8 +62,8 @@ definitions:
       put: slack-notification
       params:
         channel: '#govuk-pay-announce'
-        text: "((.:failure_snippet)) \n\n
-              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+        text: "((.:failure_snippet)) \n
+              - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
   snippet_params_all_versions: &snippet_params_all_versions
     ENV: production-2

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -48,16 +48,16 @@ definitions:
     put: slack-notification
     params:
       channel: '#govuk-pay-announce'
-      text: "((.:start_snippet)) \n\n
-            Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+      text: "((.:start_snippet)) |
+            <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
   put_success_slack_notification_p1: &put_success_slack_notification_p1
     on_success:
       put: slack-notification
       params:
         channel: '#govuk-pay-announce'
-        text: "((.:success_snippet)) \n\n
-              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+        text: "((.:success_snippet)) |
+              <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
   put_success_slack_notification: &put_success_slack_notification
     on_success:
@@ -65,15 +65,15 @@ definitions:
       params:
         channel: '#govuk-pay-activity'
         text: "((.:success_snippet)) \n\n
-              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+              <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
     
   put_failure_slack_notification: &put_failure_slack_notification
     on_failure:
       put: slack-notification
       params:
         channel: '#govuk-pay-announce'
-        text: "((.:failure_snippet)) \n\n
-              Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+        text: "((.:failure_snippet)) \n
+              - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
   
   snippet_params_all_versions: &snippet_params_all_versions
     ENV: staging-2

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -26,16 +26,16 @@ put_success_slack_notification: &put_success_slack_notification
     put: slack-notification
     params:
       channel: '#govuk-pay-activity'
-      text: "((.:success_snippet)) \n\n
-            Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+      text: "((.:success_snippet)) |
+            <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
   
 put_failure_slack_notification: &put_failure_slack_notification
   on_failure:
     put: slack-notification
     params:
       channel: '#govuk-pay-announce'
-      text: "((.:failure_snippet)) \n\n
-            Build: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+      text: "((.:failure_snippet)) \n
+            - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
   
 
 wait_for_deploy_params: &wait_for_deploy_params

--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -36,12 +36,12 @@ run:
       [ -n "${NGINX_IMAGE_TAG}" ] && \
       NGINX_RELEASE_NUMBER=$(echo ${NGINX_IMAGE_TAG} | sed 's/-release//') &&\
       echo "<https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}|nginx-proxy v${NGINX_RELEASE_NUMBER}>" | \
-      tee -a snippet/* || true
+      tee -a snippet/failure || true
 
       [ -n "${TELEGRAF_IMAGE_TAG}" ] && \
       echo " | <https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_IMAGE_TAG}|telegraf v${TELEGRAF_IMAGE_TAG}>" | \
-      tee -a snippet/* || true
+      tee -a snippet/failure || true
 
       [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
       echo " | <https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}|nginx-forward-proxy v${NGINX_FORWARD_PROXY_IMAGE_TAG}>" | \
-      tee -a snippet/* || true
+      tee -a snippet/failure || true

--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -22,7 +22,7 @@ run:
       APP_RELEASE_NUMBER=$(echo ${APPLICATION_IMAGE_TAG} | sed 's/-release//')
 
       cat <<EOT >> snippet/start
-      :rocket: FARGATE ${ACTION_NAME} of <https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}|${APP_NAME} ${APP_RELEASE_NUMBER}-release> is beginning
+      :rocket: FARGATE ${ACTION_NAME} of <https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}|${APP_NAME} ${APP_RELEASE_NUMBER}-release> on ${ENV} is beginning
       EOT
 
       cat <<EOT >> snippet/success

--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -19,43 +19,29 @@ run:
   args:
     - -c
     - |
-      cat <<EOT >> snippet/start
-      THIS MESSAGE RELATES TO FARGATE - IGNORE UNLESS WORKING ON MIGRATION
-      :rocket: ${ACTION_NAME} of ${APP_NAME} on ${ENV} is beginning
+      APP_RELEASE_NUMBER=$(echo ${APPLICATION_IMAGE_TAG} | sed 's/-release//')
 
-      Version details:
+      cat <<EOT >> snippet/start
+      :rocket: FARGATE ${ACTION_NAME} of <https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}|${APP_NAME} ${APP_RELEASE_NUMBER}-release> is beginning
       EOT
 
       cat <<EOT >> snippet/success
-      THIS MESSAGE RELATES TO FARGATE - IGNORE UNLESS WORKING ON MIGRATION
-      :green-circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} was successful :tada:
-
-      Version details:
+      :green-circle: FARGATE ${ACTION_NAME} of ${APP_NAME} on ${ENV} was successful :tada:
       EOT
 
       cat <<EOT >> snippet/failure
-      THIS MESSAGE RELATES TO FARGATE - IGNORE UNLESS WORKING ON MIGRATION
-      :red_circle: ${ACTION_NAME} of ${APP_NAME} on ${ENV} failed
-
-      Version details:
+      :red_circle: FARGATE ${ACTION_NAME} of ${APP_NAME} on ${ENV} failed
       EOT
-
-      APP_RELEASE_NUMBER=$(echo ${APPLICATION_IMAGE_TAG} | sed 's/-release//')
-      echo "${APP_NAME}: https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}" | \
-      tee -a snippet/* || true
 
       [ -n "${NGINX_IMAGE_TAG}" ] && \
       NGINX_RELEASE_NUMBER=$(echo ${NGINX_IMAGE_TAG} | sed 's/-release//') &&\
-      echo "nginx proxy: https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}" | \
-      tee -a snippet/* ||  true
-
+      echo "<https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}|nginx-proxy v${NGINX_RELEASE_NUMBER}>" | \
+      tee -a snippet/* || true
 
       [ -n "${TELEGRAF_IMAGE_TAG}" ] && \
-      echo "telegraf: https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_IMAGE_TAG}" | \
+      echo " | <https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_IMAGE_TAG}|telegraf v${TELEGRAF_IMAGE_TAG}>" | \
       tee -a snippet/* || true
 
       [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
-      echo "nginx forward proxy: https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}" | \
+      echo " | <https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}|nginx-forward-proxy v${NGINX_FORWARD_PROXY_IMAGE_TAG}>" | \
       tee -a snippet/* || true
-
-

--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -26,22 +26,22 @@ run:
       EOT
 
       cat <<EOT >> snippet/success
-      :green-circle: FARGATE ${ACTION_NAME} of ${APP_NAME} on ${ENV} was successful :tada:
+      :green-circle: FARGATE ${ACTION_NAME} of <https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}|${APP_NAME} v${APPLICATION_IMAGE_TAG}> on ${ENV} was successful :tada:
       EOT
 
       cat <<EOT >> snippet/failure
-      :red_circle: FARGATE ${ACTION_NAME} of ${APP_NAME} on ${ENV} failed
+      :red_circle: FARGATE ${ACTION_NAME} of <https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}|${APP_NAME} v${APPLICATION_IMAGE_TAG}> on ${ENV} failed. Version details:
       EOT
 
       [ -n "${NGINX_IMAGE_TAG}" ] && \
-      NGINX_RELEASE_NUMBER=$(echo ${NGINX_IMAGE_TAG} | sed 's/-release//') &&\
-      echo "<https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}|nginx-proxy v${NGINX_RELEASE_NUMBER}>" | \
+      NGINX_RELEASE_NUMBER=$(echo ${NGINX_IMAGE_TAG} | sed 's/-release//') && \
+      echo "- <https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}|nginx-proxy v${NGINX_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
 
       [ -n "${TELEGRAF_IMAGE_TAG}" ] && \
-      echo " | <https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_IMAGE_TAG}|telegraf v${TELEGRAF_IMAGE_TAG}>" | \
+      echo "- <https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_IMAGE_TAG}|telegraf v${TELEGRAF_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
 
       [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
-      echo " | <https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}|nginx-forward-proxy v${NGINX_FORWARD_PROXY_IMAGE_TAG}>" | \
+      echo "- <https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}|nginx-forward-proxy v${NGINX_FORWARD_PROXY_IMAGE_TAG}>" | \
       tee -a snippet/failure || true


### PR DESCRIPTION
- Made the Fargate element less shouty (but still a bit shouty), and linked the text rather than printing the URLs in full
- Removed the sidecar version info for 'start' and 'success' builds. People can always click on the build if they want to see the telegraf/nginx versions etc. 
- Converted full URLs to linked descriptive text where possible

These changes have been applied to the test, staging and production deploy pipelines - see `#govuk-pay-announce` and `#govuk-pay-activity` for examples.

Not done, but that we might want to consider in future:
- different green emojis for the different types of success announcement (deploys, smoke tests, pact tests)