### PR TITLE
bau: Configure dependabot for Docker containers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,15 @@
 version: 2
 - package-ecosystem: docker
-  directory: "/ci/docker"
+  directory: "/ci/docker/node-runner"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - govuk-pay
+- package-ecosystem: docker
+  directory: "/ci/docker/concourse-runner"
   schedule:
     interval: daily
     time: "03:00"


### PR DESCRIPTION
Unfortunately I don't believe the "directory" param in the dependabot config is
recursive at the moment so we'll have to specify each directory.

I've also ignored ci/docker/pact_with_jq as there's no build process for it at
the moment.