### PR TITLE
PP-8162: Deploy carbon-relay to test env

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -286,6 +286,13 @@ resources:
       repository: govukpay/selfservice
       variant: release
       <<: *aws_test_config
+  - name: carbon-relay-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/carbon-relay
+      variant: carbon-relay-release
+      <<: *aws_test_config
   - name: nginx-proxy-ecr-registry-test
     type: dev-registry-image
     icon: docker
@@ -373,12 +380,6 @@ resources:
     source:
       repository: govukpay/cardid
       <<: *aws_staging_config
-  - name: telegraf-ecr-registry-staging
-    type: dev-registry-image
-    icon: docker
-    source:
-      repository: govukpay/telegraf
-      <<: *aws_staging_config
   - name: nginx-proxy-ecr-registry-staging
     type: dev-registry-image
     icon: docker
@@ -391,6 +392,12 @@ resources:
     source:
       repository: govukpay/nginx-forward-proxy
       variant: release
+      <<: *aws_staging_config
+  - name: telegraf-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/telegraf
       <<: *aws_staging_config
   - name: slack-notification
     type: slack-notification
@@ -420,6 +427,7 @@ resource_types:
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest
+
 groups:
   - name: adminusers
     jobs:
@@ -500,6 +508,10 @@ groups:
       - deploy-toolbox
       - smoke-test-toolbox
       - push-toolbox-to-staging-ecr
+  - name: carbon-relay
+    jobs:
+      - deploy-carbon-relay
+      # - push-carbon-relay-to-staging-ecr
   - name: nginx-proxy
     jobs:
       - push-nginx-proxy-to-test-ecr
@@ -614,6 +626,40 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: tags/tags
+  
+  - name: deploy-carbon-relay
+    plan:
+      - get: carbon-relay-ecr-registry-test
+        trigger: true
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: carbon_relay_image_tag
+        file: carbon-relay-ecr-registry-test/tag
+      #TODO - task: create notification snippets  
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+     # TODO - task: check release version for carbon-relay
+      - task: deploy-to-test
+        file: pay-ci/ci/tasks/deploy-carbon-relay.yml
+        params:
+          <<: *aws_assumed_role_creds
+          CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
+          ACCOUNT: test
+          ENVIRONMENT: test-12
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: carbon-relay
+          CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
+          <<: *aws_assumed_role_creds
+          ENVIRONMENT: test-12   
+
   - name: deploy-toolbox
     serial: true
     serial_groups: [deploy-application]
@@ -1046,7 +1092,6 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
-
   - name: adminusers-pact-tag
     plan:
       - get: adminusers-ecr-registry-test
@@ -1251,7 +1296,6 @@ jobs:
           <<: *smoke-test-run-all-on-test
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
-
 
   - name: connector-pact-tag
     plan:

--- a/ci/scripts/wait-for-deploy.js
+++ b/ci/scripts/wait-for-deploy.js
@@ -7,6 +7,7 @@ const CHECK_INTERVAL = 5000
 const {
   APP_NAME: appName,
   APPLICATION_IMAGE_TAG: appVersion,
+  CARBON_RELAY_IMAGE_TAG: carbonRelayVersion,
   NGINX_IMAGE_TAG: nginxProxyVersion,
   NGINX_FORWARD_PROXY_IMAGE_TAG: nginxForwardProxyVersion,
   TELEGRAF_IMAGE_TAG: telegrafVersion,
@@ -41,10 +42,19 @@ async function run () {
       const { taskDefinition, rolloutState, rolloutStateReason } = uncompletedDeployments[0]
       const deploymentDetails = {
         taskDefinition,
-        deploymentStatus: rolloutState,
-        appVersion,
-        nginxProxyVersion,
-        telegrafVersion
+        deploymentStatus: rolloutState
+      }
+      if (appVersion) {
+        deploymentDetails.appVersion = appVersion
+      }
+      if (nginxProxyVersion) {
+        deploymentDetails.nginxProxyVersion = nginxProxyVersion
+      }
+      if (telegrafVersion) {
+        deploymentDetails.telegrafVersion = telegrafVersion
+      }
+      if (carbonRelayVersion) {
+        deploymentDetails.carbonRelayVersion = carbonRelayVersion
       }
       if (nginxForwardProxyVersion) {
         deploymentDetails.nginxForwardProxyVersion = nginxForwardProxyVersion

--- a/ci/tasks/deploy-carbon-relay.yml
+++ b/ci/tasks/deploy-carbon-relay.yml
@@ -1,0 +1,29 @@
+---
+platform: linux
+inputs:
+  - name: pay-infra
+image_resource:
+  type: registry-image
+  source:
+    repository: hashicorp/terraform
+    tag: 0.13.4
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:
+  AWS_REGION: eu-west-1
+  CARBON_RELAY_IMAGE_TAG:
+  ACCOUNT:
+  ENVIRONMENT:
+run:
+  path: /bin/sh
+  args:
+    - -ec
+    - |
+      echo ${CARBON_RELAY_IMAGE_TAG}
+      cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/carbon_relay
+      terraform init
+      terraform apply \
+        -var carbon_relay_image_tag=${CARBON_RELAY_IMAGE_TAG} \
+        -var stunnel_image_tag=1-stunnel-release \
+        -auto-approve


### PR DESCRIPTION
Deploy carbon-relay to the test environment. A notable change in this commit
would be for the the `ci/scripts/wait-for-deploy.js` file which was amended to
make it work with carbon-relay. As carbon-relay has no `APPLICATION_IMAGE_TAG`,
`NGINX_IMAGE_TAG`, or `TELEGRAF_IMAGE_TAG` these parameters are now made
optional.

This commit does not include the creation of notification snippets, the
checking that we aren't deploying an older version or pushing the image to
staging ECR. These will be done in a future PR.

Example of a successful deploy: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-carbon-relay/builds/14.