### PR TITLE
PP-9229: Add XXX-candidate tag when pushing image to ECR

### DIFF
--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -13,4 +13,4 @@ run:
     - -ec
     - |
       RELEASE_NUMBER=$(sed 's/alpha_release-//' < git-release/.git/ref)
-      echo "${RELEASE_NUMBER}-release" > tags/tags
+      echo "${RELEASE_NUMBER}-release ${RELEASE_NUMBER}-candidate" > tags/tags


### PR DESCRIPTION
Add XXX-candidate for a future job (run-frontend-e2e) to be triggered on.
According to
https://github.com/concourse/registry-image-resource#out-push-and-tag-an-image:
```
With additional_tags given in params, the image will be pushed as each tag
listed in the file (whitespace separated).
```