### PR TITLE
PP-8773: Change branch back to master for pact-broker pipeline

### DIFF
--- a/ci/pipelines/pact-broker.yml
+++ b/ci/pipelines/pact-broker.yml
@@ -11,7 +11,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: main
+      branch: master
       paths:
         - ci/pipelines/pact-broker.yml
 
@@ -20,7 +20,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: main
+      branch: master
       paths:
         - ci/pact_broker
 


### PR DESCRIPTION
I thought we'd changed the default branch on this repo from `master` to `main`, but we haven't yet 🤦‍♀️ 