### PR TITLE
BAU: Pin end-to-end tasks to use concourse-runner:0-release_2022-01-21

### DIFF
--- a/ci/tasks/endtoend/task.yml
+++ b/ci/tasks/endtoend/task.yml
@@ -5,7 +5,7 @@ image_resource:
   type: registry-image
   source:
     repository: govukpay/concourse-runner
-    tag: latest
+    tag: 0-release_2022-01-21
 inputs:
   - name: src
   - name: ci


### PR DESCRIPTION
Pin endtoend tests to use the old version of concourse-runner

It appears the endtoend tasks, when run in concourse, do not work using the newer concourse-runner. I have tested all the other pipelines and tasks and they all work. Instead of reverting everything I think it's better to pin just the endtoend tests to the older version of the concourse runner while we update the end to end tests.

It's quite strange since on my local machine and in CodeBuild the endtoend tests run well using up-to-date versions of docker and docker-compose.

A run with this image tag in use for card end to end tests can be seen: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/card-frontend-card-e2e/builds/11
A run with this image tag in use for products endtoend tests can be seen: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/endtoend-products-e2e/builds/100