### PR TITLE
BAU: Remove inappropriately placed log line

### DIFF
--- a/ci/scripts/run-codebuild/libs/executor.js
+++ b/ci/scripts/run-codebuild/libs/executor.js
@@ -12,7 +12,6 @@ function printBuildSummary (build) {
   const durationMinutes = Math.floor(durationSeconds / 60)
   const durationSecondsRemaining = Math.round(durationSeconds % 60)
 
-  console.log(`Sent command to start build ${build.buildNumber} for ${build.projectName} at ${build.startTime}`)
   console.log('|----------------------------------------------------------------------------')
   console.log('| Build info')
   console.log('|----------------------------------------------------------------------------')


### PR DESCRIPTION
This build info is printed at the end of the codebuild, the logging about sending the command to start is printed by the libs/codebuild-runner class at the start of the build.

Remove this inappropriately placed log.