### PR TITLE
PP-9338: Disable slack notifications for e2e tests

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1121,24 +1121,24 @@ jobs:
       - put: frontend-latest-ecr-registry-test
         params:
           image: frontend-candidate-ecr-registry-test/image.tar
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: frontend candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: frontend candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+#    on_failure:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-announce'
+#        silent: true
+#        text: ':red-circle: frontend candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
+#    on_success:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-activity'
+#        silent: true
+#        text: ':green-circle: frontend candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
 
   - name: deploy-frontend
     serial: true
@@ -1362,24 +1362,24 @@ jobs:
       - put: adminusers-latest-ecr-registry-test
         params:
           image: adminusers-candidate-ecr-registry-test/image.tar
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: adminusers candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: adminusers candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+#    on_failure:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-announce'
+#        silent: true
+#        text: ':red-circle: adminusers candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
+#    on_success:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-activity'
+#        silent: true
+#        text: ':green-circle: adminusers candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
 
   - name: deploy-adminusers
     serial: true
@@ -1634,24 +1634,24 @@ jobs:
       - put: connector-latest-ecr-registry-test
         params:
           image: connector-candidate-ecr-registry-test/image.tar
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: connector candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: connector candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+#    on_failure:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-announce'
+#        silent: true
+#        text: ':red-circle: connector candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
+#    on_success:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-activity'
+#        silent: true
+#        text: ':green-circle: connector candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
 
   - name: deploy-connector
     serial: true
@@ -1905,24 +1905,24 @@ jobs:
       - put: ledger-latest-ecr-registry-test
         params:
           image: ledger-candidate-ecr-registry-test/image.tar
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: ledger candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: ledger candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+#    on_failure:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-announce'
+#        silent: true
+#        text: ':red-circle: ledger candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
+#    on_success:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-activity'
+#        silent: true
+#        text: ':green-circle: ledger candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
 
   - name: deploy-ledger
     serial: true
@@ -2877,24 +2877,24 @@ jobs:
       - put: selfservice-latest-ecr-registry-test
         params:
           image: selfservice-candidate-ecr-registry-test/image.tar
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: selfservice candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: selfservice candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse            
+#    on_failure:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-announce'
+#        silent: true
+#        text: ':red-circle: selfservice candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
+#    on_success:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-activity'
+#        silent: true
+#        text: ':green-circle: selfservice candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse            
 
   - name: deploy-selfservice
     serial: true
@@ -3143,24 +3143,24 @@ jobs:
       - put: cardid-latest-ecr-registry-test
         params:
           image: cardid-candidate-ecr-registry-test/image.tar
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: cardid candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: cardid candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+#    on_failure:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-announce'
+#        silent: true
+#        text: ':red-circle: cardid candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
+#    on_success:
+#      put: slack-notification
+#      attempts: 10
+#      params:
+#        channel: '#govuk-pay-activity'
+#        silent: true
+#        text: ':green-circle: cardid candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#        icon_emoji: ":concourse:"
+#        username: pay-concourse
 
   - name: deploy-cardid
     serial: true


### PR DESCRIPTION
While we are developing the new e2e tests it's proving to be noisy, so disable the notifications for now.