### PR TITLE
PP-9229: Push to candidate ECR resource

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -985,13 +985,17 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: tags/tags
+      - put: frontend-candidate-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: tags/candidate-tag
 
   - name: run-frontend-e2e
     plan:
       - in_parallel:
         - get: frontend-candidate-ecr-registry-test
           trigger: true
-          # passed: [push-frontend-to-test-ecr]
+          passed: [push-frontend-to-test-ecr]
         - get: pay-ci
       - in_parallel:
         - load_var: candidate_image_tag

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1034,7 +1034,9 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-
+      - put: frontend-candidate-ecr-registry-test
+        params:
+          tag: latest
 
   - name: deploy-frontend
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -257,6 +257,13 @@ resources:
       repository: govukpay/frontend
       variant: candidate
       <<: *aws_test_config
+  - name: frontend-latest-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/frontend
+      tag: latest
+      <<: *aws_test_config
   - name: adminusers-ecr-registry-test
     type: registry-image
     icon: docker
@@ -995,6 +1002,8 @@ jobs:
     plan:
       - in_parallel:
         - get: frontend-candidate-ecr-registry-test
+          params:
+            format: oci
           trigger: true
           passed: [push-frontend-to-test-ecr]
         - get: pay-ci
@@ -1034,9 +1043,9 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - put: frontend-candidate-ecr-registry-test
+      - put: frontend-latest-ecr-registry-test
         params:
-          tag: latest
+          image: frontend-candidate-ecr-registry-test/image.tar
 
   - name: deploy-frontend
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -981,14 +981,15 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: frontend-git-release
-      - put: frontend-ecr-registry-test
-        params:
-          image: image/image.tar
-          additional_tags: tags/tags
-      - put: frontend-candidate-ecr-registry-test
-        params:
-          image: image/image.tar
-          additional_tags: tags/candidate-tag
+      - in_parallel:
+        - put: frontend-ecr-registry-test
+          params:
+            image: image/image.tar
+            additional_tags: tags/tags
+        - put: frontend-candidate-ecr-registry-test
+          params:
+            image: image/image.tar
+            additional_tags: tags/candidate-tag
 
   - name: run-frontend-e2e
     plan:

--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -13,4 +13,5 @@ run:
     - -ec
     - |
       RELEASE_NUMBER=$(sed 's/alpha_release-//' < git-release/.git/ref)
-      echo "${RELEASE_NUMBER}-release ${RELEASE_NUMBER}-candidate" > tags/tags
+      echo "${RELEASE_NUMBER}-release" > tags/tags
+      echo "${RELEASE_NUMBER}-candidate" > tags/candidate-tag


### PR DESCRIPTION
This will give a clearer visualisation of the journey. 

Puts the candidate and release tags into separate files, for use by different `put` jobs (that can be run in parallel).