### PR TITLE
[PP-8166] FIX: Adminusers Input Mapping Typo.

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1052,7 +1052,7 @@ jobs:
       # Temporarily fetch image from Dockerhub until Concourse can build its own
       - <<: *pull-image-from-dockerhub
         input_mapping:
-          git-release: adminuers-git-release
+          git-release: adminusers-git-release
         params:
           DOCKER_REPOSITORY: govukpay/adminusers
           <<: *docker_credentials


### PR DESCRIPTION
## What?
As part of the Inputting Mapping refactor, adminusers was inadvertently mis-typed. This fixes it in order to fix the adminusers pipeline.