### PR TITLE
PP-9233: Add adminusers e2e tests

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1284,6 +1284,24 @@ jobs:
       - put: adminusers-latest-ecr-registry-test
         params:
           image: adminusers-candidate-ecr-registry-test/image.tar
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: adminusers candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: adminusers candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: deploy-adminusers
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -271,6 +271,20 @@ resources:
       repository: govukpay/adminusers
       variant: release
       <<: *aws_test_config
+  - name: adminusers-candidate-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      variant: candidate
+      <<: *aws_test_config
+  - name: adminusers-latest-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      tag: latest
+      <<: *aws_test_config
   - name: cardid-ecr-registry-test
     type: registry-image
     icon: docker
@@ -506,6 +520,7 @@ groups:
   - name: adminusers
     jobs:
       - push-adminusers-to-test-ecr
+      - run-adminusers-e2e
       - deploy-adminusers
       - smoke-test-adminusers
       - adminusers-pact-tag
@@ -1219,10 +1234,57 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: adminusers-git-release
-      - put: adminusers-ecr-registry-test
+      - in_parallel:
+        - put: adminusers-ecr-registry-test
+          params:
+            image: image/image.tar
+            additional_tags: tags/tags
+        - put: adminusers-candidate-ecr-registry-test
+          params:
+            image: image/image.tar
+            additional_tags: tags/candidate-tag
+
+  - name: run-adminusers-e2e
+    plan:
+      - in_parallel:
+        - get: adminusers-candidate-ecr-registry-test
+          params:
+            format: oci
+          trigger: true
+          passed: [push-adminusers-to-test-ecr]
+        - get: pay-ci
+      - in_parallel:
+        - load_var: candidate_image_tag
+          file: adminusers-candidate-ecr-registry-test/tag
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
+            AWS_ROLE_SESSION_NAME: e2e-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: prepare-codebuild
+        file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          image: image/image.tar
-          additional_tags: tags/tags
+          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
+          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
+          PROJECT_UNDER_TEST: adminusers
+          RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: run-codebuild-card
+        file: pay-ci/ci/tasks/run-codebuild.yml
+        params:
+          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - put: adminusers-latest-ecr-registry-test
+        params:
+          image: adminusers-candidate-ecr-registry-test/image.tar
+
   - name: deploy-adminusers
     serial: true
     serial_groups: [deploy-application]


### PR DESCRIPTION
Add adminusers e2e tests post-push-to-ecr.

You can see it working here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/run-adminusers-e2e/builds/2

In the run-codebuld-card in that run you can see the config it's running with:

```
{
    "projectName": "endtoend-tests-test-12",
    "sourceVersion": "vvfUv6.27zgHmpqp5dkQH48PUHNf7NnJ",
    "secondarySourcesVersions": {},
    "environmentVariables": {
        "tag_adminusers": "1091-candidate",
        "END_TO_END_TEST_SUITE": "card"
    }
}
```
and also that it started up the container with the correct image version:

```
9f6b62d2afd0   <aws-test-registry-uri>/govukpay/adminusers:1091-candidate         "tini -e 143 -- bash…"   About a minute ago   Up About a minute (healthy)   8080-8081/tcp             card_adminusers_1
```
