### PR TITLE
PP-7918: Fix application tag variable name

### DIFF
--- a/ci/scripts/run-ecs-db-migration.js
+++ b/ci/scripts/run-ecs-db-migration.js
@@ -1,7 +1,7 @@
 const AWS = require('aws-sdk')
 const ecs = new AWS.ECS()
 
-const { CLUSTER_NAME, APP_NAME, TAG } = process.env
+const { CLUSTER_NAME, APP_NAME, APPLICATION_IMAGE_TAG } = process.env
 
 const RUN_MIGRATION_OVERRIDES = {
   containerOverrides: [
@@ -68,7 +68,7 @@ const run = async function run () {
     const currentAppImage = taskDefinitionDetails.containerDefinitions.find(container => container.name === APP_NAME).image
     const currentAppRelease = currentAppImage.split(':')[1].split('-')[0]
     console.log(`Current task definition is using release: ${currentAppRelease}`)
-    const jobAppRelease = TAG.split('-')[0]
+    const jobAppRelease = APPLICATION_IMAGE_TAG.split('-')[0]
 
     if (currentAppRelease !== jobAppRelease) {
       throw new Error(`The input release ${jobAppRelease} number does not match the


### PR DESCRIPTION
At some point the `ledger_db_migration` task changed the name of the `TAG` environment variable to `APPLICATION_IMAGE_TAG` (see https://github.com/alphagov/pay-ci/blob/master/ci/pipelines/deploy-to-test.yml#L1488).

This PR fixes the migration script which now uses the new variable name.

Tested this on the `deploy-to-test` Concourse pipeline using this branch - [the task is now passing](https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/ledger-db-migration/builds/23).