### PR TITLE
BAU: Fix ECR registry var file

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1624,7 +1624,7 @@ jobs:
         passed: [deploy-products]
       - get: pay-ci
       - load_var: application_image_tag
-        file: ledger-ecr-registry-test/tag
+        file: products-ecr-registry-test/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:


### PR DESCRIPTION
Copy/paste error where the products smoke test job was trying to find the ledger ECR image. This was just on the `deploy-to-test` pipeline, the staging and production pipelines are fine.

See error message on [Concourse run #28](https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/smoke-test-products/builds/28). Tested on [Concourse run #29](https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/smoke-test-products/builds/29).