### PR TITLE
PP-8729: Remove Smartpay post-deploy canaries

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -93,12 +93,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_prod"
-      - task: run_create_card_payment_smartpay-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_smartpay_prod"
       - task: run_create_card_payment_worldpay_with_3ds-production
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -102,12 +102,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_stag"
-      - task: run_create_card_payment_smartpay-staging
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_smartpay_stag"
       - task: run_create_card_payment_worldpay_with_3ds-staging
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -633,12 +633,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_test"
-      - task: run_create_card_payment_smartpay-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_smartpay_test"
       - task: run_create_card_payment_worldpay_with_3ds-test
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:


### PR DESCRIPTION
These have been removed as part of the Smartpay shutdown.

Already applied in the deploy-to-test pipeline.