### PR TITLE
Pp 9338 change products UI e2e tests to codebuild

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -115,39 +115,6 @@ definitions:
     passed: [updateThisValue]
     params:
       filename: image-updateThisValue-*.tar
-  - &put-card-e2e-pending-status
-    put: updateThisValue
-    get_params:
-      skip_download: true
-    params:
-      path: src
-      status: pending
-      context: card e2e tests
-  - &run-e2e
-    task: run e2e tests
-    privileged: true
-    file: ci/ci/tasks/endtoend/task.yml
-    input_mapping:
-      docker/connector: updateThisValue
-    params:
-      app_name: updateThisValue
-      test_type: updateThisValue
-  - &put-card-e2e-failed-status
-    put: card-connector-pull-request
-    get_params:
-      skip_download: true
-    params:
-      path: src
-      status: failure
-      context: card e2e tests
-  - &put-card-e2e-success-status
-    put: updateThisValue
-    get_params:
-      skip_download: true
-    params:
-      path: src
-      status: success
-      context: card e2e tests
   - &put-test-failed-status
     put: card-connector-pull-request
     get_params:
@@ -172,14 +139,6 @@ definitions:
       path: src
       status: pending
       context: test
-  - &put-products-e2e-pending-status
-    put: updateThisValue
-    get_params:
-      skip_download: true
-    params:
-      path: src
-      status: pending
-      context: products e2e tests
   - &put-e2e-pending-status
     put: updateThisValue
     get_params:
@@ -188,14 +147,6 @@ definitions:
       path: src
       status: pending
       context: e2e tests
-  - &put-products-e2e-failed-status
-    put: updateThisValue
-    get_params:
-      skip_download: true
-    params:
-      path: src
-      status: failure
-      context: products e2e tests
   - &put-e2e-failed-status
     put: updateThisValue
     get_params:
@@ -204,14 +155,6 @@ definitions:
       path: src
       status: failure
       context: e2e tests
-  - &put-products-e2e-success-status
-    put: updateThisValue
-    get_params:
-      skip_download: true
-    params:
-      path: src
-      status: success
-      context: products e2e tests
   - &put-e2e-success-status
     put: updateThisValue
     get_params:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -251,74 +251,6 @@ definitions:
       path: src
       status: failure
       context: node test
-  - &get-all-docker-images
-    in_parallel:
-      fail_fast: true
-      steps: &docker-image-list
-        - get: docker/publicapi
-          resource: publicapi
-          params:
-            format: oci
-        - get: docker/frontend
-          resource: card-frontend
-          params:
-            format: oci
-        - get: docker/reverse_proxy
-          resource: reverse_proxy
-          params:
-            format: oci
-        - get: docker/postgres
-          resource: postgres
-          params:
-            format: oci
-        - get: docker/sqs
-          resource: sqs
-          params:
-            format: oci
-        - get: docker/adminusers
-          resource: adminusers
-          params:
-            format: oci
-        - get: docker/selfservice
-          resource: selfservice
-          params:
-            format: oci
-        - get: docker/connector
-          resource: card-connector
-          params:
-            format: oci
-        - get: docker/ledger
-          resource: ledger
-          params:
-            format: oci
-        - get: docker/publicauth
-          resource: publicauth
-          params:
-            format: oci
-        - get: docker/stubs
-          resource: stubs
-          params:
-            format: oci
-        - get: docker/cardid
-          resource: cardid
-          params:
-            format: oci
-        - get: docker/endtoend
-          resource: endtoend
-          params:
-            format: oci
-        - get: docker/selenium
-          resource: selenium
-          params:
-            format: oci
-        - get: docker/products
-          resource: products
-          params:
-            format: oci
-        - get: docker/products-ui
-          resource: products-ui
-          params:
-            format: oci
   - &put-pact-provider-pending-status
     put: updateThisValue
     get_params:
@@ -422,7 +354,7 @@ groups:
   - name: products_ui
     jobs:
       - products-ui-test
-      - products-ui-products-e2e
+      - products-ui-e2e
       - products-ui-as-consumer-pact-test
       - record-products-ui-build-time
 
@@ -531,110 +463,6 @@ resources:
       branch: master
       username: alphagov-pay-ci
       password: ((github-access-token))
-
-  - &image
-    name: adminusers
-    type: registry-image
-    icon: docker
-    source: &image-source
-      repository: govukpay/adminusers
-      tag: latest-master
-      password: ((docker-password))
-      username: ((docker-username))
-
-  - <<: *image
-    name: cardid
-    source:
-      <<: *image-source
-      repository: govukpay/cardid
-
-  - <<: *image
-    name: card-connector
-    source:
-      <<: *image-source
-      repository: govukpay/connector
-
-  - <<: *image
-    name: card-frontend
-    source:
-      <<: *image-source
-      repository: govukpay/frontend
-
-  - <<: *image
-    name: ledger
-    source:
-      <<: *image-source
-      repository: govukpay/ledger
-
-  - <<: *image
-    name: publicapi
-    source:
-      <<: *image-source
-      repository: govukpay/publicapi
-
-  - <<: *image
-    name: publicauth
-    source:
-      <<: *image-source
-      repository: govukpay/publicauth
-
-  - <<: *image
-    name: products-ui
-    source:
-      <<: *image-source
-      repository: govukpay/products-ui
-
-  - <<: *image
-    name: products
-    source:
-      <<: *image-source
-      repository: govukpay/products
-
-  - <<: *image
-    name: selfservice
-    source:
-      <<: *image-source
-      repository: govukpay/selfservice
-
-  - <<: *image
-    name: reverse_proxy
-    source:
-      <<: *image-source
-      repository: govukpay/reverse-proxy
-
-  - <<: *image
-    name: stubs
-    source:
-      <<: *image-source
-      repository: govukpay/stubs
-
-  - <<: *image
-    name: sqs
-    source:
-      <<: *image-source
-      repository: roribio16/alpine-sqs
-      tag: latest
-
-  - <<: *image
-    name: postgres
-    source:
-      <<: *image-source
-      repository: postgres
-      tag: 11-alpine
-
-  - <<: *image
-    name: selenium
-    source:
-      <<: *image-source
-      repository: selenium/standalone-chrome
-      tag: 3.141.59-iron
-
-  - <<: *image
-    name: endtoend
-    source:
-      <<: *image-source
-      repository: govukpay/endtoend
-      tag: latest-master
 
   - &pull-request
     name: card-connector-pull-request
@@ -2285,34 +2113,72 @@ jobs:
       put: products-ui-pull-request
 
   - <<: *job-definition
-    name: products-ui-products-e2e
+    name: products-ui-e2e
     serial_groups: [e2e-test]
     plan:
-    - <<: *get-ci
     - <<: *get-pull-request
       resource: products-ui-pull-request
       trigger: false
-    - <<: *put-products-e2e-pending-status
-      put: products-ui-pull-request
-    - <<: *node-build
-      on_failure:
-        <<: *put-products-e2e-failed-status
+    - in_parallel:
+      - <<: *get-ci
+      - <<: *put-e2e-pending-status
         put: products-ui-pull-request
+    - <<: *node-build
     - <<: *build-docker-image
       params:
         app_name: products-ui
-    - <<: *get-all-docker-images
-    - <<: *run-e2e
+    - in_parallel:
+      - task: get-docker-image-info
+        file: ci/ci/tasks/get-pr-build-docker-image-info.yml
+        params:
+          app_name: products-ui
+      - task: assume-role
+        file: ci/ci/tasks/assume-role.yml
+        input_mapping:
+          pay-ci: ci
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
+          AWS_ROLE_SESSION_NAME: e2e-test-assume-role
+    - in_parallel:
+      - load_var: role
+        file: assume-role/assume-role.json
+      - load_var: image_filename
+        file: image_info/image_filename
+      - load_var: image_tag
+        file: image_info/tag
+    - in_parallel:
+      - put: pull-request-builds-ecr
+        params:
+          image: local_image/((.:image_filename))
+          additional_tags: image_info/tag
+        get_params:
+          skip_download: true
+      - task: prepare-codebuild
+        file: ci/ci/tasks/prepare-e2e-codebuild.yml
+        input_mapping:
+          pay-ci: ci
+        params:
+          PR_BUILD: true
+          PROJECT_UNDER_TEST: products-ui
+          RELEASE_TAG_UNDER_TEST: ((.:image_tag))
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    - task: run-products-e2e-tests
+      file: ci/ci/tasks/run-codebuild.yml
       input_mapping:
-        docker/products-ui: local_image
+        pay-ci: ci
       params:
-        app_name: productsui
-        test_type: products
-      on_failure:
-        <<: *put-products-e2e-failed-status
-        put: products-ui-pull-request
-    - <<: *put-products-e2e-success-status
+        PATH_TO_CONFIG: "../../../../run-codebuild-configuration/products.json"
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    - <<: *put-e2e-success-status
       put: products-ui-pull-request
+    on_failure:
+      <<: *put-e2e-failed-status
+      put: products-ui-pull-request
+
 
   - <<: *job-definition
     name: products-ui-as-consumer-pact-test

--- a/ci/tasks/endtoend/products/docker-compose.yml
+++ b/ci/tasks/endtoend/products/docker-compose.yml
@@ -291,7 +291,7 @@ services:
       driver: "json-file"
 
   productsui:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_products_ui:-govukpay/products-ui}:${tag_productsui:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_products_ui:-govukpay/products-ui}:${tag_products_ui:-latest-master}
     env_file: ../docker-config/productsui.env
     environment:
       - NODE_ENV=${NODE_ENV:-production}

--- a/ci/tasks/endtoend/products/docker-compose.yml
+++ b/ci/tasks/endtoend/products/docker-compose.yml
@@ -291,7 +291,7 @@ services:
       driver: "json-file"
 
   productsui:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_products_ui:-govukpay/products-ui}:${tag_products_ui:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_productsui:-govukpay/products-ui}:${tag_productsui:-latest-master}
     env_file: ../docker-config/productsui.env
     environment:
       - NODE_ENV=${NODE_ENV:-production}

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -51,14 +51,14 @@ run:
           --output 'text'
       )
 
+      # Some projects have a - in their name, for the end var this needs to be an underscore
+      PROJECT_UNDER_TEST_ENV_VAR_NAME=$(echo "$PROJECT_UNDER_TEST" | tr "-" "_")
+
       if [ "$PR_BUILD" == "true" ]; then
-        SOURCE_REPO_CONFIG="\"repo_${PROJECT_UNDER_TEST}\": \"govukpay/pull-request-builds\","
+        SOURCE_REPO_CONFIG="\"repo_${PROJECT_UNDER_TEST_ENV_VAR_NAME}\": \"govukpay/pull-request-builds\","
       else
         SOURCE_REPO_CONFIG=""
       fi
-
-      # Some projects have a - in their name, for the end var this needs to be an underscore
-      PROJECT_UNDER_TEST_ENV_VAR_NAME=$(echo "$PROJECT_UNDER_TEST" | tr "-" "_")
 
       echo "Uploaded pay-ci with version id $PAY_CI_VERSION_ID"
       echo

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -57,6 +57,9 @@ run:
         SOURCE_REPO_CONFIG=""
       fi
 
+      # Some projects have a - in their name, for the end var this needs to be an underscore
+      PROJECT_UNDER_TEST_ENV_VAR_NAME=$(echo "$PROJECT_UNDER_TEST" | tr "-" "_")
+
       echo "Uploaded pay-ci with version id $PAY_CI_VERSION_ID"
       echo
       echo "Products end to end test configuration"
@@ -67,7 +70,7 @@ run:
         "secondarySourcesVersions": {},
         "environmentVariables": {
           $SOURCE_REPO_CONFIG
-          "tag_${PROJECT_UNDER_TEST}": "${RELEASE_TAG_UNDER_TEST}",
+          "tag_${PROJECT_UNDER_TEST_ENV_VAR_NAME}": "${RELEASE_TAG_UNDER_TEST}",
           "END_TO_END_TEST_SUITE": "products"
         }
       }
@@ -82,7 +85,7 @@ run:
         "secondarySourcesVersions": {},
         "environmentVariables": {
           $SOURCE_REPO_CONFIG
-          "tag_${PROJECT_UNDER_TEST}": "${RELEASE_TAG_UNDER_TEST}",
+          "tag_${PROJECT_UNDER_TEST_ENV_VAR_NAME}": "${RELEASE_TAG_UNDER_TEST}",
           "END_TO_END_TEST_SUITE": "card"
         }
       }

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -51,8 +51,8 @@ run:
           --output 'text'
       )
 
-      # Some projects have a - in their name, for the end var this needs to be an underscore
-      PROJECT_UNDER_TEST_ENV_VAR_NAME=$(echo "$PROJECT_UNDER_TEST" | tr "-" "_")
+      # Some projects have a - in their name, for the end var this needs to be removed
+      PROJECT_UNDER_TEST_ENV_VAR_NAME=$(echo "$PROJECT_UNDER_TEST" | tr -d "-")
 
       if [ "$PR_BUILD" == "true" ]; then
         SOURCE_REPO_CONFIG="\"repo_${PROJECT_UNDER_TEST_ENV_VAR_NAME}\": \"govukpay/pull-request-builds\","


### PR DESCRIPTION
This PR changes the final set of e2e tests, I had no choice but to remove the unused resources since the pre-commit checks fail with a pipeline that has unused resources.

With products ui the project name is products-ui but env vars can't have hyphens, and in the docker-compose files they are already listed with the hyphens so I amended the prepare-codebuild task to remove any hyphens for use in env var names.

A working build can be seen in https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/products-ui-e2e/builds/4

If you expand the task `prepare-codebuild` you can see the env var renaming was successful:

<img width="862" alt="Screenshot 2022-02-28 at 15 39 33" src="https://user-images.githubusercontent.com/2170030/156012269-3893b95a-585e-4d11-b4b1-ddcfe3c4d951.png">

Additionally if you look in the run-products-e2e-tests output after the pull is complete you can see the products-ui container running with the correct image:

<img width="1396" alt="Screenshot 2022-02-28 at 15 43 07" src="https://user-images.githubusercontent.com/2170030/156014044-0e219bb4-e7c6-42e9-b478-ed0de263b786.png">