### PR TITLE
PP-7922 PublicAuth DB migration job

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -272,7 +272,7 @@ groups:
       - deploy-adminusers-to-prod
       - smoke-test-adminusers-on-prod
       - adminusers-pact-tag
-      - adminusers-db-migration-production
+      - adminusers-db-migration-prod
   - name: cardid
     jobs:
       - deploy-cardid-to-prod
@@ -935,7 +935,7 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
-  - name: adminusers-db-migration-production
+  - name: adminusers-db-migration-prod
     plan:
       - get: pay-ci
       - get: adminusers-ecr-registry-prod

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -314,6 +314,7 @@ groups:
     jobs:
       - deploy-publicauth-to-prod
       - smoke-test-publicauth-on-prod
+      - publicauth-db-migration-prod
   - name: selfservice
     jobs:
       - deploy-selfservice-to-prod
@@ -1400,6 +1401,47 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: publicauth-db-migration-prod
+    plan:
+      - get: pay-ci
+      - get: publicauth-ecr-registry-prod
+        params:
+          format: oci
+        trigger: false
+        passed: [deploy-publicauth-to-prod]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-prod-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: publicauth-ecr-registry-prod/tag
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "production-2-fargate"
+            APP_NAME: "publicauth"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js
 
   - name: smoke-test-publicauth-on-prod
     serial_groups: [smoke-test]

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -417,6 +417,7 @@ groups:
       - deploy-publicauth-to-staging
       - smoke-test-publicauth-on-staging
       - push-publicauth-to-production-ecr
+      - publicauth-db-migration-staging
   - name: selfservice
     jobs:
       - deploy-selfservice-to-staging
@@ -1644,6 +1645,47 @@ jobs:
           <<: *smoke-test-run-all-on-staging
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
+
+  - name: publicauth-db-migration-staging
+    plan:
+      - get: pay-ci
+      - get: publicauth-ecr-registry-staging
+        params:
+          format: oci
+        trigger: false
+        passed: [deploy-publicauth-to-staging]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: publicauth-ecr-registry-staging/tag
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-aws-sdk-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "staging-2-fargate"
+            APP_NAME: "publicauth"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js
 
   - name: push-publicauth-to-production-ecr
     plan:


### PR DESCRIPTION
Moves the PublicAuth DB migration job to Concourse (our final one of these 🎉 ). Tested the pipeline config on staging, merging this PR will apply the config on production pipeline.

I've also standardised the naming of the Adminusers DB migration job so it's consistent with the others.

This story also covers adding a Slack notification to DB migration jobs - I'll handle that in a separate PR.