### PR TITLE
BAU: Add a pipeline to restart control plane

### DIFF
--- a/ci/pipelines/control-plane.yml
+++ b/ci/pipelines/control-plane.yml
@@ -1,0 +1,64 @@
+---
+resources:
+  - name: pay-control-plane-paas
+    type: cf-cli
+    icon: cloud-upload-outline
+    source:
+      api: https://api.cloud.service.gov.uk
+      org: govuk-pay
+      space: build
+      username: ((cf-username))
+      password: ((cf-password))
+
+  - name: every-morning
+    type: time
+    icon: alarm
+    source:
+      start: "07:00"
+      stop: "07:30"
+      location: "Europe/London"
+
+  - name: slack-notification
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-notification-secret))
+
+resource_types:
+  - name: cf-cli
+    type: docker-image
+    source:
+      repository: nulldriver/cf-cli-resource
+
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+jobs:
+  - name: restart-control-plane
+    plan:
+    - get: every-morning
+      trigger: true
+    - put: pay-control-plane-paas
+      params:
+        command: restage
+        app_name: pay-control-plane
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Failed to restart Control Plane - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Control plane restarted - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse


### PR DESCRIPTION
Add a pipeline to restart pay-control-plane.

This includes automatically restarting every day between 7:00 and 7:30 GMT.

Success notifications into pay-govuk-activity
Failure notifications into pay-starling

Example build: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/control-plane/jobs/restart-control-plane/builds/3

Success notice:
<img width="621" alt="Screenshot 2022-03-03 at 08 57 40" src="https://user-images.githubusercontent.com/2170030/156531152-2cdd5644-5fc8-48b8-a1ea-62a8726526b3.png">

Failure notice:
<img width="638" alt="Screenshot 2022-03-03 at 08 57 50" src="https://user-images.githubusercontent.com/2170030/156531166-afe052eb-3377-436c-8030-1d9707b9f890.png">

Events from paas showing restage:
<img width="1189" alt="Screenshot 2022-03-03 at 08 59 35" src="https://user-images.githubusercontent.com/2170030/156531373-b611bbd3-6d6b-4a87-9063-12b1a8ee0b79.png">

