### PR TITLE
PP-9226: Use 'latest' tag for stubs and reverse-proxy ECR

### DIFF
--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -43,7 +43,7 @@ resources:
       # Hardcode the test account registry ID for now. Needs to be a string, not a number
       aws_ecr_registry_id: "((pay_aws_test_account_id))"
       aws_region: eu-west-1
-      tag: latest-master
+      tag: latest
 
   - name: reverse-proxy-dockerhub
     type: registry-image
@@ -67,7 +67,7 @@ resources:
       # Hardcode the test account registry ID for now. Needs to be a string, not a number
       aws_ecr_registry_id: "((pay_aws_test_account_id))"
       aws_region: eu-west-1
-      tag: latest-master
+      tag: latest
 
   - name: stubs-dockerhub
     type: registry-image


### PR DESCRIPTION
Going forward, the new CodeBuild E2E environment will use the `latest` tag for all Pay's images that aren't the candidate image. Our new `stubs` and `reverse-proxy` build jobs will use the `latest` tag for now, and we'll add numbered releases later (as these don't change very often).

Keep `latest-master` for the Dockerhub image tagging, to retain backwards compatibility.