### PR TITLE
PP-9226: Pipeline to build and push reverse-proxy image to ECR

### DIFF
--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -73,14 +73,12 @@ jobs:
               - -ec
               - |
                 cd reverse-proxy-src/images/proxy
-                ls -lrt
                 mkdir target
 
                 # Search pay-infra files for naxsi rules and copy to current 'target' directory
                 # See https://github.com/alphagov/pay-scripts/blob/master/images/proxy/build-latest-master.sh
                 prod_naxsi_rules_source=../../../pay-infra-src/provisioning/terraform/modules/pay_microservices_v2
                 find "$prod_naxsi_rules_source" -name \*.naxsi -exec cp {} target \;
-                ls -lrt
       - task: build-reverse-proxy-image
         privileged: true
         params:

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -1,0 +1,56 @@
+---
+resources:
+  - name: reverse-proxy-src
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-scripts
+      branch: master
+      username: alphagov-pay-ci
+      password: ((github-access-token))
+      paths:
+        # Should trigger on any changes to this folder
+        - images/proxy/*
+
+  - name: reverse-proxy-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/reverse-proxy
+      variant: release
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+
+# Builds the reverse-proxy Docker image used by end-to-end tests and pushes to ECR
+jobs:
+  - name: build-and-push-reverse-proxy-to-test-ecr
+    plan:
+      # Not sure if we need this
+      # - get: pay-ci
+      - get: reverse-proxy-src
+        trigger: true
+      - task: build-reverse-proxy-image
+        privileged: true
+        params:
+          CONTEXT: reverse-proxy-src/images/proxy/
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: vito/oci-build-task
+          inputs:
+          - name: reverse-proxy-src
+          outputs:
+          - name: image
+          run:
+            path: build
+      - put: reverse-proxy-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: latest-master

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -12,6 +12,15 @@ resources:
         # Should trigger on any changes to this folder
         - images/proxy/*
 
+  - name: pay-infra-src
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-infra
+      branch: master
+      username: alphagov-pay-ci
+      password: ((github-access-token))
+
   - name: reverse-proxy-ecr-registry-test
     type: registry-image
     icon: docker
@@ -25,6 +34,7 @@ resources:
       # Hardcode the test account registry ID for now. Needs to be a string, not a number
       aws_ecr_registry_id: "((pay_aws_test_account_id))"
       aws_region: eu-west-1
+      tag: latest-master
 
 # Builds the reverse-proxy Docker image used by end-to-end tests and pushes to ECR
 jobs:
@@ -34,6 +44,34 @@ jobs:
       # - get: pay-ci
       - get: reverse-proxy-src
         trigger: true
+      - get: pay-infra-src
+      - task: find-and-compile-naxsi-rules
+        config:
+          container_limits: { }
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          inputs:
+            - name: pay-infra-src
+            - name: reverse-proxy-src
+          outputs:
+            - name: reverse-proxy-src
+          run:
+            path: /bin/sh
+            args:
+              - -ec
+              - |
+                cd reverse-proxy-src/images/proxy
+                ls -lrt
+                mkdir target
+
+                # Search pay-infra files for naxsi rules and copy to current 'target' directory
+                # See https://github.com/alphagov/pay-scripts/blob/master/images/proxy/build-latest-master.sh
+                prod_naxsi_rules_source=../../../pay-infra-src/provisioning/terraform/modules/pay_microservices_v2
+                find "$prod_naxsi_rules_source" -name \*.naxsi -exec cp {} target \;
+                ls -lrt
       - task: build-reverse-proxy-image
         privileged: true
         params:
@@ -53,4 +91,3 @@ jobs:
       - put: reverse-proxy-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: latest-master

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -95,9 +95,10 @@ jobs:
           - name: image
           run:
             path: build
-      - put: reverse-proxy-ecr-registry-test
-        params:
-          image: image/image.tar
-      - put: reverse-proxy-dockerhub
-        params:
-          image: image/image.tar
+      - in_parallel:
+        - put: reverse-proxy-ecr-registry-test
+          params:
+            image: image/image.tar
+        - put: reverse-proxy-dockerhub
+          params:
+            image: image/image.tar

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -36,7 +36,16 @@ resources:
       aws_region: eu-west-1
       tag: latest-master
 
-# Builds the reverse-proxy Docker image used by end-to-end tests and pushes to ECR
+  - name: reverse-proxy-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/reverse-proxy
+      tag: latest-master
+      password: ((docker-password))
+      username: ((docker-username))
+
+# Builds the reverse-proxy Docker image used by end-to-end tests and pushes to ECR (and Dockerhub)
 jobs:
   - name: build-and-push-reverse-proxy-to-test-ecr
     plan:
@@ -89,5 +98,8 @@ jobs:
           run:
             path: build
       - put: reverse-proxy-ecr-registry-test
+        params:
+          image: image/image.tar
+      - put: reverse-proxy-dockerhub
         params:
           image: image/image.tar


### PR DESCRIPTION
The goal here is to replace the existing Jenkins job that does the following:
- searches the pay-infra repo for NAXSI config files
- builds the `reverse-proxy` image from the files in pay-scripts 
- copies the NAXSI files into the nginx config on the image (see [this helper script](https://github.com/alphagov/pay-scripts/blob/master/images/proxy/build-latest-master.sh))
- pushes the image to Dockerhub, for use in end-to-end tests

To replicate this, I've built a new pipeline (that will shortly include builds for some other E2E helper images), `e2e-helpers`. Here's what's included.

Resources:
- `reverse-proxy-src`: i.e. the pay-scripts repo. Changes to the `images/proxy` folder will trigger the pipeline job.
- `pay-infra-src`: i.e. the pay-infra repo. Solely used as a source of NAXSI config files.
- `reverse-proxy-ecr-registry-test`: the ECR repository we want to push to.
- `reverse-proxy-dockerhub`: the Dockerhub repository we also push to (for backwards compatibility)

Tasks:
- `find-and-compile-naxsi-rules`: takes both pay-infra and pay-scripts repos, finds the files in pay-infra and copies them into a new folder 'target' in pay-scripts, which is specified in the [Dockerfile](https://github.com/alphagov/pay-scripts/blob/master/images/proxy/Dockerfile#L19). Some wrangling of inputs and outputs means that the 'target' folder can be persisted along to the next task (hurray for the [Concourse docs](https://blog.concourse-ci.org/introduction-to-task-inputs-and-outputs/) that had an example of exactly what I wanted to do!)
- `build-reverse-proxy-image`: pretty much copied and pasted from our other image builds. The `CONTEXT` param points to the folder where the Dockerfile lives.
- `reverse-proxy-ecr-registry-test`: basic push to ECR, all the config for this is defined on the resource itself
- `reverse-proxy-dockerhub`: basic push to Dockerhub, all the config for this is defined on the resource itself

Tagging the image as `latest-master` for now - we've agreed to address versioned tagging in a later story.

The pipeline is visible on Concourse: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers. The `reverse-proxy` image built by this job has been tested in this e2e run: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/endtoend-products-e2e/builds/97.