### PR TITLE
PP-8980: Node runner pipeline

### DIFF
--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -1,0 +1,44 @@
+---
+resources:
+  - name: node-runner-src
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+      paths:
+        - ci/docker/node-runner/*
+
+  - name: node-runner
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/node-runner
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: latest
+
+# Builds and pushes the node-runner Docker image used by various Concourse CI pipelines
+jobs:
+  - name: build-and-push
+    plan:
+      - get: node-runner-src
+        trigger: true
+      - task: build
+        privileged: true
+        params: 
+          CONTEXT: node-runner-src/ci/docker/node-runner
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: vito/oci-build-task
+          inputs:
+          - name: node-runner-src
+          outputs:
+          - name: image
+          run:
+            path: build
+      - put: node-runner
+        params: {image: image/image.tar}


### PR DESCRIPTION
Merging this means any changes to `ci/docker/node-runner/` will be built, tagged with "latest" and be used by all builds.

The node-runner image is tagged with "latest". The node-runner image was originally tagged with "1-release_2022-01-05" which works (for a [deploy](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-frontend/builds/35) and [smoke test](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/smoke-test-toolbox/builds/27.1) - see task "print-node-runner-version" which comes from https://github.com/alphagov/pay-ci/pull/564) but given there are no automated tests for upgrading the node runner we might actually want to keep the tag at "1-release_2022-01-05" - this would introduce a manual step (by changing the tag manually) when we want to upgrade the node-runner. Keen for opinions/comments.