### PR TITLE
Pp 9338 run pr e2e tests in codebuild

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -506,8 +506,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      # branch: master
-      branch: pp-9338-run-pr-e2e-tests-in-codebuild
+      branch: master
       username: alphagov-pay-ci
       password: ((github-access-token))
 

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -884,44 +884,82 @@ jobs:
       - <<: *build-docker-image
         params:
           app_name: endtoend
-      - task: get-docker-image-info
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: govukpay/concourse-runner
-          inputs:
-            - name: src
-          outputs:
-            - name: image_info
-          run:
-            path: /bin/bash
-            args:
-              - -ec
-              - |
-                mkdir -p image_info/
+      - in_parallel:
+        - task: get-docker-image-info
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source:
+                repository: govukpay/concourse-runner
+            inputs:
+              - name: src
+            outputs:
+              - name: image_info
+            run:
+              path: /bin/bash
+              args:
+                - -ec
+                - |
+                  mkdir -p image_info/
 
-                PR_NUMBER=$(cat src/.git/resource/pr)
-                HEAD_SHA=$(cat src/.git/resource/head_sha)
+                  PR_NUMBER=$(cat src/.git/resource/pr)
+                  HEAD_SHA=$(cat src/.git/resource/head_sha)
 
-                # We cannot access the concourse build number in a task but we need a unique
-                # tag for our build so lets just use a UUIDv4
-                BUILD_UUID=$(uuidgen -r)
+                  # We cannot access the concourse build number in a task but we need a unique
+                  # tag for our build so lets just use a UUIDv4
+                  BUILD_UUID=$(uuidgen -r)
 
-                echo "endtoend-pr-${PR_NUMBER}-uuid-${BUILD_UUID}" | tee image_info/tag
-                echo "image-endtoend-PR-${PR_NUMBER}-GIT-SHA-${HEAD_SHA}.tar" | tee image_info/image_filename
-      - load_var: image_filename
-        file: image_info/image_filename
-      - put: pull-request-builds-ecr
+                  echo "endtoend-pr-${PR_NUMBER}-uuid-${BUILD_UUID}" | tee image_info/tag
+                  echo "image-endtoend-PR-${PR_NUMBER}-GIT-SHA-${HEAD_SHA}.tar" | tee image_info/image_filename
+        - task: assume-role
+          file: ci/ci/tasks/assume-role.yml
+          input_mapping:
+            pay-ci: ci
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
+            AWS_ROLE_SESSION_NAME: e2e-test-assume-role
+      - in_parallel:
+        - load_var: role
+          file: assume-role/assume-role.json
+        - load_var: image_filename
+          file: image_info/image_filename
+        - load_var: image_tag
+          file: image_info/tag
+      - in_parallel:
+        - put: pull-request-builds-ecr
+          params:
+            image: local_image/((.:image_filename))
+            additional_tags: image_info/tag
+          get_params:
+            skip_download: true
+        - task: prepare-codebuild
+          file: ci/ci/tasks/prepare-e2e-codebuild.yml
+          input_mapping:
+            pay-ci: ci
+          params:
+            PR_BUILD: true
+            CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
+            CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
+            PROJECT_UNDER_TEST: endtoend
+            RELEASE_TAG_UNDER_TEST: ((.:image_tag))
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: run-codebuild
+        file: ci/ci/tasks/run-codebuild.yml
+        input_mapping:
+          pay-ci: ci
         params:
-          image: local_image/((.:image_filename))
-          additional_tags: image_info/tag
-        on_failure:
-          <<: *put-card-e2e-failed-status
-          put: endtoend-pull-request
+          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - <<: *put-card-e2e-success-status
         put: endtoend-pull-request
+    on_failure:
+      <<: *put-card-e2e-failed-status
+      put: endtoend-pull-request
 
   - <<: *job-definition
     name: record-endtoend-build-time

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -454,6 +454,20 @@ resource_types:
       repository: govukpay/concourse-s3-resource
 
 resources:
+  - name: pull-request-builds-ecr
+    type: registry-image
+    icon: dockerhub
+    source:
+      repository: govukpay/pull-request-builds
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      # Hardcode the test account registry ID for now. Needs to be a string, not a number
+      aws_ecr_registry_id: "((pay_aws_test_account_id))"
+      aws_region: eu-west-1
+      tag: latest
+
   - name: card-connector-master
     type: git
     icon: github
@@ -862,20 +876,47 @@ jobs:
     plan:
       - <<: *get-pull-request
         resource: endtoend-pull-request
-      - <<: *get-ci
-      - <<: *put-card-e2e-pending-status
-        put: endtoend-pull-request
+      - in_parallel:
+        - <<: *get-ci
+        - <<: *put-card-e2e-pending-status
+          put: endtoend-pull-request
       - <<: *run-java-package
       - <<: *build-docker-image
         params:
           app_name: endtoend
-      - <<: *get-all-docker-images
-      - <<: *run-e2e
-        input_mapping:
-          docker/endtoend: local_image
+      - task: get-docker-image-info
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/concourse-runner
+          inputs:
+            - name: src
+          outputs:
+            - name: image_info
+          run:
+            path: /bin/bash
+            args:
+              - -ec
+              - |
+                mkdir -p image_info/
+
+                PR_NUMBER=$(cat src/.git/resource/pr)
+                HEAD_SHA=$(cat src/.git/resource/head_sha)
+
+                # We cannot access the concourse build number in a task but we need a unique
+                # tag for our build so lets just use a UUIDv4
+                BUILD_UUID=$(uuidgen -r)
+
+                echo "endtoend-pr-${PR_NUMBER}-uuid-${BUILD_UUID}" | tee image_info/tag
+                echo "image-endtoend-PR-${PR_NUMBER}-GIT-SHA-${HEAD_SHA}.tar" | tee image_info/image_filename
+      - load_var: image_filename
+        file: image_info/image_filename
+      - put: pull-request-builds-ecr
         params:
-          app_name: endtoend
-          test_type: card
+          image: local_image/((.:image_filename))
+          additional_tags: image_info/tag
         on_failure:
           <<: *put-card-e2e-failed-status
           put: endtoend-pull-request

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -916,8 +916,6 @@ jobs:
             pay-ci: ci
           params:
             PR_BUILD: true
-            CODEBUILD_PROJECT_NAME: endtoend-tests-test-12
-            CODEBUILD_SOURCES_BUCKET: pay-govuk-codebuild-test-12
             PROJECT_UNDER_TEST: endtoend
             RELEASE_TAG_UNDER_TEST: ((.:image_tag))
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -886,32 +886,9 @@ jobs:
           app_name: endtoend
       - in_parallel:
         - task: get-docker-image-info
-          config:
-            platform: linux
-            image_resource:
-              type: registry-image
-              source:
-                repository: govukpay/concourse-runner
-            inputs:
-              - name: src
-            outputs:
-              - name: image_info
-            run:
-              path: /bin/bash
-              args:
-                - -ec
-                - |
-                  mkdir -p image_info/
-
-                  PR_NUMBER=$(cat src/.git/resource/pr)
-                  HEAD_SHA=$(cat src/.git/resource/head_sha)
-
-                  # We cannot access the concourse build number in a task but we need a unique
-                  # tag for our build so lets just use a UUIDv4
-                  BUILD_UUID=$(uuidgen -r)
-
-                  echo "endtoend-pr-${PR_NUMBER}-uuid-${BUILD_UUID}" | tee image_info/tag
-                  echo "image-endtoend-PR-${PR_NUMBER}-GIT-SHA-${HEAD_SHA}.tar" | tee image_info/image_filename
+          file: ci/ci/tasks/get-pr-build-docker-image-info.yml
+          params:
+            app_name: endtoend
         - task: assume-role
           file: ci/ci/tasks/assume-role.yml
           input_mapping:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -456,7 +456,7 @@ resource_types:
 resources:
   - name: pull-request-builds-ecr
     type: registry-image
-    icon: dockerhub
+    icon: docker
     source:
       repository: govukpay/pull-request-builds
       aws_access_key_id: ((readonly_access_key_id))
@@ -506,7 +506,8 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      # branch: master
+      branch: pp-9338-run-pr-e2e-tests-in-codebuild
       username: alphagov-pay-ci
       password: ((github-access-token))
 

--- a/ci/tasks/get-pr-build-docker-image-info.yml
+++ b/ci/tasks/get-pr-build-docker-image-info.yml
@@ -1,0 +1,43 @@
+---
+# This task runs after a PR end to end test job has created an image build.
+#
+# The task parses information from the source repo to produce unique image tag name and
+# also to put the image filename into a file which can be used by an image-registry put.
+#
+# The 2 files created from this are:
+#
+# image_info/tag - Contains the unique tag to apply to the docker image when pushing to a registry
+# image_info/image_filename - The filename which the built image has been written to
+#
+# It uses a single param:
+#
+# app_name - The name of the app under test, this is used as part of the unique tag name and the filename
+
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/concourse-runner
+inputs:
+  - name: src
+outputs:
+  - name: image_info
+params:
+  app_name:
+run:
+  path: /bin/bash
+  args:
+    - -ec
+    - |
+      mkdir -p image_info/
+
+      pr_number=$(cat src/.git/resource/pr)
+      head_sha=$(cat src/.git/resource/head_sha)
+
+      # We cannot access the concourse build number in a task but we need a unique
+      # tag for our build so lets just use a UUIDv4
+      build_uuid=$(uuidgen -r)
+
+      echo "${app_name}-pr-${pr_number}-uuid-${build_uuid}" | tee image_info/tag
+      echo "image-${app_name}-PR-${pr_number}-GIT-SHA-${head_sha}.tar" | tee image_info/image_filename
+

--- a/ci/tasks/get-pr-build-docker-image-info.yml
+++ b/ci/tasks/get-pr-build-docker-image-info.yml
@@ -1,7 +1,7 @@
 ---
 # This task runs after a PR end to end test job has created an image build.
 #
-# The task parses information from the source repo to produce unique image tag name and
+# The task parses information from the source repo to produce a unique image tag name and
 # also to put the image filename into a file which can be used by an image-registry put.
 #
 # The 2 files created from this are:

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -20,6 +20,7 @@ outputs:
 params:
   PROJECT_UNDER_TEST:
   RELEASE_TAG_UNDER_TEST:
+  PR_BUILD: "false"
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
   AWS_SESSION_TOKEN:
@@ -49,6 +50,13 @@ run:
           --query 'VersionId' \
           --output 'text'
       )
+
+      if [ "$PR_BUILD" == "true" ]; then
+        SOURCE_REPO_CONFIG="\"repo_${PROJECT_UNDER_TEST}\": \"govukpay/pull-request-builds\","
+      else
+        SOURCE_REPO_CONFIG=""
+      fi
+
       echo "Uploaded pay-ci with version id $PAY_CI_VERSION_ID"
       echo
       echo "Products end to end test configuration"
@@ -58,6 +66,7 @@ run:
         "sourceVersion": "${PAY_CI_VERSION_ID}",
         "secondarySourcesVersions": {},
         "environmentVariables": {
+          $SOURCE_REPO_CONFIG
           "tag_${PROJECT_UNDER_TEST}": "${RELEASE_TAG_UNDER_TEST}",
           "END_TO_END_TEST_SUITE": "products"
         }
@@ -72,6 +81,7 @@ run:
         "sourceVersion": "${PAY_CI_VERSION_ID}",
         "secondarySourcesVersions": {},
         "environmentVariables": {
+          $SOURCE_REPO_CONFIG
           "tag_${PROJECT_UNDER_TEST}": "${RELEASE_TAG_UNDER_TEST}",
           "END_TO_END_TEST_SUITE": "card"
         }


### PR DESCRIPTION
This PR allows end to end tests to be run on PRs pre-merge.

Changes include:
* Modifying the prepare codebuild task to allow the repository for the app under test to be modified (in order to set it to the pull-request-builds ecr repo)
* Add a task which parses the required information about the build and puts it into files which can be used by an ecr PUT task (and also loaded into the env for later tasks)
* Modify the endtoend-card-e2e job to run in codebuild instead of directly in a concourse container.

Even through YAML anchors are used extensively in this file I've taken the active decision to not use them in this PR. When all of the remaining end to end jobs are changed there will be significantly fewer anchors and the file will be easier to comprehend, if a lot more verbose.

You can see the modified pipeline here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci?group=end_to_end
You can see a successful test run here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/endtoend-card-e2e/builds/116