### PR TITLE
PP-9338: Remove need for codebuild project name and bucket for e2e tests

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1156,8 +1156,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: frontend
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -1405,8 +1403,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: adminusers
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -1677,8 +1673,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: connector
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -1948,8 +1942,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: ledger
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -2220,8 +2212,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: products
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -2491,8 +2481,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: products-ui
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -2721,8 +2709,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: publicapi
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -2959,8 +2945,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: publicauth
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -3183,8 +3167,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: selfservice
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -3457,8 +3439,6 @@ jobs:
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
-          CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-          CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
           PROJECT_UNDER_TEST: cardid
           RELEASE_TAG_UNDER_TEST: ((.:candidate_image_tag))
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -68,7 +68,7 @@ run:
       echo "Card end to end test configuration"
       cat <<EOF | tee ./run-codebuild-configuration/card.json
       {
-        "projectName": "${CODEBUILD_PROJECT_NAME}",
+        "projectName": "endtoend-tests-test-12",
         "sourceVersion": "${PAY_CI_VERSION_ID}",
         "secondarySourcesVersions": {},
         "environmentVariables": {

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -18,8 +18,6 @@ inputs:
 outputs:
   - name: run-codebuild-configuration
 params:
-  CODEBUILD_PROJECT_NAME:
-  CODEBUILD_SOURCES_BUCKET:
   PROJECT_UNDER_TEST:
   RELEASE_TAG_UNDER_TEST:
   AWS_ACCESS_KEY_ID:
@@ -45,7 +43,7 @@ run:
       echo "Uploading pay-ci.zip to S3"
       PAY_CI_VERSION_ID=$(
         aws s3api put-object \
-          --bucket "${CODEBUILD_SOURCES_BUCKET}" \
+          --bucket "pay-govuk-codebuild-test-12" \
           --key "sources/endtoend/pay-ci.zip" \
           --body "pay-ci.zip" \
           --query 'VersionId' \
@@ -56,7 +54,7 @@ run:
       echo "Products end to end test configuration"
       cat <<EOF | tee ./run-codebuild-configuration/products.json
       {
-        "projectName": "${CODEBUILD_PROJECT_NAME}",
+        "projectName": "endtoend-tests-test-12",
         "sourceVersion": "${PAY_CI_VERSION_ID}",
         "secondarySourcesVersions": {},
         "environmentVariables": {


### PR DESCRIPTION
The task is specifically for e2e tests, and in the final design we only need a single codebuild repo and bucket for all e2e tests so we can remove those params and hard code this. This reduces a lot of repetition (of which there is plenty enough already in these yaml files)

There is a build running with this change against this branch here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/run-frontend-e2e/builds/17