### PR TITLE
BAU: fix slack notifications on deploy-to-prod pipeline

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1589,6 +1589,18 @@ jobs:
         trigger: true
         passed: [deploy-ledger-to-prod]
       - get: pay-ci
+      - load_var: application_image_tag
+        file: ledger-ecr-registry-prod/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          APP_NAME: ledger
+          ACTION_NAME: Smoke test
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -759,7 +759,7 @@ jobs:
         passed: [deploy-frontend-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
-        file: frontend-ecr-registry-staging/tag
+        file: frontend-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -547,7 +547,7 @@ jobs:
         passed: [deploy-connector-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
-        file: connector-ecr-registry-staging/tag
+        file: connector-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -1023,7 +1023,7 @@ jobs:
         passed: [deploy-products-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
-        file: products-ecr-registry-staging/tag
+        file: products-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -1155,7 +1155,7 @@ jobs:
         passed: [deploy-products-ui-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
-        file: products-ui-ecr-registry-staging/tag
+        file: products-ui-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -1274,7 +1274,7 @@ jobs:
         passed: [deploy-publicauth-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
-        file: publicauth-ecr-registry-staging/tag
+        file: publicauth-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -1359,7 +1359,7 @@ jobs:
         passed: [deploy-cardid-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
-        file: cardid-ecr-registry-staging/tag
+        file: cardid-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1457,7 +1457,7 @@ jobs:
         passed: [deploy-publicapi-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
-        file: publicapi-ecr-registry-staging/tag
+        file: publicapi-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -891,6 +891,8 @@ jobs:
         trigger: true
         passed: [deploy-adminusers-to-prod]
       - get: pay-ci
+      - load_var: application_image_tag
+        file: adminusers-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:


### PR DESCRIPTION
Small fixes for smoke tests on the production pipeline (already applied, in order to test them):

- Use the production ECR tag instead of the staging ECR tag on smoke test jobs (all apps):
  - Example fix for Frontend: compare [error build #5](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production/jobs/smoke-test-frontend-on-prod/builds/5) with [success build #6](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production/jobs/smoke-test-frontend-on-prod/builds/6)
- Adminusers smoke tests: add in missing `application_image_tag` var
  - Compare [error build #24](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production/jobs/smoke-test-adminusers-on-prod/builds/24) with [success build #25](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production/jobs/smoke-test-adminusers-on-prod/builds/25)
- Ledger smoke tests: add in missing `application_image_tag` var and creation of Slack success/failure snippets
  - Compare [error build #26](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production/jobs/smoke-test-ledger-on-prod/builds/26) with [success build #27](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production/jobs/smoke-test-ledger-on-prod/builds/27)