### PR TITLE
PP-8162: Create failure notification snippet

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -635,7 +635,28 @@ jobs:
       - get: pay-ci
       - load_var: carbon_relay_image_tag
         file: carbon-relay-ecr-registry-test/tag
-      #TODO - task: create notification snippets  
+      - task: create-failure-notification-snippet
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: alpine
+          params:
+            CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
+            ENV: test-12
+          outputs:
+            - name: snippet  
+          run:
+            path: sh
+            args:
+              - -c
+              - |
+                cat <<EOT >> snippet/failure
+                :red_circle: FARGATE Deployment of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${CARBON_RELAY_IMAGE_TAG}|carbon-relay v${CARBON_RELAY_IMAGE_TAG}> on ${ENV} failed. Version details:
+                EOT
+      - load_var: failure_snippet
+        file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -658,8 +679,9 @@ jobs:
           APP_NAME: carbon-relay
           CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
           <<: *aws_assumed_role_creds
-          ENVIRONMENT: test-12   
-
+          ENVIRONMENT: test-12
+    <<: *put_failure_slack_notification
+    
   - name: deploy-toolbox
     serial: true
     serial_groups: [deploy-application]


### PR DESCRIPTION
The team are in agreement that just like for the
nginx/nginx-forward-proxy/telegraf deploys, we only need failure notifications
for carbon-relay deploys.

Contrary to the PR name (with "check-release-version") I've decided to go for a small commit here and do that functionality in another commit.

Example of a successful build: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-carbon-relay/builds/21.

Example notification: https://gds.slack.com/archives/CNZFSNM0S/p1624875712015800