### PR TITLE
PP-9086: Fix production account variable name

### DIFF
--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -106,7 +106,7 @@ jobs:
     - task: assume-role
       file: pay-ci/ci/tasks/assume-role.yml
       params:
-        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_production_account_id)):role/pay-concourse-bastion-read-only-production-2
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/pay-concourse-bastion-read-only-production-2
         AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection
     - load_var: role
       file: assume-role/assume-role.json


### PR DESCRIPTION
The prod account id variable name is prod, not production. This has been applied and works: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/infra-drift-detector/jobs/production-2-bastion/builds/2