### PR TITLE
PP-7967 Use jdk-11 maven image

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1068,7 +1068,7 @@ jobs:
           type: registry-image
           source:
             repository: maven
-            tag: 3.8.1
+            tag: 3.8.1-adoptopenjdk-11
         caches:
           - path: src/.m2
         inputs:

--- a/ci/tasks/java-package.yml
+++ b/ci/tasks/java-package.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: maven
-    tag: 3.8.1
+    tag: 3.8.1-adoptopenjdk-11
 caches:
   - path: src/.m2
 inputs:

--- a/ci/tasks/java-tests.yml
+++ b/ci/tasks/java-tests.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: maven
-    tag: 3.8.1
+    tag: 3.8.1-adoptopenjdk-11
 caches:
   - path: src/.m2
 inputs:


### PR DESCRIPTION
## WHAT 
- maven:3.8.1 image currently used is based on java version [`16.0.1`](https://hub.docker.com/layers/maven/library/maven/3.8.1/images/sha256-1ffe2b51b6762b94590a1149cf0c35a169203d467dc34891be1439ad3b54940e?context=explore) which breaks few tests (connector) and we currently use java version 11 everywhere. Use maven image using adoptopenjdk-11 instead.