### PR TITLE
PP-8455 Run smoke tests when nginx-forward-proxy image is updated

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -902,6 +902,9 @@ jobs:
       - get: frontend-ecr-registry-prod
         trigger: true
         passed: [deploy-frontend-to-prod]
+      - get: nginx-forward-proxy-ecr-registry-prod
+        trigger: true
+        passed: [deploy-frontend-to-prod]
       - get: pay-ci
       - load_var: application_image_tag
         file: frontend-ecr-registry-prod/tag


### PR DESCRIPTION
Frontend has an Nginx forward proxy and the smoke tests should run
whenever this is updated in production, just as they do when deploying
to staging.

## WHAT

This will bring the `deploy-to-production` pipeline in line with `deploy-to-staging` pipeline
Staging triggers for running smoke tests post frontend deployment
```
gds5062-2:pay-ci danworth$ fly -t pay-deploy gp -p deploy-to-staging --json | jq '.jobs[] | select(.name == "smoke-test-frontend-on-staging").plan[] | try select(.trigger == true)'
{
  "get": "frontend-ecr-registry-staging",
  "passed": [
    "deploy-frontend-to-staging"
  ],
  "trigger": true
}
{
  "get": "nginx-forward-proxy-ecr-registry-staging",
  "passed": [
    "deploy-frontend-to-staging"
  ],
  "trigger": true
}
```

Validates ok
```
gds5062-2:pay-ci danworth$ fly -t pay-deploy vp -c ci/pipelines/deploy-to-production.yml
looks good
```

Changes that would be applied
```
+ - get: nginx-forward-proxy-ecr-registry-prod
+   passed:
+   - deploy-frontend-to-prod
+   trigger: true
```