### PR TITLE
PP-8773: Use manifest for current pact-broker app

### DIFF
--- a/ci/pact_broker/pay-pact-broker_manifest.yml
+++ b/ci/pact_broker/pay-pact-broker_manifest.yml
@@ -1,5 +1,5 @@
 applications:
-- name: pay-concourse-pact-broker
+- name: pay-pact-broker
   command: |
     eval $(ruby -rjson -e 'vcap=JSON.parse(ENV["VCAP_SERVICES"]);
       puts "export PACT_BROKER_DATABASE_USERNAME=#{vcap["postgres"][0]["credentials"]["username"]}";
@@ -11,17 +11,14 @@ applications:
   docker:
     image: pactfoundation/pact-broker:2.54.0.0
   env:
-    PACT_BROKER_PUBLIC_HEARTBEAT: "true"
     PACT_BROKER_BASIC_AUTH_USERNAME: ((pact-broker-username))
     PACT_BROKER_BASIC_AUTH_PASSWORD: ((pact-broker-password))
-    PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME: pay-team-ro
-    PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD: ((pact-broker-password))
-  health-check-http-endpoint: /diagnostic/status/heartbeat
-  health-check-type: http
-  instances: 2
-  memory: 256M
+  health-check-type: process
+  instances: 1
+  memory: 1G
   routes:
-    - route: pay-concourse-pact-broker.cloudapps.digital
+    - route: pay-pact-broker.cloudapps.digital
+    - route: pact-broker-test.cloudapps.digital
   services:
-    - concourse-pact-broker-db
+    - pact-broker-db
   stack: cflinuxfs3

--- a/ci/pipelines/pact-broker.yml
+++ b/ci/pipelines/pact-broker.yml
@@ -11,7 +11,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: main
       paths:
         - ci/pipelines/pact-broker.yml
 
@@ -20,7 +20,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: main
       paths:
         - ci/pact_broker
 
@@ -51,7 +51,7 @@ jobs:
       - put: paas
         params:
           command: push
-          app_name: pay-concourse-pact-broker
+          app_name: pay-pact-broker
           manifest: pact-broker-manifest/ci/pact_broker/pay-pact-broker_manifest.yml
           vars:
             pact-broker-username: ((pact-broker-username))


### PR DESCRIPTION
The old manifest details refer to a concourse-specific pact broker app that isn't currently running. Change the app/DB name/routes to point to the current app, and adjust the memory/instances/quota to match the current app.

The `PACT_BROKER_BASIC_AUTH_*` vars are used by the [pact-broker docker image](https://github.com/DiUS/pact_broker-docker/blob/cc4273c6ea49a59af183cd6e63b6c9b98f78ce90/container/etc/nginx/main.d/pactbroker-env.conf). I don't think we need a read-only version of the creds (and we don't have these stored in our usual place anyway).

The current app doesn't have a public healthcheck endpoint - it uses `process` instead.