### PR TITLE
Bau update runners

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:19.03
+FROM docker:20.10.10
 
 RUN apk add --no-cache \
   aws-cli \
@@ -10,26 +10,19 @@ RUN apk add --no-cache \
   python3 \
   ca-certificates \
   jq \
-  # dockerd dependencies
-  iptables \
-  util-linux 
-
-RUN apk add --no-cache \
   openjdk11 \
   npm \
   maven \
   tini \
-  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
-
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk
-RUN apk add glibc-2.31-r0.apk
+  # dockerd dependencies
+  iptables \
+  util-linux
 
 RUN apk add --virtual build-dependencies build-base
 
-RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.86.0/pact-1.86.0-linux-x86_64.tar.gz
-RUN tar xzf pact-1.86.0-linux-x86_64.tar.gz
-RUN rm -rf pact-1.86.0-linux-x86_64.tar.gz
+RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.86.0/pact-1.86.0-linux-x86_64.tar.gz \
+    && tar xzf pact-1.86.0-linux-x86_64.tar.gz \
+    && rm -f pact-1.86.0-linux-x86_64.tar.gz
 
 RUN ln -s /pact/bin/pact /usr/local/bin \
     && ln -s /pact/bin/pact-broker /usr/local/bin \

--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.4-alpine3.14@sha256:56c0e7c15a9cfb4359d463912ad0b54da4e73e917f00fd4fc8d73c67a93252a2
+FROM node:12.22.10-alpine3.15@sha256:f150ebf9402f0dd6a9c4cb208ed64884cfa7c8a6ccae3f749a7b12156c25ad88
 
 RUN npm install aws-sdk@^2.x.x
 RUN npm install @octokit/rest@^18.x.x


### PR DESCRIPTION
Update concourse-runner:
1. Bump to latest docker source container (the current one has multiple critical vulns)
2. Remove the things needed to build appmetrics
3. Compress 3 RUN layers into a single layer, the third layer does an rm of the file retrieved in the first RUN, this does mean it's not in the final layer of the image but it's still part of the container at a lower layer so it doesn't reduce the size as 3 layers.
4. We don't need to get some deps from the edge repo anymore since we moved to a later docker container build so just source them from the primary apk repo.

Update node-runner:
1. Bump to node 12.22.10 and alpine 3.15

# How?

## node-runner
```
$ cd ci/docker/node-runner
$ docker build -t node-runner:test .
```

## concourse-runner
```
$ cd ci/docker/concourse-runner
$ docker build -t concourse-runner:test .
```