### PR TITLE
PP-8162: Add deploy carbon-relay jobs to serial groups

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -680,6 +680,8 @@ jobs:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
 
   - name: deploy-carbon-relay-to-prod
+    serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: carbon-relay-ecr-registry-prod
         trigger: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -493,6 +493,8 @@ jobs:
         file: deploy-to-staging-pipeline-definition/ci/pipelines/deploy-to-staging.yml
 
   - name: deploy-carbon-relay-to-staging
+    serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: carbon-relay-ecr-registry-staging
         trigger: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -648,6 +648,8 @@ jobs:
           additional_tags: tags/tags
   
   - name: deploy-carbon-relay
+    serial: true
+    serial_groups: [deploy-application]
     plan:
       - get: carbon-relay-ecr-registry-test
         trigger: true


### PR DESCRIPTION
Running only one deploy job at any point in time will help concourse to not
fall over.