### PR TITLE
PP-8105 Add Deploy Notifications Job

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -432,6 +432,12 @@ resources:
     source:
       repository: govukpay/telegraf
       <<: *aws_staging_config
+  - name: notifications-ecr-registry-staging
+    type: dev-registry-image
+    icon: docker
+    source:
+      repository: govukpay/notifications
+      <<: *aws_staging_config
   - name: slack-notification
     type: slack-notification
     source:
@@ -566,6 +572,9 @@ groups:
   - name: notifications
     jobs:
       - push-notifications-to-test-ecr
+      - deploy-notifications
+      - smoke-test-notifications
+      - push-notifications-to-staging-ecr
   - name: update-deploy-to-test-pipeline
     jobs:
       - update-deploy-to-test-pipeline
@@ -2780,3 +2789,125 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: tags/tags
+
+  - name: deploy-notifications
+    serial: true
+    serial_groups: [deploy-application]
+    plan:
+      - get: notifications-ecr-registry-test
+        trigger: true
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-test/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          ACTION_NAME: Deployment
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENV: test-12
+      - load_var: failure_snippet
+        file: snippet/failure
+      - load_var: success_snippet
+        file: snippet/success 
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: check-release-versions
+        file: pay-ci/ci/tasks/check-release-versions.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          CLUSTER_NAME: "test-12-fargate"
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - task: deploy-to-test
+        params:
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ACCOUNT: test
+          ENVIRONMENT: test-12
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          AWS_REGION: eu-west-1
+        config:
+          platform: linux
+          inputs:
+            - name: pay-infra
+          image_resource:
+            type: registry-image
+            source:
+              repository: hashicorp/terraform
+              tag: 0.13.4
+          run:
+            path: /bin/sh
+            args:
+              - -ec
+              - |
+                cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/notifications
+                terraform init
+                terraform apply \
+                  -var notifications_image_tag=${APPLICATION_IMAGE_TAG} \
+                  -auto-approve
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENVIRONMENT: test-12
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    <<: *put_success_slack_notification 
+    <<: *put_failure_slack_notification
+
+  - name: smoke-test-notifications
+    serial_groups: [smoke-test]
+    plan:
+      - get: notifications-ecr-registry-test
+        trigger: true
+        passed: [deploy-notifications]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-test/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          ACTION_NAME: Smoke test
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENV: test-12
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-test
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
+  - name: push-notifications-to-staging-ecr
+    plan:
+      - get: notifications-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-notifications]
+      - put: notifications-ecr-registry-staging
+        params:
+          image: notifications-ecr-registry-test/image.tar
+          additional_tags: notifications-ecr-registry-test/tag


### PR DESCRIPTION
Adds a job to deploy notifications app, run smoke tests and then push
the image into staging ecr. This follows the existing pattern with a
slight change in the deploy task. Since the notifications app consists
of a single container it doesn't lend itself to reusing existing deploy
yaml files so instead it has been in-lined. Since this is specific to
the notifications app and its a simple bit of bash there it isn't worth
putting this into a yaml file for re-use at this time.

## WHAT
This has been applied to `deploy-to-test` pipeline to confirm it works...and it does https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test?group=notifications

```
gds5062-2:pay-ci danworth$ aws-vault exec staging -- aws ecr list-images --repository-name govukpay/notifications | jq '.imageIds[] | select(.imageTag == "45-release")'
{
  "imageDigest": "sha256:61547264b871bbc787dd3ac3e4db964b5f485ea8e829d6b8615b0a496ffbfc9b",
  "imageTag": "45-release"
}
```

### Notes
I'm not entirely sure if the smoke tests validate that the notifications app is working (e.g. whether they rely on the processing of a webhook for the payment). Since it was simple to add them whilst I was creating the pipeline between deploying and pushing to staging ecr I opted to add them. I'll confirm whether they're testing notifications as part of this story and if not I'll remove them. There is a *scheduled* [notifications smoke test where CI/Deploy](https://build.ci.pymnt.uk/view/HUD/job/run-scheduled-notifications-smoke-test-test-card/) curls the `v1/api/notifications/sandbox` endpoint but this hasn't been added as a Canary yet. That will probably need adding as part of https://payments-platform.atlassian.net/browse/PP-7838