### PR TITLE
PP-7918 Ledger DB migration tasks for staging and production

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -322,6 +322,7 @@ groups:
       - deploy-ledger-to-prod
       - smoke-test-ledger-on-prod
       - ledger-pact-tag
+      - ledger-db-migration-prod
   - name: telegraf
     jobs:
       - deploy-toolbox-to-prod
@@ -1647,3 +1648,44 @@ jobs:
           PACT_TAG: production-fargate
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
+
+  - name: ledger-db-migration-prod
+    plan:
+      - get: pay-ci
+      - get: ledger-ecr-registry-prod
+        params:
+          format: oci
+        trigger: false
+        passed: [deploy-ledger-to-prod]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-prod-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: ledger-ecr-registry-prod/tag
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "production-2-fargate"
+            APP_NAME: "ledger"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -427,6 +427,7 @@ groups:
       - smoke-test-ledger-on-staging
       - ledger-pact-tag
       - push-ledger-to-production-ecr
+      - ledger-db-migration-staging
   - name: telegraf
     jobs:
       - deploy-toolbox-to-staging
@@ -1895,7 +1896,48 @@ jobs:
           PACT_TAG: staging-fargate
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
-          
+
+  - name: ledger-db-migration-staging
+    plan:
+      - get: pay-ci
+      - get: ledger-ecr-registry-staging
+        params:
+          format: oci
+        trigger: false
+        passed: [deploy-ledger-to-staging]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: ledger-ecr-registry-staging/tag
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "staging-2-fargate"
+            APP_NAME: "ledger"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js
+
   - name: push-ledger-to-production-ecr
     plan:
       - get: ledger-ecr-registry-staging


### PR DESCRIPTION
Copies the [DB migration task from the `deploy-to-test` pipeline](https://github.com/alphagov/pay-ci/blob/master/ci/pipelines/deploy-to-test.yml#L1453) into the staging and production pipelines.

We seem to use `prod` instead of `production` on Concourse config, so I've kept to that naming for now.

The DB migration tasks should be manually triggered.

I've tested the [staging config on Concourse](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-staging/jobs/ledger-db-migration-staging) and it's passing with the no-op as expected. Once this PR is merged the production config will be updated.