### PR TITLE
PP-9231: Add concourse tasks for preparing and running codebuild

### DIFF
--- a/ci/pipelines/codebuild-e2e.yml
+++ b/ci/pipelines/codebuild-e2e.yml
@@ -1,0 +1,64 @@
+resource_types:
+  - name: pull-request
+    type: registry-image
+    source:
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
+
+resources:
+  - name: concourse-runner
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/concourse-runner
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: latest
+
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: pp-8839-spike-e2e-tests-in-codebuild
+
+jobs:
+  - name: frontend
+    plan:
+      - in_parallel:
+        - get: pay-ci
+        - get: concourse-runner
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::223851549868:role/pay-cd-pay-dev-codebuild-executor-test-12
+          AWS_ROLE_SESSION_NAME: terraform-test-assume-role-e2e-spike
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: prepare-codebuild
+        image: concourse-runner
+        file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
+        params:
+          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
+          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
+          PROJECT_UNDER_TEST: frontend
+          RELEASE_TAG_UNDER_TEST: "1734-release"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - in_parallel:
+        - task: run-codebuild-product
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/products.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        - task: run-codebuild-card
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -33,7 +33,7 @@ run:
       PAY_CI_VERSION_ID=$(
         aws s3api put-object \
           --bucket "${CODEBUILD_SOURCES_BUCKET}" \
-          --key "pay-${PROJECT_UNDER_TEST}/pay-ci.zip" \
+          --key "sources/endtoend/pay-ci.zip" \
           --body "pay-ci.zip" \
           --query 'VersionId' \
           --output 'text'

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -1,0 +1,68 @@
+---
+platform: linux
+inputs:
+  - name: pay-ci
+outputs:
+  - name: run-codebuild-configuration
+params:
+  CODEBUILD_PROJECT_NAME:
+  CODEBUILD_SOURCES_BUCKET:
+  PROJECT_UNDER_TEST:
+  RELEASE_TAG_UNDER_TEST:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:
+run:
+  path: /bin/bash
+  args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      echo "Installing zip"
+      apk add -q --no-progress zip
+      echo "Done"
+      echo
+
+      pushd "pay-ci" >> /dev/null
+      echo "Zipping pay-ci"
+      zip -qr "../pay-ci.zip" .
+      popd >> /dev/null
+
+      echo "Uploading pay-ci.zip to S3"
+      PAY_CI_VERSION_ID=$(
+        aws s3api put-object \
+          --bucket "${CODEBUILD_SOURCES_BUCKET}" \
+          --key "pay-${PROJECT_UNDER_TEST}/pay-ci.zip" \
+          --body "pay-ci.zip" \
+          --query 'VersionId' \
+          --output 'text'
+      )
+      echo "Uploaded pay-ci with version id $PAY_CI_VERSION_ID"
+      echo
+      echo "Products end to end test configuration"
+      cat <<EOF | tee ./run-codebuild-configuration/products.json
+      {
+        "projectName": "${CODEBUILD_PROJECT_NAME}",
+        "sourceVersion": "${PAY_CI_VERSION_ID}",
+        "secondarySourcesVersions": {},
+        "environmentVariables": {
+          "tag_${PROJECT_UNDER_TEST}": "${RELEASE_TAG_UNDER_TEST}",
+          "END_TO_END_TEST_SUITE": "products"
+        }
+      }
+      EOF
+
+      echo
+      echo "Card end to end test configuration"
+      cat <<EOF | tee ./run-codebuild-configuration/card.json
+      {
+        "projectName": "${CODEBUILD_PROJECT_NAME}",
+        "sourceVersion": "${PAY_CI_VERSION_ID}",
+        "secondarySourcesVersions": {},
+        "environmentVariables": {
+          "tag_${PROJECT_UNDER_TEST}": "${RELEASE_TAG_UNDER_TEST}",
+          "END_TO_END_TEST_SUITE": "card"
+        }
+      }
+      EOF

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -1,4 +1,13 @@
 ---
+# This task zips up the pay-ci repository (provided as the input pay-ci), uploads it to s3, and generates the json
+# configurations (card.json, products.json) required by the run-codebuild tasks later. The configuration includes:
+#
+#   1. The codebuild project to execute
+#   2. The source version of pay-ci on s3 (this is the version id of the s3 object that is uploaded)
+#   3. Environment variables to say which set of endtoend tests to execute, and the project and version under test
+#       (e.g. frontend 3-release)
+#
+# The json configuration is written into the run-codebuild-configuration output for a later task to use as an input
 platform: linux
 inputs:
   - name: pay-ci

--- a/ci/tasks/run-codebuild.yml
+++ b/ci/tasks/run-codebuild.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/node-runner
+inputs:
+  - name: pay-ci
+  - name: run-codebuild-configuration
+run:
+  dir: pay-ci/ci/scripts/run-codebuild/
+  path: sh
+  args:
+    - -eu
+    - -c
+    - |
+      echo "Installing NPM dependencies"
+      npm ci --quiet --production
+      echo "Running codebuild"
+      node run-codebuild.js


### PR DESCRIPTION
Add a generic task that just executes the run-codebuild script
Add a prepare task specifically to prepare the config needed by run-codebuild to run e2e tests for any project

You can see these tasks in use in this pipeline from my spike PR: https://github.com/alphagov/pay-ci/pull/581/files#diff-005891d8552095a02a99c65c922b140e9d0f5c5a3d2052c17aef93170ceff3a9

And in action in this build of my spike pipeline: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/codebuild-e2e/jobs/frontend/builds/169