### PR TITLE
PP-9002: Stop all running canaries before updating them

### DIFF
--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -89,6 +89,8 @@ jobs:
         format: json
       - task: stop-all-running-canaries  
         file: pay-ci/ci/tasks/stop-canaries.yml
+        params:
+          <<: *aws_assumed_role_creds
       - task: apply-the-terraform
         config:
           platform: linux

--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -76,7 +76,7 @@ jobs:
             args:
               - -ec
               - |
-                echo "Unzipping release ${RELEASE_VERSION} into zip-files-direcotry/${RELEASE_VERSION}"
+                echo "Unzipping release ${RELEASE_VERSION} into zip-files-directory/${RELEASE_VERSION}"
                 mkdir "zip-files-directory/${RELEASE_VERSION}"
                 unzip smoke-tests-git-release/pay-smoke-tests-v*.zip -d "zip-files-directory/${RELEASE_VERSION}"
       - task: assume-role
@@ -87,6 +87,8 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
+      - task: stop-all-running-canaries  
+        file: pay-ci/ci/tasks/stop-canaries.yml
       - task: apply-the-terraform
         config:
           platform: linux

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -5,6 +5,9 @@ image_resource:
   source:
     repository: govukpay/concourse-runner
 params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:    
   AWS_REGION: eu-west-1
 run:
   path: /bin/bash

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -14,7 +14,10 @@ run:
   args:
     - -ec
     - |
-      for canary in card_wpay_3ds_test card_wpay_test card_stripe_3ds_test card_stripe_test; do
+      for canary in notifcatns_sndbx_test pymntlnk_sandbox_test cancel_sandbox_test card_wpay_3ds2ex_test \
+      card_wpay_3ds2_test card_wpay_3ds_test card_wpay_test card_stripe_3ds_test card_stripe_test card_sandbox_test \
+      s_card_stripe_test s_card_stripe_3d_test s_card_wpay_test s_card_wpay_3ds_test s_card_wpay_3ds2_test \
+      s_wpay_3ds2ex_test s_card_sandbox_test s_cancel_sandbox_test s_paylnk_sandbox_test s_notifications_test; do
 
         status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
         echo "status: $status"

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -11,10 +11,7 @@ run:
   args:
     - -ec
     - |
-      for canary in notifcatns_sndbx_test pymntlnk_sandbox_test cancel_sandbox_test card_wpay_3ds2ex_test \
-      card_wpay_3ds2_test card_wpay_3ds_test card_wpay_test card_stripe_3ds_test card_stripe_test card_sandbox_test \
-      s_card_stripe_test s_card_stripe_3d_test s_card_wpay_test s_card_wpay_3ds_test s_card_wpay_3ds2_test \
-      s_wpay_3ds2ex_test s_card_sandbox_test s_cancel_sandbox_test s_paylnk_sandbox_test s_notifications_test; do
+      for canary in card_wpay_3ds_test card_wpay_test card_stripe_3ds_test card_stripe_test; do
 
         status=$(aws --region $AWS_REGION synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
         echo "status: $status"

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -18,11 +18,11 @@ run:
 
         status=$(aws --region $AWS_REGION synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
         echo "status: $status"
-        if [ $status == "STOPPED" ]
+        if [ $status == "RUNNING" ]
         then
-          echo "Status of $canary is STOPPED, nothing to do."
-        else
           echo "Stopping canary $canary"
           aws --region $AWS_REGION synthetics stop-canary --name $canary
+        else
+          echo "Canary $canary is not running, nothing to do."
         fi
       done

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -1,0 +1,26 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/concourse-runner
+run:
+  path: /bin/bash
+  args:
+    - -ec
+    - |
+      for canary in notifcatns_sndbx_test pymntlnk_sandbox_test cancel_sandbox_test card_wpay_3ds2ex_test \
+      card_wpay_3ds2_test card_wpay_3ds_test card_wpay_test card_stripe_3ds_test card_stripe_test card_sandbox_test \
+      s_card_stripe_test s_card_stripe_3d_test s_card_wpay_test s_card_wpay_3ds_test s_card_wpay_3ds2_test \
+      s_wpay_3ds2ex_test s_card_sandbox_test s_cancel_sandbox_test s_paylnk_sandbox_test s_notifications_test; do
+
+        status=$(aws synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
+        echo "status: $status"
+        if [ $status == "STOPPED" ]
+        then
+          echo "Status of $canary is STOPPED, nothing to do."
+        else
+          echo "Stopping canary $canary"
+          aws synthetics stop-canary --name $canary
+        fi
+      done

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -15,7 +15,7 @@ run:
 
         status=$(aws --region $AWS_REGION synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
         echo "status: $status"
-        if [ $status == "RUNNING" ]
+        if [ "$status" == "RUNNING" ]
         then
           echo "Stopping canary $canary"
           aws --region $AWS_REGION synthetics stop-canary --name $canary

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -16,12 +16,16 @@ run:
     - |
       for canary in card_wpay_3ds_test card_wpay_test card_stripe_3ds_test card_stripe_test; do
 
-        status=$(aws --region $AWS_REGION synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
+        status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
         echo "status: $status"
         if [ "$status" == "RUNNING" ]
         then
           echo "Stopping canary $canary"
-          aws --region $AWS_REGION synthetics stop-canary --name $canary
+          aws --region "$AWS_REGION" synthetics stop-canary --name $canary
+        elif [ "$status" == "ERROR" ]
+        then  
+          echo "Canary $canary is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
+          exit 1
         else
           echo "Canary $canary is not running, nothing to do."
         fi

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -4,6 +4,8 @@ image_resource:
   type: registry-image
   source:
     repository: govukpay/concourse-runner
+params:
+  AWS_REGION: eu-west-1
 run:
   path: /bin/bash
   args:

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -16,13 +16,13 @@ run:
       s_card_stripe_test s_card_stripe_3d_test s_card_wpay_test s_card_wpay_3ds_test s_card_wpay_3ds2_test \
       s_wpay_3ds2ex_test s_card_sandbox_test s_cancel_sandbox_test s_paylnk_sandbox_test s_notifications_test; do
 
-        status=$(aws synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
+        status=$(aws --region $AWS_REGION synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
         echo "status: $status"
         if [ $status == "STOPPED" ]
         then
           echo "Status of $canary is STOPPED, nothing to do."
         else
           echo "Stopping canary $canary"
-          aws synthetics stop-canary --name $canary
+          aws --region $AWS_REGION synthetics stop-canary --name $canary
         fi
       done


### PR DESCRIPTION
We've had trouble updating the canaries in the deploy-smoke-tests pipeline. A
typical error:

```
│ Error: error updating Synthetics Canary (card_wpay_3ds2ex_test): ConflictException: Canary is in a state that can't be modified: ERROR
```

We've found that manually stopping the canaries first unblocks the pipeline, so
that's what we're doing in this PR.

In the interests of small PRs, this PR is for update-canaries-for-test-environment only. Staging and prod will be in another PR.

Example build: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-smoke-tests/jobs/update-canaries-for-test-environment/builds/21