### PR TITLE
PP-8162: Deployment to prod should be a manual process

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -684,9 +684,7 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: carbon-relay-ecr-registry-prod
-        trigger: true
       - get: stunnel-ecr-registry-prod
-        trigger: true  
       - get: pay-infra
       - get: pay-ci
       - load_var: carbon_relay_image_tag


### PR DESCRIPTION
At the moment we are of the opinion that carbon-relay shouldn’t be continuously
deployed into staging/production because we don’t have smoke tests that cover
whether or not app metrics are being sent. That said, we don’t send app metrics
from test-12 so it has to go into at least staging before one could make an
assessment. Therefore we are leaving `trigger: true` on staging, whilst
deployment to prod will have to be manually triggered.