### PR TITLE
PP-8729: Fix github release resource

### DIFF
--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -3,6 +3,13 @@ aws_assumed_role_creds: &aws_assumed_role_creds
   AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
   AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
+resource_types:
+  - name: github-release-1-5-5
+    type: registry-image
+    source:
+      repository: concourse/github-release-resource
+      tag: 1.5.5
+
 resources:
   - name: deploy-smoke-tests-pipeline-definition
     type: git
@@ -27,7 +34,7 @@ resources:
       username: alphagov-pay-ci
       password: ((github-access-token))
   - name: smoke-tests-git-release
-    type: github-release
+    type: github-release-1-5-5
     icon: github
     source:
       owner: alphagov


### PR DESCRIPTION
Fixes the resource check error we were seeing: `illegal base64 data at input byte 2`

Github recently changed their Graphqa release formatting behind the scenes (see https://github.com/concourse/github-release-resource/pull/107). The fix has been pushed for the Concourse `github-release-resource`, but this is not available in the version of Concourse that BigConcourse is currently running (v7.2.0). Given it may be 'a while' before BigConcourse reaches 7.5.0+, we can instead pin to the version of the resource repo that contains the fix, and specify this as a `resource_type`.

The naming of the resource type is a bit clumsy but I want it to be clear that this is a version of the resource, not the bleeding edge of the repo. Suggestions for a better name welcome.

[Tested this on the pipeline already](https://cd.gds-reliability.engineering/teams/pay-deploy/pipelines/deploy-smoke-tests/resources/smoke-tests-git-release) - the resource (v21 of the smoke tests code) is fetched successfully, and the release tag is pinned to 1.5.5 (click the cogs on the right of the `check: smoke-tests-git-release` bar).