### PR TITLE
PP-8511: Use node-runner instead of node-aws-sdk-runner

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -782,7 +782,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1167,7 +1167,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1407,7 +1407,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1636,7 +1636,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -2063,7 +2063,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -928,7 +928,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1404,7 +1404,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1669,7 +1669,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1942,7 +1942,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -2373,7 +2373,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1282,7 +1282,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1489,7 +1489,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1772,7 +1772,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -1901,7 +1901,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:
@@ -2421,7 +2421,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-aws-sdk-runner
+              repository: govukpay/node-runner
           inputs:
             - name: pay-ci
           params:

--- a/ci/tasks/assume-role.yml
+++ b/ci/tasks/assume-role.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-aws-sdk-runner
+    repository: govukpay/node-runner
 inputs:
   - name: pay-ci
 outputs:

--- a/ci/tasks/check-release-versions.yml
+++ b/ci/tasks/check-release-versions.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-aws-sdk-runner
+    repository: govukpay/node-runner
 inputs:
   - name: pay-ci
 params:

--- a/ci/tasks/run-smoke-test.yml
+++ b/ci/tasks/run-smoke-test.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-aws-sdk-runner
+    repository: govukpay/node-runner
 inputs:
   - name: pay-ci
 outputs:

--- a/ci/tasks/wait-for-deploy.yml
+++ b/ci/tasks/wait-for-deploy.yml
@@ -5,7 +5,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-aws-sdk-runner
+    repository: govukpay/node-runner
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:


### PR DESCRIPTION
The `node-aws-sdk-runner` image was renamed `node-runner` in [3550219](https://github.com/alphagov/pay-ci/commit/3550219db9247c44d07be7ba9fe1a0aab457e639#diff-f3983b37267a01991abeeac0e00d76bc33745465692a5be69bd638c435193003) when we added the `octokit/rest` npm package, but not all the usages were updated.

Given we're not managing the old version of the image anywhere, we should update these usages to the new one:
- DB migration running scripts on each pipeline (tested this out on Ledger test-12 DB migration task ✅ )
- Assume Role task
- Check Release Versions task
- Run Smoke Test task
- Wait For Deploy task