### PR TITLE
Pp 9086 check for bastion update

### DIFF
--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -57,7 +57,7 @@ jobs:
     - task: assume-role
       file: pay-ci/ci/tasks/assume-role.yml
       params:
-        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/pay-concourse-bastion-staging-2
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/pay-concourse-bastion-read-only-staging-2
         AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection
     - load_var: role
       file: assume-role/assume-role.json
@@ -106,7 +106,7 @@ jobs:
     - task: assume-role
       file: pay-ci/ci/tasks/assume-role.yml
       params:
-        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_production_account_id)):role/pay-concourse-bastion-production-2
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_production_account_id)):role/pay-concourse-bastion-read-only-production-2
         AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection
     - load_var: role
       file: assume-role/assume-role.json

--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -39,7 +39,7 @@ resources:
     source:
       url: https://hooks.slack.com/services/((slack-notification-secret))
 
-definitiions:
+definitions:
   aws_assumed_role_creds: &aws_assumed_role_creds
     AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
     AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))

--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -1,0 +1,127 @@
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+resources:
+  - name: pay-infra
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-infra
+      branch: master
+      username: alphagov-pay-ci
+      password: ((github-access-token))
+  - name: every-morning-at-six
+    icon: alarm
+    source:
+      start: "06:00"
+      stop: "06:30"
+      location: Europe/London
+    type: time
+  - name: every-morning-at-six-thirty
+    icon: alarm
+    source:
+      start: "06:30"
+      stop: "07:00"
+      location: Europe/London
+    type: time
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+  - name: slack-notification
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-notification-secret))
+
+definitiions:
+  aws_assumed_role_creds: &aws_assumed_role_creds
+    AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+    AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+    AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+
+jobs:
+  - name: staging-2-bastion
+    serial: true
+    plan:
+    - in_parallel:
+      - get: every-morning-at-six
+        trigger: true
+      - get: pay-ci
+      - get: pay-infra
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/pay-concourse-bastion-staging-2
+        AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-for-drift
+      file: pay-ci/ci/tasks/check-for-tf-drift.yml
+      params:
+        <<: *aws_assumed_role_creds
+        DEPLOYMENT_PATH: "staging/staging-2/environment/bastion"
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Terraform state consistent for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+
+  - name: production-2-bastion
+    serial: true
+    plan:
+    - in_parallel:
+      - get: every-morning-at-six-thirty
+        trigger: true
+      - get: pay-ci
+      - get: pay-infra
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_production_account_id)):role/pay-concourse-bastion-production-2
+        AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-for-drift
+      file: pay-ci/ci/tasks/check-for-tf-drift.yml
+      params:
+        <<: *aws_assumed_role_creds
+        DEPLOYMENT_PATH: "production/production-2/environment/bastion"
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Terraform state consistent for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector

--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -76,6 +76,15 @@ jobs:
         text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
         icon_emoji: ":terraform:"
         username: pay-concourse-drift-detector
+    on_error:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Pipeline to detect drift for $BUILD_JOB_NAME failed to run <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
     on_success:
       put: slack-notification
       attempts: 10
@@ -114,6 +123,15 @@ jobs:
         channel: '#govuk-pay-starling'
         silent: true
         text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_error:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Pipeline to detect drift for $BUILD_JOB_NAME failed to run <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
         icon_emoji: ":terraform:"
         username: pay-concourse-drift-detector
     on_success:

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -39,7 +39,7 @@ resources:
     source:
       url: https://hooks.slack.com/services/((slack-notification-secret))
 
-definitiions:
+definitions:
   aws_assumed_role_creds: &aws_assumed_role_creds
     AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
     AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -1,0 +1,127 @@
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+resources:
+  - name: pay-infra
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-infra
+      branch: master
+      username: alphagov-pay-ci
+      password: ((github-access-token))        
+  - name: every-morning-at-five
+    icon: alarm
+    source:
+      start: "05:00"
+      stop: "05:30"
+      location: Europe/London
+    type: time
+  - name: every-morning-at-five-thirty
+    icon: alarm
+    source:
+      start: "05:30"
+      stop: "06:00"
+      location: Europe/London
+    type: time
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+  - name: slack-notification
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-notification-secret))
+
+definitiions:
+  aws_assumed_role_creds: &aws_assumed_role_creds
+    AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+    AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+    AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+
+jobs:
+  - name: test-12-bastion
+    serial: true
+    plan:
+    - in_parallel:
+      - get: every-morning-at-five
+        trigger: true
+      - get: pay-ci
+      - get: pay-infra
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-concourse-bastion-test-12
+        AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection-test-12
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-for-drift
+      file: pay-ci/ci/tasks/check-for-tf-drift.yml
+      params:
+        <<: *aws_assumed_role_creds
+        DEPLOYMENT_PATH: "test/test-12/environment/bastion"
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Terraform state consistent for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+
+  - name: test-perf-1-bastion
+    serial: true
+    plan:
+    - in_parallel:
+      - get: every-morning-at-five-thirty
+        trigger: true
+      - get: pay-ci
+      - get: pay-infra
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-concourse-bastion-test-perf-1
+        AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection-test-perf-1
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-for-drift
+      file: pay-ci/ci/tasks/check-for-tf-drift.yml
+      params:
+        <<: *aws_assumed_role_creds
+        DEPLOYMENT_PATH: "test/test-perf-1/environment/bastion"
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Terraform state consistent for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -57,7 +57,7 @@ jobs:
     - task: assume-role
       file: pay-ci/ci/tasks/assume-role.yml
       params:
-        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-concourse-bastion-test-12
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-concourse-bastion-read-only-test-12
         AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection-test-12
     - load_var: role
       file: assume-role/assume-role.json
@@ -106,7 +106,7 @@ jobs:
     - task: assume-role
       file: pay-ci/ci/tasks/assume-role.yml
       params:
-        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-concourse-bastion-test-perf-1
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-concourse-bastion-read-only-test-perf-1
         AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection-test-perf-1
     - load_var: role
       file: assume-role/assume-role.json

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -76,6 +76,15 @@ jobs:
         text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
         icon_emoji: ":terraform:"
         username: pay-concourse-drift-detector
+    on_error:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Pipeline to detect drift for $BUILD_JOB_NAME failed to run <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
     on_success:
       put: slack-notification
       attempts: 10
@@ -114,6 +123,15 @@ jobs:
         channel: '#govuk-pay-starling'
         silent: true
         text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_error:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Pipeline to detect drift for $BUILD_JOB_NAME failed to run <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
         icon_emoji: ":terraform:"
         username: pay-concourse-drift-detector
     on_success:

--- a/ci/tasks/check-for-tf-drift.yml
+++ b/ci/tasks/check-for-tf-drift.yml
@@ -1,0 +1,31 @@
+---
+# This task is designed to fail if the terraform plan is not clean. You should decide what to do with that knowledge in
+# an on_failure hook
+#
+# The terraform to be planned with this must be able to be planned with no extra command line arguments
+platform: linux
+inputs:
+  - name: pay-infra
+image_resource:
+  type: registry-image
+  source:
+    repository: hashicorp/terraform
+    tag: 1.0.8
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:
+  AWS_REGION: eu-west-1
+  DEPLOYMENT_PATH:
+run:
+  path: /bin/sh
+  args:
+    - -euc
+    - |
+      cd "pay-infra/provisioning/terraform/deployments/${DEPLOYMENT_PATH}"
+      terraform init
+      # --detailed-exitcode returns:
+      #  0 on Success with empty diff
+      #  1 on error
+      #  2 on Success with changes
+      terraform plan -no-color -detailed-exitcode


### PR DESCRIPTION
Create pipelines for test, staging, and production which check to see if the bastion plan has any changes.

This will alert us when there is a new ami available since drift will be detected. As a positive side effect we will also see if anyone changes anything without our knowledge.

See https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/infra-drift-detector for the lower-envs file having been applied. Only test-12 will work right now.

There is an accompanying PR to create the role used for this in pay-infra https://github.com/alphagov/pay-infra/pull/3545

This has only been applied in test-12 so the assume-role step will fail right now in all other jobs other than test-12.