### PR TITLE
PP-9230: Add configurations for running zap endtoend tests

### DIFF
--- a/ci/tasks/endtoend/zap/docker-compose.yml
+++ b/ci/tasks/endtoend/zap/docker-compose.yml
@@ -276,6 +276,8 @@ services:
       - pymnt_network
     mem_limit: ${END_TO_END_MEM_LIMIT}
     depends_on:
+      zap:
+        condition: service_started
       selenium:
         condition: service_started
       cardid:
@@ -307,3 +309,15 @@ services:
       driver: "json-file"
     volumes:
       - /dev/shm:/dev/shm
+
+  zap:
+    image: ${DOCKER_REGISTRY_URI:-}${repo_zap:-govukpay/zap}:${tag_zap:-latest}
+    # args passed to zap.sh, which can accept -Xmx
+    # https://github.com/zaproxy/zaproxy/blob/develop/src/zap.sh#L90
+    command: "-Xmx2G"
+    networks:
+      pymnt_network:
+        aliases:
+          - zap.pymnt.localdomain
+    logging:
+      driver: "json-file"

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -90,3 +90,18 @@ run:
         }
       }
       EOF
+
+      echo
+      echo "Zap test configuration"
+      cat <<EOF | tee ./run-codebuild-configuration/zap.json
+      {
+        "projectName": "endtoend-tests-test-12",
+        "sourceVersion": "${PAY_CI_VERSION_ID}",
+        "secondarySourcesVersions": {},
+        "environmentVariables": {
+          $SOURCE_REPO_CONFIG
+          "tag_${PROJECT_UNDER_TEST_ENV_VAR_NAME}": "${RELEASE_TAG_UNDER_TEST}",
+          "END_TO_END_TEST_SUITE": "zap"
+        }
+      }
+      EOF


### PR DESCRIPTION
It seems like adding the following to the docker-compose was all that's needed
to run the zap endtoend tests locally:
```
  zap:
    image: ${DOCKER_REGISTRY_URI:-}${repo_zap:-govukpay/zap}:${tag_endtoend:-latest}
    # args passed to zap.sh, which can accept -Xmx
    # https://github.com/zaproxy/zaproxy/blob/develop/src/zap.sh#L90
    command: "-Xmx2G"
    networks:
      pymnt_network:
        aliases:
          - zap.pymnt.localdomain
    logging:
      driver: "json-file"
```

To run locally, add the following script to ci/tasks/endtoend/zap:
```
#!/bin/bash

export END_TO_END_JAVA_OPTS="-Xms1G -Xmx2G"
export HTTP_ZAP_ENABLED=true

docker-compose up -d --no-recreate
echo "Sleeping to allow everything to come to life"
sleep 10
docker ps -a
endtoend=$(docker ps -aqf "name=zap_endtoend")
echo "E2E container id - ${endtoend}"
docker exec "${endtoend}" "/app/bin/zap"
```
and run it from the ci/tasks/endtoend/zap directory.