### PR TITLE
Pp 8105 concourse notifications

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -271,6 +271,13 @@ resources:
       repository: govukpay/publicapi
       variant: release
       <<: *aws_prod_config
+  - name: notifications-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/notifications
+      variant: release
+      <<: *aws_prod_config
   - name: slack-notification
     type: slack-notification
     source:
@@ -358,6 +365,10 @@ groups:
   - name: nginx-proxy
     jobs:
       - deploy-toolbox-to-prod
+  - name: notifications
+    jobs:
+      - deploy-notifications-to-prod
+      - smoke-test-notifications-on-prod
   - name: pipeline-meta-update
     jobs:
       - update-deploy-to-prod-pipeline
@@ -1956,3 +1967,116 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
+
+  - name: deploy-notifications-to-prod
+    serial: true
+    serial_groups: [deploy-application]
+    plan:
+      - get: notifications-ecr-registry-prod
+        trigger: false
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-prod/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          ACTION_NAME: Deployment
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENV: production-2
+      - load_var: failure_snippet
+        file: snippet/failure
+      - load_var: success_snippet
+        file: snippet/success 
+      - load_var: start_snippet
+        file: snippet/start
+      - <<: *put_start_slack_notification
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-production-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: check-release-versions
+        file: pay-ci/ci/tasks/check-release-versions.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          CLUSTER_NAME: "production-2-fargate"
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - task: deploy-to-production
+        params:
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ACCOUNT: production
+          ENVIRONMENT: production-2
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          AWS_REGION: eu-west-1
+        config:
+          platform: linux
+          inputs:
+            - name: pay-infra
+          image_resource:
+            type: registry-image
+            source:
+              repository: hashicorp/terraform
+              tag: 0.13.4
+          run:
+            path: /bin/sh
+            args:
+              - -ec
+              - |
+                cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/notifications
+                terraform init
+                terraform apply \
+                  -var notifications_image_tag=${APPLICATION_IMAGE_TAG} \
+                  -auto-approve
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENVIRONMENT: production-2
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    <<: *put_success_slack_notification_p1
+    <<: *put_failure_slack_notification
+
+  - name: smoke-test-notifications-on-prod
+    serial_groups: [smoke-test]
+    plan:
+      - get: notifications-ecr-registry-prod
+        trigger: true
+        passed: [deploy-notifications-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-prod/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          ACTION_NAME: Smoke test
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENV: production-2
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-production
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -344,6 +344,13 @@ resources:
       repository: govukpay/telegraf
       variant: release
       <<: *aws_staging_config
+  - name: notifications-ecr-registry-staging
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/notifications
+      variant: release
+      <<: *aws_staging_config
   - name: telegraf-ecr-registry-prod
     type: registry-image-resource-1-1-0
     icon: docker
@@ -375,6 +382,12 @@ resources:
     icon: docker
     source:
       repository: govukpay/nginx-forward-proxy
+      <<: *aws_production_config
+  - name: notifications-ecr-registry-prod
+    type: registry-image-resource-1-1-0
+    icon: docker
+    source:
+      repository: govukpay/notifications
       <<: *aws_production_config
   - name: slack-notification
     type: slack-notification
@@ -480,6 +493,11 @@ groups:
       - deploy-frontend-to-staging
       - smoke-test-frontend-on-staging
       - push-nginx-forward-proxy-to-production-ecr
+  - name: notifications
+    jobs:
+      - deploy-notifications-to-staging
+      - smoke-test-notifications-on-staging
+      - push-notifications-to-production-ecr
   - name: update-deploy-to-staging-pipeline
     jobs:
       - update-deploy-to-staging-pipeline
@@ -2288,3 +2306,125 @@ jobs:
         params:
           image: nginx-forward-proxy-ecr-registry-staging/image.tar
           additional_tags: nginx-forward-proxy-ecr-registry-staging/tag
+
+  - name: deploy-notifications-to-staging
+    serial: true
+    serial_groups: [deploy-application]
+    plan:
+      - get: notifications-ecr-registry-staging
+        trigger: false
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-staging/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          ACTION_NAME: Deployment
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENV: staging-2
+      - load_var: failure_snippet
+        file: snippet/failure
+      - load_var: success_snippet
+        file: snippet/success 
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: check-release-versions
+        file: pay-ci/ci/tasks/check-release-versions.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          CLUSTER_NAME: "staging-2-fargate"
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - task: deploy-to-staging
+        params:
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ACCOUNT: staging
+          ENVIRONMENT: staging-2
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          AWS_REGION: eu-west-1
+        config:
+          platform: linux
+          inputs:
+            - name: pay-infra
+          image_resource:
+            type: registry-image
+            source:
+              repository: hashicorp/terraform
+              tag: 0.13.4
+          run:
+            path: /bin/sh
+            args:
+              - -ec
+              - |
+                cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/notifications
+                terraform init
+                terraform apply \
+                  -var notifications_image_tag=${APPLICATION_IMAGE_TAG} \
+                  -auto-approve
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENVIRONMENT: staging-2
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    <<: *put_success_slack_notification 
+    <<: *put_failure_slack_notification
+
+  - name: smoke-test-notifications-on-staging
+    serial_groups: [smoke-test]
+    plan:
+      - get: notifications-ecr-registry-staging
+        trigger: true
+        passed: [deploy-notifications-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-staging/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          ACTION_NAME: Smoke test
+          APP_NAME: notifications
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENV: staging-2
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_trigger_canary
+          AWS_ROLE_SESSION_NAME: trigger-canary-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - in_parallel:
+          <<: *smoke-test-run-all-on-staging
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
+  - name: push-notifications-to-production-ecr
+    plan:
+      - get: notifications-ecr-registry-staging
+        params:
+          format: oci
+        trigger: true
+        passed: [smoke-test-notifications-on-staging]
+      - put: notifications-ecr-registry-prod
+        params:
+          image: notifications-ecr-registry-staging/image.tar
+          additional_tags: notifications-ecr-registry-staging/tag


### PR DESCRIPTION
This adds a deployment pipeline for Notifications into `pay-deploy` `deploy-to-staging` and `deploy-to-production`. This has been applied to test the configuration and has passed on both pipelines.
staging: https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-staging?group=notifications
production: https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production?group=notifications

Confirmed that the running task definition in staging and prod is using `45-release` as deployed by Concourse (I have manually tested using `0-release`)
```
gds5062-2:scripts danworth$ aws-vault exec staging -- aws ecs describe-task-definition --task-definition staging-2_notifications_FG | jq '.taskDefinition.containerDefinitions[].image'
"888564216586.dkr.ecr.eu-west-1.amazonaws.com/govukpay/notifications:45-release"


gds5062-2:scripts danworth$ aws-vault exec production -- aws ecs describe-task-definition --task-definition production-2_notifications_FG | jq '.taskDefinition.containerDefinitions[].image'
"092359438320.dkr.ecr.eu-west-1.amazonaws.com/govukpay/notifications:45-release"
```
Slack notifications are being sent as per our convention, here's the start one for the production deployment:
>:rocket: FARGATE Deployment of notifications 45-release on production-2 is beginning
Concourse build #4

## Notes
I noticed that in the `deploy-to-staging.yml` file we use `production` yet in `deploy-to-production.yml` we use the abbreviation `prod`. This inconsistency is a slight annoyance when it comes to creating new pipelines as its easy to mix them up. I've stuck with the conventions so that there is at least consistency within each file if not between them (updating them all to be consistent is beyond the scope of this PR).