### PR TITLE
BAU Stop running Cypress tests on PR builds

### DIFF
--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -14,7 +14,6 @@ outputs:
   - name: pacts
 caches:
   - path: npm_cache
-  - path: cypress_cache
 params:
   skip_tests: false
 run:
@@ -34,7 +33,6 @@ run:
         node $(pwd)/scripts/generate-dev-environment.js local
       fi
 
-      export CYPRESS_CACHE_FOLDER=$(pwd)/../cypress_cache
       npm config set cache ../npm_cache
       npm rebuild node-sass
       npm ci
@@ -45,12 +43,6 @@ run:
       else
         npm run lint
         npm test -- --forbid-only --forbid-pending
-
-        if [ -f "cypress.json" ]; then
-          npm run cypress:server > /dev/null 2>&1 &
-          sleep 3
-          npm run cypress:test
-        fi
       fi
 
       cd ..


### PR DESCRIPTION
Cypress tests are now run by a GitHub action on pay-frontend and
pay-selfservice and it is mandatory for this check to pass before a PR
can be merged.

Therefore it is no longer necessary to run them as part of the concourse
PR pipeline. We still need to run the unit tests as the output of these
is used for the pact verification job, which hasn't been moved to GitHub
actions yet.