### PR TITLE
PP-8011 Deploy apps, one release at a time

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -341,6 +341,7 @@ jobs:
         file: deploy-to-prod-pipeline-definition/ci/pipelines/deploy-to-production.yml
 
   - name: deploy-selfservice-to-prod
+    serial: true
     plan:
       - get: selfservice-ecr-registry-prod
         trigger: true
@@ -472,6 +473,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-connector-to-prod
+    serial: true
     plan:
       - get: connector-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -602,6 +604,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-toolbox-to-prod
+    serial: true
     plan:
       - get: toolbox-ecr-registry-prod
         trigger: true
@@ -674,6 +677,7 @@ jobs:
           <<: *smoke-test-run-all-on-production
 
   - name: deploy-frontend-to-prod
+    serial: true
     plan:
       - get: frontend-ecr-registry-prod
       - get: nginx-forward-proxy-ecr-registry-prod
@@ -810,6 +814,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-adminusers-to-prod
+    serial: true
     plan:
       - get: adminusers-ecr-registry-prod
         trigger: true
@@ -939,6 +944,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-products-to-prod
+    serial: true
     plan:
       - get: products-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1068,6 +1074,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-products-ui-to-prod
+    serial: true
     plan:
       - get: products-ui-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1198,6 +1205,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-publicauth-to-prod
+    serial: true
     plan:
       - get: publicauth-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1281,6 +1289,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-cardid-to-prod
+    serial: true
     plan:
       - get: cardid-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1364,6 +1373,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-publicapi-to-prod
+    serial: true
     plan:
       - get: publicapi-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1494,6 +1504,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: deploy-ledger-to-prod
+    serial: true
     plan:
       - get: ledger-ecr-registry-prod
         trigger: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -450,6 +450,7 @@ jobs:
         file: deploy-to-staging-pipeline-definition/ci/pipelines/deploy-to-staging.yml
         
   - name: deploy-selfservice-to-staging
+    serial: true
     plan:
       - get: selfservice-ecr-registry-staging
         trigger: true
@@ -593,6 +594,7 @@ jobs:
           additional_tags: selfservice-ecr-registry-staging/tag
 
   - name: deploy-connector-to-staging
+    serial: true
     plan:
       - get: connector-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -736,6 +738,7 @@ jobs:
           additional_tags: connector-ecr-registry-staging/tag
 
   - name: deploy-toolbox-to-staging
+    serial: true
     plan:
       - get: toolbox-ecr-registry-staging
         trigger: true
@@ -834,6 +837,7 @@ jobs:
           additional_tags: toolbox-ecr-registry-staging/tag
 
   - name: deploy-frontend-to-staging
+    serial: true
     plan:
       - get: frontend-ecr-registry-staging
       - get: nginx-forward-proxy-ecr-registry-staging
@@ -985,6 +989,7 @@ jobs:
           additional_tags: frontend-ecr-registry-staging/tag
           
   - name: deploy-adminusers-to-staging
+    serial: true
     plan:
       - get: adminusers-ecr-registry-staging
         trigger: true
@@ -1128,6 +1133,7 @@ jobs:
           additional_tags: adminusers-ecr-registry-staging/tag
           
   - name: deploy-products-to-staging
+    serial: true
     plan:
       - get: products-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1270,6 +1276,7 @@ jobs:
           additional_tags: products-ecr-registry-staging/tag
           
   - name: deploy-products-ui-to-staging
+    serial: true
     plan:
       - get: products-ui-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1412,6 +1419,7 @@ jobs:
           additional_tags: products-ui-ecr-registry-staging/tag
           
   - name: deploy-publicauth-to-staging
+    serial: true
     plan:
       - get: publicauth-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1507,6 +1515,7 @@ jobs:
           additional_tags: publicauth-ecr-registry-staging/tag
 
   - name: deploy-cardid-to-staging
+    serial: true
     plan:
       - get: cardid-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1602,6 +1611,7 @@ jobs:
           additional_tags: cardid-ecr-registry-staging/tag
           
   - name: deploy-publicapi-to-staging
+    serial: true
     plan:
       - get: publicapi-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1744,6 +1754,7 @@ jobs:
           image: publicapi-ecr-registry-staging/image.tar
           additional_tags: publicapi-ecr-registry-staging/tag
   - name: deploy-ledger-to-staging
+    serial: true
     plan:
       - get: ledger-ecr-registry-staging
         trigger: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -611,6 +611,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-toolbox
+    serial: true
     plan:
       - get: toolbox-ecr-registry-test
         trigger: true
@@ -725,6 +726,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-frontend
+    serial: true
     plan:
       - get: frontend-ecr-registry-test
         trigger: true
@@ -896,6 +898,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-adminusers
+    serial: true
     plan:
       - get: adminusers-ecr-registry-test
         trigger: true
@@ -1098,6 +1101,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-connector
+    serial: true
     plan:
       - get: connector-ecr-registry-test
         trigger: true
@@ -1299,6 +1303,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-ledger
+    serial: true
     plan:
       - get: ledger-ecr-registry-test
         trigger: true
@@ -1501,6 +1506,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-products
+    serial: true
     plan:
       - get: products-ecr-registry-test
         trigger: true
@@ -1701,6 +1707,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-products-ui
+    serial: true
     plan:
       - get: products-ui-ecr-registry-test
         trigger: true
@@ -1861,6 +1868,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-publicapi
+    serial: true
     plan:
       - get: publicapi-ecr-registry-test
         trigger: true
@@ -2021,6 +2029,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-publicauth
+    serial: true
     plan:
       - get: publicauth-ecr-registry-test
         trigger: true
@@ -2174,6 +2183,7 @@ jobs:
           image: image/image.tar
           additional_tags: tags/tags
   - name: deploy-selfservice
+    serial: true
     plan:
       - get: selfservice-ecr-registry-test
         trigger: true
@@ -2371,6 +2381,7 @@ jobs:
          image: image/image.tar
          additional_tags: tags/tags
   - name: deploy-cardid
+    serial: true
     plan:
       - get: cardid-ecr-registry-test
         trigger: true


### PR DESCRIPTION
Previously, triggering a new release (e.g `release-123`) in Concourse before a previous release (`release-122`) had finished caused the newer release to fail (as the newer job can't acquire the terraform lock). We don't want more than 1 release at once anyway, so adding `serial: true` ensures releases happen one after the other.

I've tested this on `deploy-to-test` pipeline already and it works: newer releases are shown as pending (grey) with the message `'checking max-in-flight is not reached'` until the previous release has finished, after which they continue as normal. 

Once this PR is approved and merged, I'll apply to the `deploy-to-staging` and `deploy-to-production` pipelines.