### PR TITLE
PP-7919 Connector DB migration tasks for staging and prod

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -281,6 +281,7 @@ groups:
       - deploy-connector-to-prod
       - smoke-test-connector-on-prod
       - connector-pact-tag
+      - connector-db-migration-prod
   - name: frontend
     jobs:
       - deploy-frontend-to-prod
@@ -605,6 +606,47 @@ jobs:
           PACT_TAG: production-fargate
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
+
+  - name: connector-db-migration-prod
+    plan:
+      - get: pay-ci
+      - get: connector-ecr-registry-prod
+        params:
+          format: oci
+        trigger: false
+        passed: [deploy-connector-to-prod]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-prod-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: connector-ecr-registry-prod/tag
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "production-2-fargate"
+            APP_NAME: "connector"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js
 
   - name: deploy-toolbox-to-prod
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -378,6 +378,7 @@ groups:
       - smoke-test-connector-on-staging
       - connector-pact-tag
       - push-connector-to-production-ecr
+      - connector-db-migration-staging
   - name: frontend
     jobs:
       - deploy-frontend-to-staging
@@ -727,6 +728,47 @@ jobs:
           PACT_TAG: staging-fargate
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
+
+  - name: connector-db-migration-staging
+    plan:
+      - get: pay-ci
+      - get: connector-ecr-registry-staging
+        params:
+          format: oci
+        trigger: false
+        passed: [deploy-connector-to-staging]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: connector-ecr-registry-staging/tag
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "staging-2-fargate"
+            APP_NAME: "connector"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js
 
   - name: push-connector-to-production-ecr
     plan:


### PR DESCRIPTION
Adds the task to run Connector DB migrations for the staging and production pipelines, exactly as per the [Ledger PR](https://github.com/alphagov/pay-ci/pull/485).

I've applied to the `deploy-to-staging` and have done a no-op run of the job.

Merging this PR will add the job to the `deploy-to-production` pipeline.