### PR TITLE
PP-8890: Add aws-cli to concourse-runner docker image

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker:19.03
 
 RUN apk add --no-cache \
+  aws-cli \
   bash \
   curl \
   netcat-openbsd \


### PR DESCRIPTION
Add aws-cli to concourse-runner docker image

```
cd ci/docker/concourse-runner
docker build -t concourse-runner:local-master .
```