### PR TITLE
BAU: Exit assume-role with failure on unhandled promise rejection

### DIFF
--- a/ci/scripts/assume-role.js
+++ b/ci/scripts/assume-role.js
@@ -19,4 +19,9 @@ const run = async function run () {
   }))
 }
 
+process.on('unhandledRejection', error => {
+  console.log('unhandledRejection, assume role failed: ', error.message)
+  process.exit(1)
+})
+
 run()


### PR DESCRIPTION
When assume role fails the node script still exits with a success and so the pipeline continues onto the next step.

Given the lack of testing and the importance of this assume-role script I've just added an unhandled promise rejection causing the script to terminate with a failure.