### PR TITLE
BAU: Fix docker-compose in concourse-runner container

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache \
   aws-cli \
   bash \
   curl \
+  docker-compose \
   netcat-openbsd \
   git \
   python3 \
@@ -18,7 +19,6 @@ RUN apk add --no-cache \
   npm \
   maven \
   tini \
-  docker-compose>1.25.4-r1 \
   --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub


### PR DESCRIPTION
Install docker-compose from the main repo, the version is high enough that it doesn't need to come from edge anymore.

This whole container really needs updating and having some tests written around it to make updating it safer, but for now we will get it working like this and can schedule that task along with the normal planning.

The version from the edge apk repo isn't looking in the right place for installed python modules so running docker-compose just shows it can't find any python modules.

# How

```
docker built -t concourse-runner:test .
docker run --rm -ti concourse-runner:test docker-compose help
```

