### PR TITLE
PP-8107 serial groups for deploy jobs

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -344,6 +344,7 @@ jobs:
 
   - name: deploy-selfservice-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: selfservice-ecr-registry-prod
         trigger: true
@@ -477,6 +478,7 @@ jobs:
 
   - name: deploy-connector-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: connector-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -650,6 +652,7 @@ jobs:
 
   - name: deploy-toolbox-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: toolbox-ecr-registry-prod
         trigger: true
@@ -724,6 +727,7 @@ jobs:
 
   - name: deploy-frontend-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: frontend-ecr-registry-prod
       - get: nginx-forward-proxy-ecr-registry-prod
@@ -862,6 +866,7 @@ jobs:
 
   - name: deploy-adminusers-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: adminusers-ecr-registry-prod
         trigger: true
@@ -995,6 +1000,7 @@ jobs:
 
   - name: deploy-products-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: products-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1126,6 +1132,7 @@ jobs:
 
   - name: deploy-products-ui-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: products-ui-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1258,6 +1265,7 @@ jobs:
 
   - name: deploy-publicauth-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: publicauth-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1343,6 +1351,7 @@ jobs:
 
   - name: deploy-cardid-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: cardid-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1428,6 +1437,7 @@ jobs:
 
   - name: deploy-publicapi-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: publicapi-ecr-registry-prod
       - get: nginx-proxy-ecr-registry-prod
@@ -1560,6 +1570,7 @@ jobs:
 
   - name: deploy-ledger-to-prod
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: ledger-ecr-registry-prod
         trigger: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -453,6 +453,7 @@ jobs:
         
   - name: deploy-selfservice-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: selfservice-ecr-registry-staging
         trigger: true
@@ -598,6 +599,7 @@ jobs:
 
   - name: deploy-connector-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: connector-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -784,6 +786,7 @@ jobs:
 
   - name: deploy-toolbox-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: toolbox-ecr-registry-staging
         trigger: true
@@ -884,6 +887,7 @@ jobs:
 
   - name: deploy-frontend-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: frontend-ecr-registry-staging
       - get: nginx-forward-proxy-ecr-registry-staging
@@ -1037,6 +1041,7 @@ jobs:
           
   - name: deploy-adminusers-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: adminusers-ecr-registry-staging
         trigger: true
@@ -1182,6 +1187,7 @@ jobs:
           
   - name: deploy-products-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: products-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1326,6 +1332,7 @@ jobs:
           
   - name: deploy-products-ui-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: products-ui-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1470,6 +1477,7 @@ jobs:
           
   - name: deploy-publicauth-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: publicauth-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1567,6 +1575,7 @@ jobs:
 
   - name: deploy-cardid-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: cardid-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1664,6 +1673,7 @@ jobs:
           
   - name: deploy-publicapi-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: publicapi-ecr-registry-staging
       - get: nginx-proxy-ecr-registry-staging
@@ -1808,6 +1818,7 @@ jobs:
           additional_tags: publicapi-ecr-registry-staging/tag
   - name: deploy-ledger-to-staging
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: ledger-ecr-registry-staging
         trigger: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -610,6 +610,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-toolbox
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: toolbox-ecr-registry-test
         trigger: true
@@ -726,6 +727,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-frontend
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: frontend-ecr-registry-test
         trigger: true
@@ -899,6 +901,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-adminusers
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: adminusers-ecr-registry-test
         trigger: true
@@ -1103,6 +1106,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-connector
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: connector-ecr-registry-test
         trigger: true
@@ -1306,6 +1310,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-ledger
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: ledger-ecr-registry-test
         trigger: true
@@ -1510,6 +1515,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-products
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: products-ecr-registry-test
         trigger: true
@@ -1712,6 +1718,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-products-ui
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: products-ui-ecr-registry-test
         trigger: true
@@ -1874,6 +1881,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-publicapi
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: publicapi-ecr-registry-test
         trigger: true
@@ -2036,6 +2044,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-publicauth
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: publicauth-ecr-registry-test
         trigger: true
@@ -2191,6 +2200,7 @@ jobs:
           additional_tags: tags/tags
   - name: deploy-selfservice
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: selfservice-ecr-registry-test
         trigger: true
@@ -2390,6 +2400,7 @@ jobs:
          additional_tags: tags/tags
   - name: deploy-cardid
     serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: cardid-ecr-registry-test
         trigger: true


### PR DESCRIPTION
While testing a new telegraf image, the deploy jobs for the test environment all started at once, and the Concourse container count was exceeded.

Let's put the application deploy jobs into a `serial_group` to force each deploy to happen sequentially. Any deploy job with the `deploy-application` tag will not begin until the other job in progress has finished.

Already tested this on the `deploy-to-test` pipeline in Concourse.

Paired with @danworth 