### PR TITLE
Pp 9338 change pre-merge endtoend e2e tests to run in codebuild

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -850,25 +850,66 @@ jobs:
     plan:
       - <<: *get-pull-request
         resource: endtoend-pull-request
-      - <<: *get-ci
-      - <<: *put-products-e2e-pending-status
-        put: endtoend-pull-request
+      - in_parallel:
+        - <<: *get-ci
+        - <<: *put-products-e2e-pending-status
+          put: endtoend-pull-request
       - <<: *run-java-package
       - <<: *build-docker-image
         params:
           app_name: endtoend
-      - <<: *get-all-docker-images
-      - <<: *run-e2e
+      - in_parallel:
+        - task: get-docker-image-info
+          file: ci/ci/tasks/get-pr-build-docker-image-info.yml
+          params:
+            app_name: endtoend
+        - task: assume-role
+          file: ci/ci/tasks/assume-role.yml
+          input_mapping:
+            pay-ci: ci
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
+            AWS_ROLE_SESSION_NAME: e2e-test-assume-role
+      - in_parallel:
+        - load_var: role
+          file: assume-role/assume-role.json
+        - load_var: image_filename
+          file: image_info/image_filename
+        - load_var: image_tag
+          file: image_info/tag
+      - in_parallel:
+        - put: pull-request-builds-ecr
+          params:
+            image: local_image/((.:image_filename))
+            additional_tags: image_info/tag
+          get_params:
+            skip_download: true
+        - task: prepare-codebuild
+          file: ci/ci/tasks/prepare-e2e-codebuild.yml
+          input_mapping:
+            pay-ci: ci
+          params:
+            PR_BUILD: true
+            PROJECT_UNDER_TEST: endtoend
+            RELEASE_TAG_UNDER_TEST: ((.:image_tag))
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: run-codebuild
+        file: ci/ci/tasks/run-codebuild.yml
         input_mapping:
-          docker/endtoend: local_image
+          pay-ci: ci
         params:
-          app_name: endtoend
-          test_type: products
-        on_failure:
-          <<: *put-products-e2e-failed-status
-          put: endtoend-pull-request
+          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/products.json"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - <<: *put-products-e2e-success-status
         put: endtoend-pull-request
+
+    on_failure:
+      <<: *put-products-e2e-failed-status
+      put: endtoend-pull-request
 
   - <<: *job-definition
     name: endtoend-card-e2e

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -529,8 +529,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      # branch: master
-      branch: pp-9338-change-other-e2e-tests-to-run-in-codebuild
+      branch: master
       username: alphagov-pay-ci
       password: ((github-access-token))
 

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -180,6 +180,14 @@ definitions:
       path: src
       status: pending
       context: products e2e tests
+  - &put-e2e-pending-status
+    put: updateThisValue
+    get_params:
+      skip_download: true
+    params:
+      path: src
+      status: pending
+      context: e2e tests
   - &put-products-e2e-failed-status
     put: updateThisValue
     get_params:
@@ -188,6 +196,14 @@ definitions:
       path: src
       status: failure
       context: products e2e tests
+  - &put-e2e-failed-status
+    put: updateThisValue
+    get_params:
+      skip_download: true
+    params:
+      path: src
+      status: failure
+      context: e2e tests
   - &put-products-e2e-success-status
     put: updateThisValue
     get_params:
@@ -196,6 +212,14 @@ definitions:
       path: src
       status: success
       context: products e2e tests
+  - &put-e2e-success-status
+    put: updateThisValue
+    get_params:
+      skip_download: true
+    params:
+      path: src
+      status: success
+      context: e2e tests
   - &node-test
     task: test
     file: ci/ci/tasks/node-build-pr.yml
@@ -344,8 +368,7 @@ groups:
 
   - name: end_to_end
     jobs:
-      - endtoend-card-e2e
-      - endtoend-products-e2e
+      - endtoend-e2e
       - record-endtoend-build-time
 
   - name: publicapi
@@ -506,7 +529,8 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      # branch: master
+      branch: pp-9338-change-other-e2e-tests-to-run-in-codebuild
       username: alphagov-pay-ci
       password: ((github-access-token))
 
@@ -845,14 +869,14 @@ jobs:
     - <<: *send-pr-build-time
 
   - <<: *job-definition
-    name: endtoend-products-e2e
+    name: endtoend-e2e
     serial_groups: [e2e-test]
     plan:
       - <<: *get-pull-request
         resource: endtoend-pull-request
       - in_parallel:
         - <<: *get-ci
-        - <<: *put-products-e2e-pending-status
+        - <<: *put-e2e-pending-status
           put: endtoend-pull-request
       - <<: *run-java-package
       - <<: *build-docker-image
@@ -895,86 +919,30 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - task: run-codebuild
-        file: ci/ci/tasks/run-codebuild.yml
-        input_mapping:
-          pay-ci: ci
-        params:
-          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/products.json"
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - <<: *put-products-e2e-success-status
-        put: endtoend-pull-request
-
-    on_failure:
-      <<: *put-products-e2e-failed-status
-      put: endtoend-pull-request
-
-  - <<: *job-definition
-    name: endtoend-card-e2e
-    serial_groups: [e2e-test]
-    plan:
-      - <<: *get-pull-request
-        resource: endtoend-pull-request
       - in_parallel:
-        - <<: *get-ci
-        - <<: *put-card-e2e-pending-status
-          put: endtoend-pull-request
-      - <<: *run-java-package
-      - <<: *build-docker-image
-        params:
-          app_name: endtoend
-      - in_parallel:
-        - task: get-docker-image-info
-          file: ci/ci/tasks/get-pr-build-docker-image-info.yml
-          params:
-            app_name: endtoend
-        - task: assume-role
-          file: ci/ci/tasks/assume-role.yml
+        - task: run-card-e2e-tests
+          file: ci/ci/tasks/run-codebuild.yml
           input_mapping:
             pay-ci: ci
           params:
-            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
-            AWS_ROLE_SESSION_NAME: e2e-test-assume-role
-      - in_parallel:
-        - load_var: role
-          file: assume-role/assume-role.json
-        - load_var: image_filename
-          file: image_info/image_filename
-        - load_var: image_tag
-          file: image_info/tag
-      - in_parallel:
-        - put: pull-request-builds-ecr
-          params:
-            image: local_image/((.:image_filename))
-            additional_tags: image_info/tag
-          get_params:
-            skip_download: true
-        - task: prepare-codebuild
-          file: ci/ci/tasks/prepare-e2e-codebuild.yml
-          input_mapping:
-            pay-ci: ci
-          params:
-            PR_BUILD: true
-            PROJECT_UNDER_TEST: endtoend
-            RELEASE_TAG_UNDER_TEST: ((.:image_tag))
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - task: run-codebuild
-        file: ci/ci/tasks/run-codebuild.yml
-        input_mapping:
-          pay-ci: ci
-        params:
-          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - <<: *put-card-e2e-success-status
+        - task: run-products-e2e-tests
+          file: ci/ci/tasks/run-codebuild.yml
+          input_mapping:
+            pay-ci: ci
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/products.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - <<: *put-e2e-success-status
         put: endtoend-pull-request
+
     on_failure:
-      <<: *put-card-e2e-failed-status
+      <<: *put-e2e-failed-status
       put: endtoend-pull-request
 
   - <<: *job-definition
@@ -982,7 +950,7 @@ jobs:
     plan:
     - <<: *get-pull-request
       resource: endtoend-pull-request
-      passed: [endtoend-products-e2e, endtoend-card-e2e]
+      passed: [endtoend-e2e]
     - <<: *send-pr-build-time
 
   - <<: *job-definition


### PR DESCRIPTION
1. Change the endtoend e2e tests to run both sets of tests in parallel in a single job. 
2. Change the job name to be generic and not products/card
3. Add status sending without products/card nomenclature

Build pipeline applied:

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/endtoend-e2e/builds/2
Looks a lot cleaner too :)
<img width="774" alt="Screenshot 2022-02-28 at 10 35 20" src="https://user-images.githubusercontent.com/2170030/155968403-36d6926e-85aa-48bb-a6b1-7ba513a4f405.png">

See the build status getting reported correctly:

Pending:
<img width="849" alt="Screenshot 2022-02-28 at 09 32 04" src="https://user-images.githubusercontent.com/2170030/155968448-a4affcb9-e69c-406b-b835-7a5f7267edd8.png">

Complete:
<img width="865" alt="Screenshot 2022-02-28 at 09 46 52" src="https://user-images.githubusercontent.com/2170030/155968482-db1c2f2c-12da-432f-b1fe-0cac6aac6231.png">

An actual working build for endtoend:
https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/endtoend-e2e/builds/2
