### PR TITLE
BAU: Allow rollback of connector in test and staging

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -829,11 +829,11 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
-      - task: check-release-versions
-        file: pay-ci/ci/tasks/check-release-versions.yml
-        params:
-          <<: *check_release_versions_params
-          APP_NAME: connector
+#       - task: check-release-versions
+#         file: pay-ci/ci/tasks/check-release-versions.yml
+#         params:
+#           <<: *check_release_versions_params
+#           APP_NAME: connector
       - task: deploy-to-staging
         file: pay-ci/ci/tasks/deploy-app.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1424,11 +1424,11 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
-      - task: check-release-versions
-        file: pay-ci/ci/tasks/check-release-versions.yml
-        params:
-          <<: *check_release_versions_params
-          APP_NAME: connector
+#       - task: check-release-versions
+#         file: pay-ci/ci/tasks/check-release-versions.yml
+#         params:
+#           <<: *check_release_versions_params
+#           APP_NAME: connector
       - task: deploy-to-test
         file: pay-ci/ci/tasks/deploy-app.yml
         params:


### PR DESCRIPTION
In an emergency we allowed staging and test to rollback to an older version (2578-release). This has been applied and should be reverted after the weekend