### PR TITLE
PP-8162: Don't allow a deploy of an older carbon-relay version

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -665,7 +665,14 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
-     # TODO - task: check release version for carbon-relay
+      - task: check-release-versions
+        file: pay-ci/ci/tasks/check-release-versions.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          CLUSTER_NAME: "test-12-fargate"
+          APP_NAME: carbon-relay
+          CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
       - task: deploy-to-test
         file: pay-ci/ci/tasks/deploy-carbon-relay.yml
         params:

--- a/ci/scripts/check-release-versions.js
+++ b/ci/scripts/check-release-versions.js
@@ -42,7 +42,8 @@ async function run () {
     APPLICATION_IMAGE_TAG,
     TELEGRAF_IMAGE_TAG,
     NGINX_IMAGE_TAG,
-    NGINX_FORWARD_PROXY_IMAGE_TAG
+    NGINX_FORWARD_PROXY_IMAGE_TAG,
+    CARBON_RELAY_IMAGE_TAG
   } = process.env
 
   try {
@@ -56,9 +57,22 @@ async function run () {
       throw new Error('failed to get task definition details')
     }
 
-    checkReleaseVersion(APP_NAME, APPLICATION_IMAGE_TAG, containerDefinitions)
-    checkReleaseVersion('telegraf', TELEGRAF_IMAGE_TAG, containerDefinitions)
-    checkReleaseVersion('nginx', NGINX_IMAGE_TAG, containerDefinitions)
+    if (CARBON_RELAY_IMAGE_TAG) {
+      checkReleaseVersion('carbon-relay', CARBON_RELAY_IMAGE_TAG, containerDefinitions)
+    }
+
+    if (APPLICATION_IMAGE_TAG) {
+      checkReleaseVersion(APP_NAME, APPLICATION_IMAGE_TAG, containerDefinitions)
+    }
+    
+    if (TELEGRAF_IMAGE_TAG) {
+      checkReleaseVersion('telegraf', TELEGRAF_IMAGE_TAG, containerDefinitions)
+    }
+    
+    if (NGINX_IMAGE_TAG) {
+      checkReleaseVersion('nginx', NGINX_IMAGE_TAG, containerDefinitions)
+    }
+    
     if (NGINX_FORWARD_PROXY_IMAGE_TAG) {
       checkReleaseVersion('nginx-forward-proxy', NGINX_FORWARD_PROXY_IMAGE_TAG, containerDefinitions)
     }

--- a/ci/tasks/check-release-versions.yml
+++ b/ci/tasks/check-release-versions.yml
@@ -17,6 +17,7 @@ params:
   TELEGRAF_IMAGE_TAG:
   NGINX_IMAGE_TAG:
   NGINX_FORWARD_PROXY_IMAGE_TAG:
+  CARBON_RELAY_IMAGE_TAG:
 run:
   path: node
   args:


### PR DESCRIPTION
Example build to show this is working: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-carbon-relay/builds/26

Example build to show the deploy hasn't been broken: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-carbon-relay/builds/26