### PR TITLE
PP-9232: Change branch name to be master, not the spike branch

### DIFF
--- a/ci/pipelines/codebuild-e2e.yml
+++ b/ci/pipelines/codebuild-e2e.yml
@@ -20,7 +20,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: pp-8839-spike-e2e-tests-in-codebuild
+      branch: master
 
 jobs:
   - name: frontend


### PR DESCRIPTION
Sadly I forgot to change the branch of pay-ci the example pipeline uses back to master now pay-ci is merged.

This PR just changes that back to master.

You can see a successful run after a set-pipeline here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/codebuild-e2e/jobs/frontend/builds/179