### PR TITLE
PP-8166 Refactor to use input mappings

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -588,7 +588,6 @@ definitions:
       DOCKER_USERNAME: updateThisValue
       DOCKER_AUTH_TOKEN: updateThisValue
       DOCKER_REPOSITORY: updateThisValue
-      APP_GIT_DIR: updateThisValue
   # Separate tasks for each combination of scenario/environment
   - &smoke-test-run-all-on-test
     limit: 8
@@ -660,9 +659,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: toolbox-git-release
         params:
           DOCKER_REPOSITORY: govukpay/toolbox
-          APP_GIT_DIR: toolbox-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -859,9 +859,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: frontend-git-release
         params:
           DOCKER_REPOSITORY: govukpay/frontend
-          APP_GIT_DIR: frontend-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -1033,9 +1034,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: adminuers-git-release
         params:
           DOCKER_REPOSITORY: govukpay/adminusers
-          APP_GIT_DIR: adminusers-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -1239,9 +1241,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: connector-git-release
         params:
           DOCKER_REPOSITORY: govukpay/connector
-          APP_GIT_DIR: connector-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -1443,9 +1446,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: ledger-git-release
         params:
           DOCKER_REPOSITORY: govukpay/ledger
-          APP_GIT_DIR: ledger-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -1649,9 +1653,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: products-git-release
         params:
           DOCKER_REPOSITORY: govukpay/products
-          APP_GIT_DIR: products-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -1853,9 +1858,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: products-ui-git-release
         params:
           DOCKER_REPOSITORY: govukpay/products-ui
-          APP_GIT_DIR: products-ui-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -2016,9 +2022,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: publicapi-git-release
         params:
           DOCKER_REPOSITORY: govukpay/publicapi
-          APP_GIT_DIR: publicapi-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -2179,9 +2186,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: publicauth-git-release
         params:
           DOCKER_REPOSITORY: govukpay/publicauth
-          APP_GIT_DIR: publicauth-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -2336,9 +2344,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: selfservice-git-release
         params:
           DOCKER_REPOSITORY: govukpay/selfservice
-          APP_GIT_DIR: selfservice-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -2536,9 +2545,10 @@ jobs:
                 sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
     # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: cardid-git-release
         params:
           DOCKER_REPOSITORY: govukpay/cardid
-          APP_GIT_DIR: cardid-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -2652,9 +2662,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: nginx-proxy-git-release
         params:
           DOCKER_REPOSITORY: govukpay/docker-nginx-proxy
-          APP_GIT_DIR: nginx-proxy-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
@@ -2777,9 +2788,10 @@ jobs:
         trigger: true
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
+        input_mapping:
+          git-release: notifications-git-release
         params:
           DOCKER_REPOSITORY: govukpay/notifications
-          APP_GIT_DIR: notifications-git-release
           <<: *docker_credentials
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml

--- a/ci/tasks/pull-image-from-dockerhub.yml
+++ b/ci/tasks/pull-image-from-dockerhub.yml
@@ -7,34 +7,8 @@ params:
   DOCKER_USERNAME: DockerhubUsername
   DOCKER_AUTH_TOKEN: DockerhubAuthToken
   DOCKER_REPOSITORY: DockerhubRepositoryName
-  APP_GIT_DIR: AppName
 inputs:
-  - name: toolbox-git-release
-    optional: true
-  - name: frontend-git-release
-    optional: true
-  - name: adminusers-git-release
-    optional: true
-  - name: cardid-git-release
-    optional: true
-  - name: connector-git-release
-    optional: true
-  - name: ledger-git-release
-    optional: true
-  - name: products-git-release
-    optional: true
-  - name: products-ui-git-release
-    optional: true
-  - name: publicapi-git-release
-    optional: true
-  - name: publicauth-git-release
-    optional: true
-  - name: selfservice-git-release
-    optional: true
-  - name: nginx-proxy-git-release
-    optional: true
-  - name: notifications-git-release
-    optional: true
+  - name: git-release
 outputs:
   - name: image
   - name: docker_tags
@@ -58,10 +32,10 @@ run:
       echo "Authenticating with Docker Hub..."
       # TODO: use alternative auth method for docker
       echo "$DOCKER_AUTH_TOKEN" | docker login -u $DOCKER_USERNAME --password-stdin
-      COMMIT_SHA=$(cat $APP_GIT_DIR/.git/HEAD)
+      COMMIT_SHA=$(cat git-release/.git/HEAD)
       docker pull $DOCKER_REPOSITORY:$COMMIT_SHA
 
       docker save $DOCKER_REPOSITORY:$COMMIT_SHA --output image/image.tar
 
-      GIT_TAG=$(cat $APP_GIT_DIR/.git/ref)
+      GIT_TAG=$(cat git-release/.git/ref)
       echo "$COMMIT_SHA $GIT_TAG" > docker_tags/docker_tags.txt


### PR DESCRIPTION
Rather than list many different git-release resources and have each one
optional this uses the `input_mapping` feature so that the common script
does not need to know about all of the different git-release resources.
This will make adding new jobs simpler and avoid developers having to
know about the need to update the `pull-image-dockerhub.yml` script.

## WHAT

Temporarily applied this and tried it out on toolbox which worked: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/push-toolbox-to-test-ecr/builds/204
and with Notifications: https://cd.gds-reliability.engineering/teams/pay-dev/pipelines/deploy-to-test/jobs/push-notifications-to-test-ecr/builds/9