### PR TITLE
PP-8513 Add stripe smoke tests post deploy

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -135,7 +135,18 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "pymntlnk_sandbox_prod"
-
+      - task: run_create_card_payment_stripe-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_prod"
+      - task: run_create_card_payment_stripe_3ds-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_3ds_prod"
 resources:
   - name: deploy-to-prod-pipeline-definition
     type: git

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -144,7 +144,18 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "pymntlnk_sandbox_stag"
-
+      - task: run_create_card_payment_stripe-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_stag"
+      - task: run_create_card_payment_stripe_3ds-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_3ds_stag"
 resources:
   - name: deploy-to-staging-pipeline-definition
     type: git

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -675,6 +675,18 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "pymntlnk_sandbox_test"
+      - task: run_create_card_payment_stripe-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_test"
+      - task: run_create_card_payment_stripe_3ds-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_3ds_test"
 
 docker_credentials: &docker_credentials
   DOCKER_USERNAME: ((docker-username))


### PR DESCRIPTION
The stripe with and without 3ds canaries are now working and should be
run post deployment to test, staging and production.

## What

The config validates with `fly validate-pipeline`
```
gds5062-2:pay-ci danworth$ fly -t pay-deploy vp -c ci/pipelines/deploy-to-production.yml
looks good
gds5062-2:pay-ci danworth$ fly -t pay-deploy vp -c ci/pipelines/deploy-to-staging.yml
looks good
gds5062-2:pay-ci danworth$ fly -t pay-deploy vp -c ci/pipelines/deploy-to-test.yml
looks good
```