### PR TITLE
PP-8011 run smoke test in serial groups

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -408,6 +408,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-selfservice-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: selfservice-ecr-registry-prod
         trigger: true
@@ -539,6 +540,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-connector-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: connector-ecr-registry-prod
         trigger: true
@@ -660,6 +662,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-toolbox-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: toolbox-ecr-registry-prod
         trigger: true
@@ -749,6 +752,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-frontend-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: frontend-ecr-registry-prod
         trigger: true
@@ -881,6 +885,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-adminusers-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: adminusers-ecr-registry-prod
         trigger: true
@@ -1009,6 +1014,7 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
   - name: smoke-test-products-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: products-ecr-registry-prod
         trigger: true
@@ -1140,6 +1146,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-products-ui-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: products-ui-ecr-registry-prod
         trigger: true
@@ -1258,6 +1265,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-publicauth-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: publicauth-ecr-registry-prod
         trigger: true
@@ -1342,6 +1350,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-cardid-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: cardid-ecr-registry-prod
         trigger: true
@@ -1439,6 +1448,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-publicapi-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: publicapi-ecr-registry-prod
         trigger: true
@@ -1571,6 +1581,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-ledger-on-prod
+    serial_groups: [smoke-test]
     plan:
       - get: ledger-ecr-registry-prod
         trigger: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -517,6 +517,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-selfservice-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: selfservice-ecr-registry-staging
         trigger: true
@@ -660,6 +661,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-connector-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: connector-ecr-registry-staging
         trigger: true
@@ -794,6 +796,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-toolbox-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: toolbox-ecr-registry-staging
         trigger: true
@@ -909,6 +912,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-frontend-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: frontend-ecr-registry-staging
         trigger: true
@@ -1056,6 +1060,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-adminusers-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: adminusers-ecr-registry-staging
         trigger: true
@@ -1199,6 +1204,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-products-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: products-ecr-registry-staging
         trigger: true
@@ -1342,6 +1348,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-products-ui-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: products-ui-ecr-registry-staging
         trigger: true
@@ -1472,6 +1479,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-publicauth-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: publicauth-ecr-registry-staging
         trigger: true
@@ -1568,6 +1576,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-cardid-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: cardid-ecr-registry-staging
         trigger: true
@@ -1677,6 +1686,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-publicapi-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: publicapi-ecr-registry-staging
         trigger: true
@@ -1821,6 +1831,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-ledger-on-staging
+    serial_groups: [smoke-test]
     plan:
       - get: ledger-ecr-registry-staging
         trigger: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -664,6 +664,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-toolbox
+    serial_groups: [smoke-test]
     plan:
       - get: toolbox-ecr-registry-test
         trigger: true
@@ -800,6 +801,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-frontend
+    serial_groups: [smoke-test]
     plan:
       - get: frontend-ecr-registry-test
         trigger: true
@@ -1004,6 +1006,7 @@ jobs:
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
   - name: smoke-test-adminusers
+    serial_groups: [smoke-test]
     plan:
       - get: adminusers-ecr-registry-test
         trigger: true
@@ -1207,6 +1210,7 @@ jobs:
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
   - name: smoke-test-connector
+    serial_groups: [smoke-test]
     plan:
       - get: connector-ecr-registry-test
         trigger: true
@@ -1369,6 +1373,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-ledger
+    serial_groups: [smoke-test]
     plan:
       - get: ledger-ecr-registry-test
         trigger: true
@@ -1612,6 +1617,7 @@ jobs:
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
   - name: smoke-test-products
+    serial_groups: [smoke-test]
     plan:
       - get: products-ecr-registry-test
         trigger: true
@@ -1773,6 +1779,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-products-ui
+    serial_groups: [smoke-test]
     plan:
       - get: products-ui-ecr-registry-test
         trigger: true
@@ -1934,6 +1941,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-publicapi
+    serial_groups: [smoke-test]
     plan:
       - get: publicapi-ecr-registry-test
         trigger: true
@@ -2122,6 +2130,7 @@ jobs:
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
   - name: smoke-test-publicauth
+    serial_groups: [smoke-test]
     plan:
       - get: publicauth-ecr-registry-test
         trigger: true
@@ -2249,6 +2258,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-selfservice
+    serial_groups: [smoke-test]
     plan:
       - get: selfservice-ecr-registry-test
         trigger: true
@@ -2434,6 +2444,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: smoke-test-cardid
+    serial_groups: [smoke-test]
     plan:
       - get: cardid-ecr-registry-test
         trigger: true


### PR DESCRIPTION
Previously, the same smoke test jobs (Canaries) could be triggered by the release of different apps. Although we have a workaround in place to retry Canaries that are already running, this can still cause some issues (and is slow, as the workaround involves waiting 60 seconds).

Instead, we can add a `serial_groups` tag for the smoke test jobs. Any job with the tag '`smoke-test`' in its `serial_groups` list will not run if another job with the same tag is in progress (see [example in the Concourse docs](https://concourse-ci.org/jobs.html#schema.job.serial_groups)).

As per https://github.com/alphagov/pay-ci/pull/480 I've already tested this on the `deploy-to-test` pipeline: I started the smoke test job for frontend, then also triggered the smoke test job for toolbox. The toolbox smoke tests waited patiently until the frontend smoke tests had finished, then started up as usual.

Merging this PR will update the pipelines for staging and production.