### PR TITLE
PP-9338: Allow repo name override per-app in e2e tests

### DIFF
--- a/ci/tasks/endtoend/card/docker-compose.yml
+++ b/ci/tasks/endtoend/card/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   publicapi:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/publicapi:${tag_publicapi:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_publicapi:-govukpay/publicapi}:${tag_publicapi:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/publicapi.env
@@ -26,7 +26,7 @@ services:
       driver: "json-file"
 
   frontend:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/frontend:${tag_frontend:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_frontend:-govukpay/frontend}:${tag_frontend:-latest-master}
     env_file: ../docker-config/frontend.env
     networks:
       pymnt_network:
@@ -41,7 +41,7 @@ services:
       driver: "json-file"
 
   frontend_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/reverse-proxy:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${image_reverse-proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/frontend.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/frontend.pymnt.localdomain.crt
@@ -87,7 +87,7 @@ services:
     mem_limit: 500M
 
   adminusers:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/adminusers:${tag_adminusers:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_adminusers:-govukpay/adminusers}:${tag_adminusers:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/adminusers.env
@@ -110,7 +110,7 @@ services:
       driver: "json-file"
 
   selfservice:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/selfservice:${tag_selfservice:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_selfservice:-govukpay/selfservice}:${tag_selfservice:-latest-master}
     env_file: ../docker-config/selfservice.env
     environment:
       - NODE_ENV=${NODE_ENV:-production}
@@ -128,7 +128,7 @@ services:
       driver: "json-file"
 
   selfservice_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/reverse-proxy:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${image_reverse-proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/selfservice.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/selfservice.pymnt.localdomain.crt
@@ -149,7 +149,7 @@ services:
       driver: "json-file"
       
   connector:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/connector:${tag_connector:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_connector:-govukpay/connector}:${tag_connector:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/connector.env
@@ -174,7 +174,7 @@ services:
       driver: "json-file"
 
   ledger:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/ledger:${tag_ledger:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_ledger:-govukpay/ledger}:${tag_ledger:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/ledger.env
@@ -197,7 +197,7 @@ services:
     logging:
       driver: "json-file"
   publicauth:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/publicauth:${tag_publicauth:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_publicauth:-govukpay/publicauth}:${tag_publicauth:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/publicauth.env
@@ -220,7 +220,7 @@ services:
       driver: "json-file"
 
   stubs:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/stubs:${tag_stubs:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_stubs:-govukpay/stubs}:${tag_stubs:-latest-master}
     env_file: ../docker-config/stubs.env
     networks:
       pymnt_network:
@@ -231,7 +231,7 @@ services:
       driver: "json-file"
 
   stubs_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/reverse-proxy:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${image_reverse-proxy:-govukpay/reverse-proxy}:latest-master
     volumes:
       - "./../docker-config/ssl:/ssl"
     environment:
@@ -250,7 +250,7 @@ services:
       driver: "json-file"
 
   cardid:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/cardid:${tag_cardid:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_cardid:-govukpay/cardid}:${tag_cardid:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/cardid.env
@@ -267,7 +267,7 @@ services:
     logging:
       driver: "json-file"
   endtoend:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/endtoend:${tag_endtoend:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${image_endtoend:-govukpay/endtoend}:${tag_endtoend:-latest-master}
     env_file: ../docker-config/endtoend.env
     environment:
       - MAVEN_OPTS=${END_TO_END_JAVA_OPTS}

--- a/ci/tasks/endtoend/card/docker-compose.yml
+++ b/ci/tasks/endtoend/card/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   publicapi:
-    image: ${DOCKER_REGISTRY_URI:-}${image_publicapi:-govukpay/publicapi}:${tag_publicapi:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_publicapi:-govukpay/publicapi}:${tag_publicapi:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/publicapi.env
@@ -26,7 +26,7 @@ services:
       driver: "json-file"
 
   frontend:
-    image: ${DOCKER_REGISTRY_URI:-}${image_frontend:-govukpay/frontend}:${tag_frontend:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_frontend:-govukpay/frontend}:${tag_frontend:-latest-master}
     env_file: ../docker-config/frontend.env
     networks:
       pymnt_network:
@@ -41,7 +41,7 @@ services:
       driver: "json-file"
 
   frontend_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}${image_reverse-proxy:-govukpay/reverse-proxy}:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse_proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/frontend.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/frontend.pymnt.localdomain.crt
@@ -87,7 +87,7 @@ services:
     mem_limit: 500M
 
   adminusers:
-    image: ${DOCKER_REGISTRY_URI:-}${image_adminusers:-govukpay/adminusers}:${tag_adminusers:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_adminusers:-govukpay/adminusers}:${tag_adminusers:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/adminusers.env
@@ -110,7 +110,7 @@ services:
       driver: "json-file"
 
   selfservice:
-    image: ${DOCKER_REGISTRY_URI:-}${image_selfservice:-govukpay/selfservice}:${tag_selfservice:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_selfservice:-govukpay/selfservice}:${tag_selfservice:-latest-master}
     env_file: ../docker-config/selfservice.env
     environment:
       - NODE_ENV=${NODE_ENV:-production}
@@ -128,7 +128,7 @@ services:
       driver: "json-file"
 
   selfservice_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}${image_reverse-proxy:-govukpay/reverse-proxy}:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse_proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/selfservice.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/selfservice.pymnt.localdomain.crt
@@ -149,7 +149,7 @@ services:
       driver: "json-file"
       
   connector:
-    image: ${DOCKER_REGISTRY_URI:-}${image_connector:-govukpay/connector}:${tag_connector:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_connector:-govukpay/connector}:${tag_connector:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/connector.env
@@ -174,7 +174,7 @@ services:
       driver: "json-file"
 
   ledger:
-    image: ${DOCKER_REGISTRY_URI:-}${image_ledger:-govukpay/ledger}:${tag_ledger:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_ledger:-govukpay/ledger}:${tag_ledger:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/ledger.env
@@ -197,7 +197,7 @@ services:
     logging:
       driver: "json-file"
   publicauth:
-    image: ${DOCKER_REGISTRY_URI:-}${image_publicauth:-govukpay/publicauth}:${tag_publicauth:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_publicauth:-govukpay/publicauth}:${tag_publicauth:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/publicauth.env
@@ -220,7 +220,7 @@ services:
       driver: "json-file"
 
   stubs:
-    image: ${DOCKER_REGISTRY_URI:-}${image_stubs:-govukpay/stubs}:${tag_stubs:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_stubs:-govukpay/stubs}:${tag_stubs:-latest-master}
     env_file: ../docker-config/stubs.env
     networks:
       pymnt_network:
@@ -231,7 +231,7 @@ services:
       driver: "json-file"
 
   stubs_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}${image_reverse-proxy:-govukpay/reverse-proxy}:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse_proxy:-govukpay/reverse-proxy}:latest-master
     volumes:
       - "./../docker-config/ssl:/ssl"
     environment:
@@ -250,7 +250,7 @@ services:
       driver: "json-file"
 
   cardid:
-    image: ${DOCKER_REGISTRY_URI:-}${image_cardid:-govukpay/cardid}:${tag_cardid:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_cardid:-govukpay/cardid}:${tag_cardid:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/cardid.env
@@ -267,7 +267,7 @@ services:
     logging:
       driver: "json-file"
   endtoend:
-    image: ${DOCKER_REGISTRY_URI:-}${image_endtoend:-govukpay/endtoend}:${tag_endtoend:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_endtoend:-govukpay/endtoend}:${tag_endtoend:-latest-master}
     env_file: ../docker-config/endtoend.env
     environment:
       - MAVEN_OPTS=${END_TO_END_JAVA_OPTS}

--- a/ci/tasks/endtoend/products/docker-compose.yml
+++ b/ci/tasks/endtoend/products/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   publicapi:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/publicapi:${tag_publicapi:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_publicapi:-govukpay/publicapi}:${tag_publicapi:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/publicapi.env
@@ -26,7 +26,7 @@ services:
       driver: "json-file"
 
   frontend:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/frontend:${tag_frontend:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_frontend:-govukpay/frontend}:${tag_frontend:-latest-master}
     env_file: ../docker-config/frontend.env
     networks:
       pymnt_network:
@@ -41,7 +41,7 @@ services:
       driver: "json-file"
 
   frontend_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/reverse-proxy:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse-proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/frontend.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/frontend.pymnt.localdomain.crt
@@ -87,7 +87,7 @@ services:
     mem_limit: 500M
 
   adminusers:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/adminusers:${tag_adminusers:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_adminusers:-govukpay/adminusers}:${tag_adminusers:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/adminusers.env
@@ -110,7 +110,7 @@ services:
       driver: "json-file"
 
   selfservice:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/selfservice:${tag_selfservice:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_selfservice:-govukpay/selfservice}:${tag_selfservice:-latest-master}
     env_file: ../docker-config/selfservice.env
     environment:
       - NODE_ENV=${NODE_ENV:-production}
@@ -128,7 +128,7 @@ services:
       driver: "json-file"
 
   selfservice_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/reverse-proxy:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse-proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/selfservice.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/selfservice.pymnt.localdomain.crt
@@ -149,7 +149,7 @@ services:
       driver: "json-file"
       
   connector:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/connector:${tag_connector:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_connector:-govukpay/connector}:${tag_connector:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/connector.env
@@ -174,7 +174,7 @@ services:
       driver: "json-file"
 
   ledger:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/ledger:${tag_ledger:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_ledger:-govukpay/ledger}:${tag_ledger:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/ledger.env
@@ -197,7 +197,7 @@ services:
     logging:
       driver: "json-file"
   publicauth:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/publicauth:${tag_publicauth:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_publicauth:-govukpay/publicauth}:${tag_publicauth:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/publicauth.env
@@ -220,7 +220,7 @@ services:
       driver: "json-file"
 
   stubs:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/stubs:${tag_stubs:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_stubs:-govukpay/stubs}:${tag_stubs:-latest-master}
     env_file: ../docker-config/stubs.env
     networks:
       pymnt_network:
@@ -231,7 +231,7 @@ services:
       driver: "json-file"
 
   stubs_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/reverse-proxy:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse-proxy:-govukpay/reverse-proxy}:latest-master
     volumes:
       - "./../docker-config/ssl:/ssl"
     environment:
@@ -250,7 +250,7 @@ services:
       driver: "json-file"
 
   cardid:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/cardid:${tag_cardid:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_cardid:-govukpay/cardid}:${tag_cardid:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/cardid.env
@@ -268,7 +268,7 @@ services:
       driver: "json-file"
 
   products:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/products:${tag_products:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_products:-govukpay/products}:${tag_products:-latest-master}
     env_file:
       - ../docker-config/java_app.env
       - ../docker-config/products.env
@@ -291,7 +291,7 @@ services:
       driver: "json-file"
 
   productsui:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/products-ui:${tag_productsui:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_products-ui:-govukpay/products-ui}:${tag_productsui:-latest-master}
     env_file: ../docker-config/productsui.env
     environment:
       - NODE_ENV=${NODE_ENV:-production}
@@ -310,7 +310,7 @@ services:
       driver: "json-file"
 
   endtoend:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/endtoend:${tag_endtoend:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_endtoend:-govukpay/endtoend}:${tag_endtoend:-latest-master}
     env_file: ../docker-config/endtoend.env
     environment:
       - MAVEN_OPTS=${END_TO_END_JAVA_OPTS}

--- a/ci/tasks/endtoend/products/docker-compose.yml
+++ b/ci/tasks/endtoend/products/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       driver: "json-file"
 
   frontend_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse-proxy:-govukpay/reverse-proxy}:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse_proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/frontend.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/frontend.pymnt.localdomain.crt
@@ -128,7 +128,7 @@ services:
       driver: "json-file"
 
   selfservice_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse-proxy:-govukpay/reverse-proxy}:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse_proxy:-govukpay/reverse-proxy}:latest-master
     environment:
       - KEY_FILE=/ssl/keys/selfservice.pymnt.localdomain.key
       - CERT_FILE=/ssl/certs/selfservice.pymnt.localdomain.crt
@@ -231,7 +231,7 @@ services:
       driver: "json-file"
 
   stubs_proxy:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse-proxy:-govukpay/reverse-proxy}:latest-master
+    image: ${DOCKER_REGISTRY_URI:-}${repo_reverse_proxy:-govukpay/reverse-proxy}:latest-master
     volumes:
       - "./../docker-config/ssl:/ssl"
     environment:
@@ -291,7 +291,7 @@ services:
       driver: "json-file"
 
   productsui:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_products-ui:-govukpay/products-ui}:${tag_productsui:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_products_ui:-govukpay/products-ui}:${tag_productsui:-latest-master}
     env_file: ../docker-config/productsui.env
     environment:
       - NODE_ENV=${NODE_ENV:-production}


### PR DESCRIPTION
When we build PR images we are going to push them to a single ECR repo no matter what the app is (this is to make it easy to expire them when there are a lot, and to not mix the images with the candidate and released images).

This PR allows end-to-end tests to override the repo name for any single app and allow all apps to default to their original repo name

This build had the pipeline set for this branch so was using these docker files: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/run-frontend-e2e/builds/14