### PR TITLE
PP-9303: Allow a release tag prefix in the reusable release workflow

### DIFF
--- a/.github/workflows/_create-alpha-release-tag.yml
+++ b/.github/workflows/_create-alpha-release-tag.yml
@@ -14,6 +14,12 @@ name: Create alpha_release tag
 
 on:
   workflow_call:
+    inputs:
+      tag_prefix:
+        description: An additional prefix to add the to the tag. This must not contain any hyphens!
+        default: ""
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -33,13 +39,13 @@ jobs:
           fetch-depth: '0'
       - name: Tag release
         run: |
-          LATEST_RELEASE_NUMBER=$(git describe --abbrev=0 --tags --match "alpha_release-*" | awk -F- '{print $2}' || true)
+          LATEST_RELEASE_NUMBER=$(git describe --abbrev=0 --tags --match "${{ inputs.tag_prefix }}alpha_release-*" | awk -F- '{print $2}' || true)
           number_regex='^[0-9]+$'
           if ! [[ ${LATEST_RELEASE_NUMBER} =~ $number_regex ]]; then
            LATEST_RELEASE_NUMBER=0
           fi
           NEW_RELEASE_NUMBER=$((LATEST_RELEASE_NUMBER + 1))
-          TAG_NAME=alpha_release-${NEW_RELEASE_NUMBER}
+          TAG_NAME=${{ inputs.tag_prefix }}alpha_release-${NEW_RELEASE_NUMBER}
           echo "TAG_NAME: ${TAG_NAME}"
           git config user.email payments-team@digital.cabinet-office.gov.uk
           git config user.name pay-github-actions


### PR DESCRIPTION
Allow the create release reusable workflow to accept an additional prefix to add to the tag. This is useful in monorepos which have multiple artefacts to release.