### PR TITLE
PP-7922 Slack notifications for DB migration jobs

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -65,6 +65,13 @@ definitions:
         text: "((.:failure_snippet)) \n
               - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
+  put_db_migration_slack_notification: &put_db_migration_slack_notification
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-announce'
+      text: ":postgres: FARGATE starting $BUILD_JOB_NAME on production-2\n
+            - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
   snippet_params_all_versions: &snippet_params_all_versions
     ENV: production-2
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
@@ -630,6 +637,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: connector-ecr-registry-prod/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -953,6 +961,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: adminusers-ecr-registry-prod/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1192,6 +1201,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: products-ecr-registry-prod/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1420,6 +1430,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: publicauth-ecr-registry-prod/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1846,6 +1857,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: ledger-ecr-registry-prod/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -74,7 +74,14 @@ definitions:
         channel: '#govuk-pay-announce'
         text: "((.:failure_snippet)) \n
               - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-  
+
+  put_db_migration_slack_notification: &put_db_migration_slack_notification
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-announce'
+      text: ":postgres: FARGATE starting $BUILD_JOB_NAME on staging-2\n
+            - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
   snippet_params_all_versions: &snippet_params_all_versions
     ENV: staging-2
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
@@ -752,6 +759,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: connector-ecr-registry-staging/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1128,6 +1136,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1392,6 +1401,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: products-ecr-registry-staging/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1664,6 +1674,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: publicauth-ecr-registry-staging/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -2094,6 +2105,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: ledger-ecr-registry-staging/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -36,7 +36,13 @@ put_failure_slack_notification: &put_failure_slack_notification
       channel: '#govuk-pay-announce'
       text: "((.:failure_snippet)) \n
             - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-  
+
+put_db_migration_slack_notification: &put_db_migration_slack_notification
+  put: slack-notification
+  params:
+    channel: '#govuk-pay-announce'
+    text: ":postgres: FARGATE starting $BUILD_JOB_NAME on test-12\n
+          - <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
 wait_for_deploy_params: &wait_for_deploy_params
   <<: *aws_assumed_role_creds
@@ -984,6 +990,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1006,6 +1013,7 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
+
   - name: smoke-test-adminusers
     serial_groups: [smoke-test]
     plan:
@@ -1189,6 +1197,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: connector-ecr-registry-test/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1471,6 +1480,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: ledger-ecr-registry-test/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -1598,6 +1608,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: products-ecr-registry-test/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux
@@ -2114,6 +2125,7 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: publicauth-ecr-registry-test/tag
+      - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
           platform: linux


### PR DESCRIPTION
Pay developers have kindly requested that we add automatic Slack notifications when a DB migration job is triggered, to save them having to post in Slack manually.

- Concourse can't determine the result of a DB migration, so we don't need success/failure snippets like we have for the release jobs. This means we can hardcode a single snippet and don't need to use the `create-notification-snippet.yml` bash script.
- I've set test, staging and production to all put notifications in `#govuk-pay-announce` (as opposed to `#govuk-pay-activity`) as DB migrations are important to know about but rare enough to not cause too much noise. 
- However [I did test this change on the new publicauth DB migration job](https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/publicauth-db-migration/builds/2), temporarily going to `#govuk-pay-activity` (to avoid panic in case it sent a bunch of mangled text) (which it didn't 😸 ). 