### PR TITLE
PP-9151: Disable continuous deployment for egress

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -419,7 +419,6 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: egress-ecr-registry-prod
-        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1074,7 +1074,6 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: egress-ecr-registry-staging
-        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag


### PR DESCRIPTION
During the deployment process for the egress proxy app we're seeing errors on container shutdown. We want manual oversight of deployments for now.