### PR TITLE
PP-8511: Remove unused terraform-runner Dockerfile

### DIFF
--- a/ci/docker/terraform/Dockerfile
+++ b/ci/docker/terraform/Dockerfile
@@ -1,5 +1,0 @@
-FROM hashicorp/terraform:0.13.4
-
-RUN apk add --no-cache \
-  aws-cli \
-  bash


### PR DESCRIPTION
Found during the Dockerfile review. This particular image was introduced in [49a32d0](https://github.com/alphagov/pay-ci/commit/49a32d05e0cd379e788d1824882a6df217d0f823#diff-21e072aa0ca4d97577a6d94c19ec3ae36ac8f49d0e5858f3b8c9a25892af7ae2) when first creating the deploy pipelines, but was shortly replaced with the Hashicorp terraform resource in [d00bd0c](https://github.com/alphagov/pay-ci/commit/d00bd0c87e639ef0f4e1d543e4afc623a7dacb43#diff-21e072aa0ca4d97577a6d94c19ec3ae36ac8f49d0e5858f3b8c9a25892af7ae2).
