### PR TITLE
PP-8547 Fix egress deploy timeout

### DIFF
--- a/ci/scripts/check-release-versions.js
+++ b/ci/scripts/check-release-versions.js
@@ -64,15 +64,15 @@ async function run () {
     if (APPLICATION_IMAGE_TAG) {
       checkReleaseVersion(APP_NAME, APPLICATION_IMAGE_TAG, containerDefinitions)
     }
-    
+
     if (TELEGRAF_IMAGE_TAG) {
       checkReleaseVersion('telegraf', TELEGRAF_IMAGE_TAG, containerDefinitions)
     }
-    
+
     if (NGINX_IMAGE_TAG) {
       checkReleaseVersion('nginx', NGINX_IMAGE_TAG, containerDefinitions)
     }
-    
+
     if (NGINX_FORWARD_PROXY_IMAGE_TAG) {
       checkReleaseVersion('nginx-forward-proxy', NGINX_FORWARD_PROXY_IMAGE_TAG, containerDefinitions)
     }

--- a/ci/scripts/run_smoke_test.js
+++ b/ci/scripts/run_smoke_test.js
@@ -104,7 +104,7 @@ async function run () {
       console.log('Check the Deploy account AWS Cloudwatch console at ')
       console.log(`https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#synthetics:canary/detail/${SMOKE_TEST_NAME}`)
       console.log('Instructions on accessing Canaries if you do not have a Deploy account: ')
-      console.log(`https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#access`)
+      console.log('https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#access')
       console.log('\n============================================================\n')
 
       process.exitCode = 1


### PR DESCRIPTION
Addresses the timeout issue seen in https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-to-production/jobs/deploy-egress-to-prod/builds/3.

Egress sits behind a Network Load Balancer, which has a longer wait time for deregistering the old tasks (which means less time for actual deploying). I've increased it to 15 minutes.

Also:
- fixed the timeout log message which was showing seconds instead of milliseconds
- committed some linting suggestions from running `npm run lint` (StandardJS).