### PR TITLE
PP-8548: Replace functionality to retrieve S3 errors with link to Canary dashboard

### DIFF
--- a/ci/scripts/run_smoke_test.js
+++ b/ci/scripts/run_smoke_test.js
@@ -106,21 +106,8 @@ async function run () {
     } else if (state === 'FAILED') {
       prettyPrintRunReport(result.LastRun)
       console.log('\n===FAILURE LOGS==============================================\n')
-      const splitLocation = result.LastRun.ArtifactS3Location.split('/')
-      const prefix = splitLocation.slice(1, splitLocation.size).reduce((a, b) => a + '/' + b)
-      console.log(`${prefix}${splitLocation[0]}`)
-
-      // Check failure details from S3 bucket
-      try {
-        const s3Objects = await getS3Objects(splitLocation, prefix)
-        const logFile = s3Objects.Contents.filter(obj => obj.Key.includes('.txt')).map(obj => obj.Key)[0]
-        const logStream = s3.getObject({ Bucket: splitLocation[0], Key: logFile }).createReadStream()
-        logStream.on('readable', () => {
-          console.log(`${logStream.read()}`)
-        })
-      } catch (error) {
-        console.log(error)
-      }
+      console.log('Check the AWS Cloudwatch console at ')
+      console.log(`https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#synthetics:canary/detail/${SMOKE_TEST_NAME}`)
       console.log('\n============================================================\n')
 
       process.exitCode = 1

--- a/ci/scripts/run_smoke_test.js
+++ b/ci/scripts/run_smoke_test.js
@@ -106,8 +106,10 @@ async function run () {
     } else if (state === 'FAILED') {
       prettyPrintRunReport(result.LastRun)
       console.log('\n===FAILURE LOGS==============================================\n')
-      console.log('Check the AWS Cloudwatch console at ')
+      console.log('Check the Deploy account AWS Cloudwatch console at ')
       console.log(`https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#synthetics:canary/detail/${SMOKE_TEST_NAME}`)
+      console.log('Instructions on accessing Canaries if you do not have a Deploy account: ')
+      console.log(`https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#access`)
       console.log('\n============================================================\n')
 
       process.exitCode = 1


### PR DESCRIPTION
The 'fetching error info from S3' functionality has never worked - having a link to the right place in the AWS console should be a better experience for developers.

This also addresses the UnhandledPromiseRejectionWarning from https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-staging/jobs/smoke-test-frontend-on-staging/builds/66. 

Simplifying the code within the `deploymentChecker` loop (which is still needed to check the result of the canary run) means the unhappy path should now reach the `process.exitCode = 1` instead of looping forever.