### PR TITLE
PP-9002: Check if canaries are in error state

### DIFF
--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -91,6 +91,7 @@ jobs:
         file: pay-ci/ci/tasks/stop-canaries.yml
         params:
           <<: *aws_assumed_role_creds
+          ENVIRONMENT: test
       - task: apply-the-terraform
         config:
           platform: linux
@@ -137,6 +138,11 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
+      - task: stop-all-running-canaries  
+        file: pay-ci/ci/tasks/stop-canaries.yml
+        params:
+          <<: *aws_assumed_role_creds
+          ENVIRONMENT: stag
       - task: apply-the-terraform
         config:
           platform: linux
@@ -184,6 +190,11 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
+      - task: stop-all-running-canaries  
+        file: pay-ci/ci/tasks/stop-canaries.yml
+        params:
+          <<: *aws_assumed_role_creds
+          ENVIRONMENT: prod        
       - task: apply-the-terraform
         config:
           platform: linux

--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -87,8 +87,8 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
-      - task: stop-all-running-canaries  
-        file: pay-ci/ci/tasks/stop-canaries.yml
+      - task: check-canaries-in-error-state  
+        file: pay-ci/ci/tasks/check-canaries-in-error-state.yml
         params:
           <<: *aws_assumed_role_creds
           ENVIRONMENT: test
@@ -138,8 +138,8 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
-      - task: stop-all-running-canaries  
-        file: pay-ci/ci/tasks/stop-canaries.yml
+      - task: check-canaries-in-error-state
+        file: pay-ci/ci/tasks/check-canaries-in-error-state.yml
         params:
           <<: *aws_assumed_role_creds
           ENVIRONMENT: stag
@@ -190,8 +190,8 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
-      - task: stop-all-running-canaries  
-        file: pay-ci/ci/tasks/stop-canaries.yml
+      - task: check-canaries-in-error-state
+        file: pay-ci/ci/tasks/check-canaries-in-error-state.yml
         params:
           <<: *aws_assumed_role_creds
           ENVIRONMENT: prod        

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -16,7 +16,7 @@ run:
   args:
     - -ec
     - |
-      NON_SCHEDULED_CANARIES="notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
+      POST_DEPLOY_CANARIES="notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
       card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox"
 
       SCHEDULED_CANARIES_STAGING="s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
@@ -25,11 +25,11 @@ run:
       SCHEDULED_CANARIES_PROD="s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications"
 
       if [ "$ENVIRONMENT" == "test" ]; then
-        CANARIES_FOR_ENV="$NON_SCHEDULED_CANARIES"
+        CANARIES_FOR_ENV="$POST_DEPLOY_CANARIES"
       elif [ "$ENVIRONMENT" == "stag" ]; then
-        CANARIES_FOR_ENV="$NON_SCHEDULED_CANARIES $SCHEDULED_CANARIES_STAGING"
+        CANARIES_FOR_ENV="$POST_DEPLOY_CANARIES $SCHEDULED_CANARIES_STAGING"
       else
-        CANARIES_FOR_ENV="$NON_SCHEDULED_CANARIES $SCHEDULED_CANARIES_PROD" 
+        CANARIES_FOR_ENV="$POST_DEPLOY_CANARIES $SCHEDULED_CANARIES_PROD" 
       fi
 
       echo "Checking canaries: $CANARIES_FOR_ENV"

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -15,10 +15,19 @@ run:
   args:
     - -ec
     - |
-      for canary in notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
-      card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox \
-      s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
-      s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications; do
+      NON_SCHEDULED_CANARIES="notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
+      card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox"
+
+      SCHEDULED_CANARIES="s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
+      s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications"
+
+      if [ "$ENVIRONMENT" == "test" ]; then
+        CANARIES_FOR_ENV="$NON_SCHEDULED_CANARIES"
+      else
+        CANARIES_FOR_ENV="$SCHEDULED_CANARIES $NON_SCHEDULED_CANARIES"
+      fi
+
+      for canary in $CANARIES_FOR_ENV; do
 
         canary_name="${canary}_${ENVIRONMENT}"
 
@@ -27,7 +36,5 @@ run:
         then  
           echo "Canary $canary_name is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
           exit 1
-        else
-          echo "$canary_name is either ok or doesn't exist (ok if the canary is a scheduled one - we don't have scheduled canaries in the test environment)."
         fi
       done

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -27,8 +27,7 @@ run:
         then  
           echo "Canary $canary_name is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
           exit 1
-        elif [[ "$status" == *"Canary not found"* ]]
-        then
-          echo "Canary $canary_name not found. This is ok if it's the test environment and the canary is a scheduled one."
+        else
+          echo "$canary_name is either ok or doesn't exist (ok if the canary is a scheduled one - we don't have scheduled canaries in the test environment)."
         fi
       done

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -23,15 +23,9 @@ run:
         canary_name="${canary}_${ENVIRONMENT}"
 
         status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary_name | jq -r '.Canary.Status.State')
-        if [ "$status" == "RUNNING" ]
-        then
-          echo "Stopping canary $canary_name"
-          aws --region "$AWS_REGION" synthetics stop-canary --name $canary_name
-        elif [ "$status" == "ERROR" ]
+        if [ "$status" == "ERROR" ]
         then  
           echo "Canary $canary_name is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
           exit 1
-        else
-          echo "Canary $canary_name is not running, nothing to do."
         fi
       done

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -27,5 +27,7 @@ run:
         then  
           echo "Canary $canary_name is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
           exit 1
-        fi
+        elif [ "$status" == *"Canary not found"* ]
+        then
+          echo "Canary $canary_name not found. This is ok if it's the test environment and the canary is a scheduled one."
       done

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -18,16 +18,20 @@ run:
       NON_SCHEDULED_CANARIES="notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
       card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox"
 
-      SCHEDULED_CANARIES="s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
+      SCHEDULED_CANARIES_STAGING="s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
       s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications"
+
+      SCHEDULED_CANARIES_PROD="s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications"
 
       if [ "$ENVIRONMENT" == "test" ]; then
         CANARIES_FOR_ENV="$NON_SCHEDULED_CANARIES"
+      elif [ "$ENVIRONMENT" == "stag" ]; then
+        CANARIES_FOR_ENV="$NON_SCHEDULED_CANARIES $SCHEDULED_CANARIES_STAGING"
       else
-        CANARIES_FOR_ENV="$SCHEDULED_CANARIES $NON_SCHEDULED_CANARIES"
+        CANARIES_FOR_ENV="$NON_SCHEDULED_CANARIES $SCHEDULED_CANARIES_PROD" 
       fi
 
-      echo "$CANARIES_FOR_ENV"
+      echo "Checking canaries: $CANARIES_FOR_ENV"
 
       for canary in $CANARIES_FOR_ENV; do
 

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -9,6 +9,7 @@ params:
   AWS_SECRET_ACCESS_KEY:
   AWS_SESSION_TOKEN:    
   AWS_REGION: eu-west-1
+  # ENVIRONMENT is one of "test", "stag" or "prod" as that's what the canaries are appended with (due to the character limitation)."
   ENVIRONMENT:
 run:
   path: /bin/bash

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -22,12 +22,13 @@ run:
 
         canary_name="${canary}_${ENVIRONMENT}"
 
-        status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary_name | jq -r '.Canary.Status.State')
+        status=$(aws --region "$AWS_REGION" synthetics get-canary --name "$canary_name" | jq -r '.Canary.Status.State')
         if [ "$status" == "ERROR" ]
         then  
           echo "Canary $canary_name is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
           exit 1
-        elif [ "$status" == *"Canary not found"* ]
+        elif [[ "$status" == *"Canary not found"* ]]
         then
           echo "Canary $canary_name not found. This is ok if it's the test environment and the canary is a scheduled one."
+        fi
       done

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -27,6 +27,8 @@ run:
         CANARIES_FOR_ENV="$SCHEDULED_CANARIES $NON_SCHEDULED_CANARIES"
       fi
 
+      echo "$CANARIES_FOR_ENV"
+
       for canary in $CANARIES_FOR_ENV; do
 
         canary_name="${canary}_${ENVIRONMENT}"

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -9,18 +9,18 @@ params:
   AWS_SECRET_ACCESS_KEY:
   AWS_SESSION_TOKEN:    
   AWS_REGION: eu-west-1
+  ENVIRONMENT:
 run:
   path: /bin/bash
   args:
     - -ec
     - |
-      for canary in notifcatns_sndbx_test pymntlnk_sandbox_test cancel_sandbox_test card_wpay_3ds2ex_test \
-      card_wpay_3ds2_test card_wpay_3ds_test card_wpay_test card_stripe_3ds_test card_stripe_test card_sandbox_test \
-      s_card_stripe_test s_card_stripe_3d_test s_card_wpay_test s_card_wpay_3ds_test s_card_wpay_3ds2_test \
-      s_wpay_3ds2ex_test s_card_sandbox_test s_cancel_sandbox_test s_paylnk_sandbox_test s_notifications_test; do
+      for canary in notifcatns_sndbx_$ENVIRONMENT pymntlnk_sandbox_$ENVIRONMENT cancel_sandbox_$ENVIRONMENT card_wpay_3ds2ex_$ENVIRONMENT \
+      card_wpay_3ds2_$ENVIRONMENT card_wpay_3ds_$ENVIRONMENT card_wpay_$ENVIRONMENT card_stripe_3ds_$ENVIRONMENT card_stripe_$ENVIRONMENT card_sandbox_$ENVIRONMENT \
+      s_card_stripe_$ENVIRONMENT s_card_stripe_3d_$ENVIRONMENT s_card_wpay_$ENVIRONMENT s_card_wpay_3ds_$ENVIRONMENT s_card_wpay_3ds2_$ENVIRONMENT \
+      s_wpay_3ds2ex_$ENVIRONMENT s_card_sandbox_$ENVIRONMENT s_cancel_sandbox_$ENVIRONMENT s_paylnk_sandbox_$ENVIRONMENT s_notifications_$ENVIRONMENT; do
 
         status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
-        echo "status: $status"
         if [ "$status" == "RUNNING" ]
         then
           echo "Stopping canary $canary"

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -20,7 +20,9 @@ run:
       s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
       s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications; do
 
-        canary_name=$canary_$ENVIRONMENT
+        canary_name="$canary_$ENVIRONMENT"
+
+        echo $canary_name
 
         status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary_name | jq -r '.Canary.Status.State')
         if [ "$status" == "RUNNING" ]

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -22,12 +22,10 @@ run:
 
         canary_name="${canary}_${ENVIRONMENT}"
 
-        echo $canary_name
-
         status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary_name | jq -r '.Canary.Status.State')
         if [ "$status" == "RUNNING" ]
         then
-          echo "Stopping canary $canary"
+          echo "Stopping canary $canary_name"
           aws --region "$AWS_REGION" synthetics stop-canary --name $canary_name
         elif [ "$status" == "ERROR" ]
         then  

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -20,7 +20,7 @@ run:
       s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
       s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications; do
 
-        canary_name="$canary_$ENVIRONMENT"
+        canary_name="${canary}_${ENVIRONMENT}"
 
         echo $canary_name
 

--- a/ci/tasks/stop-canaries.yml
+++ b/ci/tasks/stop-canaries.yml
@@ -15,21 +15,23 @@ run:
   args:
     - -ec
     - |
-      for canary in notifcatns_sndbx_$ENVIRONMENT pymntlnk_sandbox_$ENVIRONMENT cancel_sandbox_$ENVIRONMENT card_wpay_3ds2ex_$ENVIRONMENT \
-      card_wpay_3ds2_$ENVIRONMENT card_wpay_3ds_$ENVIRONMENT card_wpay_$ENVIRONMENT card_stripe_3ds_$ENVIRONMENT card_stripe_$ENVIRONMENT card_sandbox_$ENVIRONMENT \
-      s_card_stripe_$ENVIRONMENT s_card_stripe_3d_$ENVIRONMENT s_card_wpay_$ENVIRONMENT s_card_wpay_3ds_$ENVIRONMENT s_card_wpay_3ds2_$ENVIRONMENT \
-      s_wpay_3ds2ex_$ENVIRONMENT s_card_sandbox_$ENVIRONMENT s_cancel_sandbox_$ENVIRONMENT s_paylnk_sandbox_$ENVIRONMENT s_notifications_$ENVIRONMENT; do
+      for canary in notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
+      card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox \
+      s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
+      s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications; do
 
-        status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary | jq -r '.Canary.Status.State')
+        canary_name=$canary_$ENVIRONMENT
+
+        status=$(aws --region "$AWS_REGION" synthetics get-canary --name $canary_name | jq -r '.Canary.Status.State')
         if [ "$status" == "RUNNING" ]
         then
           echo "Stopping canary $canary"
-          aws --region "$AWS_REGION" synthetics stop-canary --name $canary
+          aws --region "$AWS_REGION" synthetics stop-canary --name $canary_name
         elif [ "$status" == "ERROR" ]
         then  
-          echo "Canary $canary is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
+          echo "Canary $canary_name is in an errored state. It must be manually deleted and created - see https://pay-team-manual.cloudapps.digital/manual/tools/canary.html#updating-canary-tests-in-error-state."
           exit 1
         else
-          echo "Canary $canary is not running, nothing to do."
+          echo "Canary $canary_name is not running, nothing to do."
         fi
       done


### PR DESCRIPTION
We currently require canaries in errored states to be manually recreated by a
person with privileged access. We haven't tested that canaries in the running
state causes a deployment of smoke tests to fail, so the code that stops
canaries if they are running is reverted here.

Builds for this PR:
https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-smoke-tests/jobs/update-canaries-for-production-environment/builds/8
https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-smoke-tests/jobs/update-canaries-for-staging-environment/builds/10
https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-smoke-tests/jobs/update-canaries-for-test-environment/builds/30