### PR TITLE
PP-8162: Create start/success notifications for deploys

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -34,6 +34,7 @@ definitions:
     aws_role_arn: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
     aws_ecr_registry_id: "((pay_aws_prod_account_id))"
     aws_region: eu-west-1
+    
   put_start_slack_notification: &put_start_slack_notification
     put: slack-notification
     params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -486,28 +486,15 @@ jobs:
       - get: pay-ci
       - load_var: carbon_relay_image_tag
         file: carbon-relay-ecr-registry-staging/tag
-      - task: create-failure-notification-snippet
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: alpine
-          params:
-            CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
-            ENV: staging-2
-          outputs:
-            - name: snippet  
-          run:
-            path: sh
-            args:
-              - -c
-              - |
-                cat <<EOT >> snippet/failure
-                :red_circle: FARGATE Deployment of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${CARBON_RELAY_IMAGE_TAG}|carbon-relay v${CARBON_RELAY_IMAGE_TAG}> on ${ENV} failed. Version details:
-                EOT
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-carbon-relay-notification-snippets.yml
+        params:
+          CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
+          ENV: test-12
       - load_var: failure_snippet
         file: snippet/failure
+      - load_var: success_snippet
+        file: snippet/success    
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -539,6 +526,7 @@ jobs:
           CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
           <<: *aws_assumed_role_creds
           ENVIRONMENT: staging-2
+    <<: *put_success_slack_notification_p1      
     <<: *put_failure_slack_notification
 
   - name: push-carbon-relay-to-production-ecr

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -490,11 +490,14 @@ jobs:
         file: pay-ci/ci/tasks/create-carbon-relay-notification-snippets.yml
         params:
           CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
-          ENV: test-12
+          ENV: staging-2
       - load_var: failure_snippet
         file: snippet/failure
       - load_var: success_snippet
-        file: snippet/success    
+        file: snippet/success
+      - load_var: start_snippet
+        file: snippet/start    
+      - <<: *put_start_slack_notification  
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -641,28 +641,15 @@ jobs:
       - get: pay-ci
       - load_var: carbon_relay_image_tag
         file: carbon-relay-ecr-registry-test/tag
-      - task: create-failure-notification-snippet
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: alpine
-          params:
-            CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
-            ENV: test-12
-          outputs:
-            - name: snippet  
-          run:
-            path: sh
-            args:
-              - -c
-              - |
-                cat <<EOT >> snippet/failure
-                :red_circle: FARGATE Deployment of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${CARBON_RELAY_IMAGE_TAG}|carbon-relay v${CARBON_RELAY_IMAGE_TAG}> on ${ENV} failed. Version details:
-                EOT
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-carbon-relay-notification-snippets.yml
+        params:
+          CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
+          ENV: test-12
       - load_var: failure_snippet
         file: snippet/failure
+      - load_var: success_snippet
+        file: snippet/success  
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -694,6 +681,7 @@ jobs:
           CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
           <<: *aws_assumed_role_creds
           ENVIRONMENT: test-12
+    <<: *put_success_slack_notification      
     <<: *put_failure_slack_notification
 
   - name: push-carbon-relay-to-staging-ecr

--- a/ci/tasks/create-carbon-relay-notification-snippets.yml
+++ b/ci/tasks/create-carbon-relay-notification-snippets.yml
@@ -14,6 +14,10 @@ run:
   args:
     - -c
     - |
+      cat <<EOT >> snippet/start
+      :rocket: FARGATE Deployment of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${CARBON_RELAY_IMAGE_TAG}|carbon-relay v${CARBON_RELAY_IMAGE_TAG}> on ${ENV} is beginning
+      EOT
+
       cat <<EOT >> snippet/success
       :green-circle: FARGATE Deployment of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${CARBON_RELAY_IMAGE_TAG}|carbon-relay v${CARBON_RELAY_IMAGE_TAG}> on ${ENV} was successful :tada:
       EOT

--- a/ci/tasks/create-carbon-relay-notification-snippets.yml
+++ b/ci/tasks/create-carbon-relay-notification-snippets.yml
@@ -1,0 +1,23 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+params:
+  CARBON_RELAY_IMAGE_TAG:
+  ENV:
+outputs:
+  - name: snippet
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      cat <<EOT >> snippet/success
+      :green-circle: FARGATE Deployment of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${CARBON_RELAY_IMAGE_TAG}|carbon-relay v${CARBON_RELAY_IMAGE_TAG}> on ${ENV} was successful :tada:
+      EOT
+
+      cat <<EOT >> snippet/failure
+      :red_circle: FARGATE Deployment of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${CARBON_RELAY_IMAGE_TAG}|carbon-relay v${CARBON_RELAY_IMAGE_TAG}> on ${ENV} failed. Version details:
+      EOT


### PR DESCRIPTION
[Success notification](https://gds.slack.com/archives/CEBPUR2JE/p1624962960017200) for deploy of carbon-relay to test.

[Success notification](https://gds.slack.com/archives/CAEN2AVLP/p1624963353004100) for deploy of carbon-relay to staging.

There are no start notifications for deploys to test.

[Start notification](https://gds.slack.com/archives/CAEN2AVLP/p1624963916004300) for deploy of carbon-relay to staging.