### PR TITLE
PP-9000: Add notifications sandbox smoke test to post deploy tests

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -141,6 +141,13 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_3ds_prod"
+      - task: run_notifications_sandbox-prod
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "notifcatns_sndbx_prod"
+
 resources:
   - name: deploy-to-prod-pipeline-definition
     type: git

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -150,6 +150,13 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_3ds_stag"
+      - task: run_notifications_sandbox-stag
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "notifcatns_sndbx_stag"
+
 resources:
   - name: deploy-to-staging-pipeline-definition
     type: git

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -652,6 +652,12 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_3ds_test"
+      - task: run_notifications_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "notifcatns_sndbx_test"
 
 docker_credentials: &docker_credentials
   DOCKER_USERNAME: ((docker-username))


### PR DESCRIPTION
Notifications sandbox smoke tests have been run:
https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-staging/jobs/smoke-test-adminusers-on-staging/builds/35.1
https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/smoke-test-adminusers/builds/37.3
https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-production/jobs/smoke-test-adminusers-on-prod/builds/33.1