### PR TITLE
PP-9233: Add selfservice e2e tests

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -348,6 +348,20 @@ resources:
       repository: govukpay/selfservice
       variant: release
       <<: *aws_test_config
+  - name: selfservice-candidate-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/selfservice
+      variant: candidate
+      <<: *aws_test_config
+  - name: selfservice-latest-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/selfservice
+      tag: latest
+      <<: *aws_test_config
   - name: carbon-relay-ecr-registry-test
     type: registry-image
     icon: docker
@@ -593,6 +607,7 @@ groups:
   - name: selfservice
     jobs:
       - push-selfservice-to-test-ecr
+      - run-selfservice-e2e
       - deploy-selfservice
       - smoke-test-selfservice
       - selfservice-pact-tag
@@ -2593,6 +2608,7 @@ jobs:
         params:
           image: publicauth-ecr-registry-test/image.tar
           additional_tags: publicauth-ecr-registry-test/tag
+
   - name: push-selfservice-to-test-ecr
     plan:
       - get: pay-ci
@@ -2609,10 +2625,83 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: selfservice-git-release
-      - put: selfservice-ecr-registry-test
+      - in_parallel:    
+        - put: selfservice-ecr-registry-test
+          params:
+            image: image/image.tar
+            additional_tags: tags/tags
+        - put: selfservice-candidate-ecr-registry-test
+          params:
+            image: image/image.tar
+            additional_tags: tags/candidate-tag
+
+  - name: run-selfservice-e2e
+    plan:
+      - in_parallel:
+        - get: selfservice-candidate-ecr-registry-test
+          params:
+            format: oci
+          trigger: true
+          passed: [push-selfservice-to-test-ecr]
+        - get: pay-ci
+      - in_parallel:
+        - load_var: candidate_image_tag
+          file: selfservice-candidate-ecr-registry-test/tag
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
+            AWS_ROLE_SESSION_NAME: e2e-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: prepare-codebuild
+        file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          image: image/image.tar
-          additional_tags: tags/tags
+          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
+          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
+          PROJECT_UNDER_TEST: selfservice
+          RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - in_parallel:
+        - task: run-codebuild-product
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/products.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        - task: run-codebuild-card
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - put: selfservice-latest-ecr-registry-test
+        params:
+          image: selfservice-candidate-ecr-registry-test/image.tar
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: selfservice candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: selfservice candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse            
+
   - name: deploy-selfservice
     serial: true
     serial_groups: [deploy-application]


### PR DESCRIPTION
Add adminusers e2e tests post-push-to-ecr.

Example 🟢 build: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/run-selfservice-e2e/builds/5.