### PR TITLE
BAU Temporarily disable card worldpay 3ds production

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -99,12 +99,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_smartpay_prod"
-      - task: run_create_card_payment_worldpay_with_3ds-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds_prod"
       - task: run_create_card_payment_worldpay_with_3ds2-production
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:


### PR DESCRIPTION
This canary is stuck in "starting" and we are waiting on a response from
AWS since all attempts to revive it have failed.

### WHAT
This is temp, the test passes locally and we'll reinstate this once its unstuck.

```
UNKNOWN:pay-smoke-tests danworth$ aws-vault exec deploy -- node run-local/index.js --env production --test make-card-payment-worldpay-with-3ds --headless
Running make-card-payment-worldpay-with-3ds
Going to create a payment to worldpay
Going to get page https://www.payments.service.gov.uk/secure/3527a98f-c80e-4537-879d-56eab0025412
Finished entering card details and confirmed
Payment status is success
```