### PR TITLE
BAU Reinstate dodgy smoke test

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -99,6 +99,12 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_smartpay_prod"
+      - task: run_create_card_payment_worldpay_with_3ds-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds_prod"
       - task: run_create_card_payment_worldpay_with_3ds2-production
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:


### PR DESCRIPTION
The problematic canary seems to have sorted itself out, so add back to pipeline.