### PR TITLE
BAU: Remove unused e2e tests

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -405,7 +405,6 @@ groups:
   - name: Selfservice
     jobs:
       - selfservice-test
-      - selfservice-card-e2e
       - selfservice-pact-provider-verification
       - record-selfservice-build-time
 
@@ -1421,36 +1420,6 @@ jobs:
       params:
         consumer_name: selfservice
     - <<: *put-test-success-status
-      put: selfservice-pull-request
-
-  - <<: *job-definition
-    name: selfservice-card-e2e
-    serial_groups: [e2e-test]
-    plan:
-    - <<: *get-ci
-    - <<: *get-pull-request
-      resource: selfservice-pull-request
-      trigger: false
-    - <<: *put-card-e2e-pending-status
-      put: selfservice-pull-request
-    - <<: *node-build
-      on_failure:
-        <<: *put-card-e2e-failed-status
-        put: selfservice-pull-request
-    - <<: *build-docker-image
-      params:
-        app_name: selfservice
-    - <<: *get-all-docker-images
-    - <<: *run-e2e
-      input_mapping:
-        docker/selfservice: local_image
-      params:
-        app_name: selfservice
-        test_type: card
-      on_failure:
-        <<: *put-card-e2e-failed-status
-        put: selfservice-pull-request
-    - <<: *put-card-e2e-success-status
       put: selfservice-pull-request
 
   - <<: *job-definition


### PR DESCRIPTION
Concourse isn't automatically running end-to-end tests on PR builds. I propose we simplify the PR CI pipeline and get rid of these jobs.

Here's a summary of the last build date and total number of runs for each app:

|App | Job   | Last run | No of runs |
| -- | --  | -- | -- |  
|Connector | card-connector-card-e2e  | Aug 11 2021 | 71|
|PublicAPI | publicapi-card-e2e  | Mar 2 2021 | 12|
|PublicAPI | publicapi-products-e2e   | Aug 19 2020 | 11|
|Adminusers | adminusers-card-e2e   | Aug 19 2020 | 26|
|CardID | cardid-card-e2e | Aug 19 2020 | 9
|Ledger | ledger-card-e2e  | Sep 9 2020 | 29|
|PublicAuth | publicauth-card-e2e |  Aug 19 2020 | 8|
|Products | products-products-e2e | Aug 19 2020 | 6|
|Products UI | products-ui-products-e2e | Never | 0|
|Frontend | card-frontend-card-e2e  | Never | 0|
|Selfservice | selfservice-card-e2e  | Mar 16 2021 | 5|

The e2e tests can be run manually against a branch as [a parameterised build on Jenkins](https://build.ci.pymnt.uk/job/run-end-to-end-tests/build?delay=0sec) if required.