### PR TITLE
PP-8162: Deploy carbon-relay on detection of new stunnel image

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -166,6 +166,13 @@ resources:
       repository: govukpay/carbon-relay
       variant: carbon-relay-release
       <<: *aws_prod_config    
+  - name: stunnel-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/stunnel
+      variant: stunnel-release
+      <<: *aws_prod_config    
   - name: toolbox-ecr-registry-prod
     type: registry-image-resource-1-1-0
     icon: docker
@@ -676,10 +683,14 @@ jobs:
     plan:
       - get: carbon-relay-ecr-registry-prod
         trigger: true
+      - get: stunnel-ecr-registry-prod
+        trigger: true  
       - get: pay-infra
       - get: pay-ci
       - load_var: carbon_relay_image_tag
         file: carbon-relay-ecr-registry-prod/tag
+      - load_var: stunnel_image_tag
+        file: stunnel-ecr-registry-prod/tag  
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-carbon-relay-notification-snippets.yml
         params:
@@ -713,7 +724,7 @@ jobs:
         params:
           <<: *aws_assumed_role_creds
           CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
-          STUNNEL_IMAGE_TAG: 0-stunnel
+          STUNNEL_IMAGE_TAG: ((.:stunnel_image_tag))
           ACCOUNT: production
           ENVIRONMENT: production-2
       - task: wait-for-deploy

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -181,6 +181,19 @@ resources:
     source:
       repository: govukpay/carbon-relay
       <<: *aws_production_config
+  - name: stunnel-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/stunnel
+      variant: stunnel-release
+      <<: *aws_staging_config
+  - name: stunnel-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/stunnel
+      <<: *aws_production_config
   - name: toolbox-ecr-registry-staging
     type: registry-image-resource-1-1-0
     icon: docker
@@ -453,6 +466,7 @@ groups:
     jobs:
       - deploy-carbon-relay-to-staging
       - push-carbon-relay-to-production-ecr
+      - push-stunnel-to-production-ecr
   - name: telegraf
     jobs:
       - deploy-toolbox-to-staging
@@ -482,10 +496,14 @@ jobs:
     plan:
       - get: carbon-relay-ecr-registry-staging
         trigger: true
+      - get: stunnel-ecr-registry-staging
+        trigger: true  
       - get: pay-infra
       - get: pay-ci
       - load_var: carbon_relay_image_tag
         file: carbon-relay-ecr-registry-staging/tag
+      - load_var: stunnel_image_tag
+        file: stunnel-ecr-registry-staging/tag  
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-carbon-relay-notification-snippets.yml
         params:
@@ -519,7 +537,7 @@ jobs:
         params:
           <<: *aws_assumed_role_creds
           CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
-          STUNNEL_IMAGE_TAG: test
+          STUNNEL_IMAGE_TAG: ((.:stunnel_image_tag))
           ACCOUNT: staging
           ENVIRONMENT: staging-2
       - task: wait-for-deploy
@@ -543,6 +561,18 @@ jobs:
         params:
           image: carbon-relay-ecr-registry-staging/image.tar
           additional_tags: carbon-relay-ecr-registry-staging/tag
+
+  - name: push-stunnel-to-production-ecr
+    plan:
+      - get: stunnel-ecr-registry-staging
+        passed: [deploy-carbon-relay-to-staging]
+        params:
+          format: oci
+        trigger: true
+      - put: stunnel-ecr-registry-prod
+        params:
+          image: stunnel-ecr-registry-staging/image.tar
+          additional_tags: stunnel-ecr-registry-staging/tag
 
   - name: deploy-selfservice-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -293,6 +293,13 @@ resources:
       repository: govukpay/carbon-relay
       variant: carbon-relay-release
       <<: *aws_test_config
+  - name: stunnel-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/stunnel
+      variant: stunnel-release
+      <<: *aws_test_config
   - name: nginx-proxy-ecr-registry-test
     type: dev-registry-image
     icon: docker
@@ -391,6 +398,12 @@ resources:
     icon: docker
     source:
       repository: govukpay/carbon-relay
+      <<: *aws_staging_config
+  - name: stunnel-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/stunnel
       <<: *aws_staging_config
   - name: nginx-forward-proxy-ecr-registry-staging
     type: dev-registry-image
@@ -518,6 +531,7 @@ groups:
     jobs:
       - deploy-carbon-relay
       - push-carbon-relay-to-staging-ecr
+      - push-stunnel-to-staging-ecr
   - name: nginx-proxy
     jobs:
       - push-nginx-proxy-to-test-ecr
@@ -637,10 +651,14 @@ jobs:
     plan:
       - get: carbon-relay-ecr-registry-test
         trigger: true
+      - get: stunnel-ecr-registry-test
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: carbon_relay_image_tag
         file: carbon-relay-ecr-registry-test/tag
+      - load_var: stunnel_image_tag
+        file: stunnel-ecr-registry-test/tag  
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-carbon-relay-notification-snippets.yml
         params:
@@ -671,7 +689,7 @@ jobs:
         params:
           <<: *aws_assumed_role_creds
           CARBON_RELAY_IMAGE_TAG: ((.:carbon_relay_image_tag))
-          STUNNEL_IMAGE_TAG: 1-stunnel-release
+          STUNNEL_IMAGE_TAG: ((.:stunnel_image_tag))
           ACCOUNT: test
           ENVIRONMENT: test-12
       - task: wait-for-deploy
@@ -695,6 +713,18 @@ jobs:
         params:
           image: carbon-relay-ecr-registry-test/image.tar
           additional_tags: carbon-relay-ecr-registry-test/tag
+
+  - name: push-stunnel-to-staging-ecr
+    plan:
+      - get: stunnel-ecr-registry-test
+        passed: [deploy-carbon-relay]
+        params:
+          format: oci
+        trigger: true
+      - put: stunnel-ecr-registry-staging
+        params:
+          image: stunnel-ecr-registry-test/image.tar
+          additional_tags: stunnel-ecr-registry-test/tag
 
   - name: deploy-toolbox
     serial: true


### PR DESCRIPTION
Carbon-relay is now deployed when a new stunnel image is detected. 
deploy-carbon-relay job on test: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test?group=carbon-relay
deploy-carbon-relay job on staging: https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-staging?group=carbon-relay
deploy-carbon-relay job on prod: https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production?group=carbon-relay

The deploy-carbon-relay job on test and staging push new images of stunnel to the staging ECR and prod ECR respectively. The 1-stunnel-release image, pushed from the test ECR can be seen in those ECRs.