### PR TITLE
PP-8711: Upgrade to terraform 1.0.8

### DIFF
--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -97,7 +97,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.3
+              tag: 1.0.8
           params:
             ENVIRONMENT: test
             SMOKE_TEST_VERSION: ((.:release_version))
@@ -143,7 +143,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.3
+              tag: 1.0.8
           params:
             ENVIRONMENT: staging
             SMOKE_TEST_VERSION: ((.:release_version))
@@ -190,7 +190,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.3
+              tag: 1.0.8
           params:
             ENVIRONMENT: production
             SMOKE_TEST_VERSION: ((.:release_version))

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -2131,7 +2131,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 0.14.11
+              tag: 1.0.8
           run:
             path: /bin/sh
             args:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -2483,7 +2483,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 0.14.11
+              tag: 1.0.8
           run:
             path: /bin/sh
             args:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -3014,7 +3014,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 0.14.11
+              tag: 1.0.8
           run:
             path: /bin/sh
             args:

--- a/ci/tasks/deploy-app.yml
+++ b/ci/tasks/deploy-app.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 0.14.11
+    tag: 1.0.8
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-carbon-relay.yml
+++ b/ci/tasks/deploy-carbon-relay.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 0.14.11
+    tag: 1.0.8
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-egress.yml
+++ b/ci/tasks/deploy-egress.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 0.14.11
+    tag: 1.0.8
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 0.14.11
+    tag: 1.0.8
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:


### PR DESCRIPTION
Terraform is being upgraded to 1.0.8 for all microservices in PR https://github.com/alphagov/pay-infra/pull/3313

This PR needs to be merged prior to https://github.com/alphagov/pay-infra/pull/3313 is applied to enable deploys to continue.