### PR TITLE
PP-8105 Add Notifications Docker to ECR Job

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -199,6 +199,13 @@ resources:
       uri: https://github.com/alphagov/pay-nginx-proxy
       branch: master
       tag_regex: "alpha_release-(.*)"
+  - name: notifications-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-notifications
+      branch: master
+      tag_regex: "alpha_release-(.*)"
   - name: pay-infra
     type: git
     icon: github
@@ -319,6 +326,13 @@ resources:
     icon: docker
     source:
       repository: govukpay/telegraf
+      variant: release
+      <<: *aws_test_config
+  - name: notifications-ecr-registry-test
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/notifications
       variant: release
       <<: *aws_test_config
   - name: toolbox-ecr-registry-staging
@@ -549,6 +563,9 @@ groups:
       - build-and-push-telegraf-to-test-ecr
       - deploy-toolbox
       - push-telegraf-to-staging-ecr
+  - name: notifications
+    jobs:
+      - push-notifications-to-test-ecr
   - name: update-deploy-to-test-pipeline
     jobs:
       - update-deploy-to-test-pipeline
@@ -2743,3 +2760,23 @@ jobs:
         params:
           image: telegraf-ecr-registry-test/image.tar
           additional_tags: telegraf-ecr-registry-test/tag
+
+  - name: push-notifications-to-test-ecr
+    plan:
+      - get: pay-ci
+      - get: notifications-git-release
+        trigger: true
+      # Temporarily fetch image from Dockerhub until Concourse can build its own
+      - <<: *pull-image-from-dockerhub
+        params:
+          DOCKER_REPOSITORY: govukpay/notifications
+          APP_GIT_DIR: notifications-git-release
+          <<: *docker_credentials
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: notifications-git-release
+      - put: notifications-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: tags/tags

--- a/ci/tasks/pull-image-from-dockerhub.yml
+++ b/ci/tasks/pull-image-from-dockerhub.yml
@@ -33,6 +33,8 @@ inputs:
     optional: true
   - name: nginx-proxy-git-release
     optional: true
+  - name: notifications-git-release
+    optional: true
 outputs:
   - name: image
   - name: docker_tags


### PR DESCRIPTION
Notifications is being built by Jenkins CI which pushes it into
Dockerhub as per the other apps. This Job triggers on releases in
pay-notifications github repo, pulls the image from Dockerhub and pushes
into ECR. This is the same pattern we have for the other apps built by
Jenkins CI until we move the build somewhere else.

## WHAT

This has been applied and its works:
https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/push-notifications-to-test-ecr/builds/7

```
gds5062-2:pay-ci danworth$ aws-vault exec test -- aws ecr list-images --repository-name govukpay/notifications | jq '.imageIds[] | select(.imageTag == "45-release")'
{
  "imageDigest": "sha256:61547264b871bbc787dd3ac3e4db964b5f485ea8e829d6b8615b0a496ffbfc9b",
  "imageTag": "45-release"
}
```