### PR TITLE
PP-9234: Require e2e tests for adminusers

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -279,14 +279,14 @@ resources:
       repository: govukpay/adminusers
       variant: release
       <<: *aws_test_config
-  - name: adminusers-candidate-ecr-registry-test
+  - name: adminusers-candidate
     type: registry-image
     icon: docker
     source:
       repository: govukpay/adminusers
       variant: candidate
       <<: *aws_test_config
-  - name: adminusers-latest-ecr-registry-test
+  - name: adminusers-latest
     type: registry-image
     icon: docker
     source:
@@ -1385,7 +1385,7 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: adminusers-git-release
-      - put: adminusers-candidate-ecr-registry-test
+      - put: adminusers-candidate
         params:
           image: image/image.tar
           additional_tags: tags/candidate-tag
@@ -1393,7 +1393,7 @@ jobs:
   - name: run-adminusers-e2e
     plan:
       - in_parallel:
-        - get: adminusers-candidate-ecr-registry-test
+        - get: adminusers-candidate
           params:
             format: oci
           trigger: true
@@ -1403,9 +1403,9 @@ jobs:
         - task: parse-candidate-tag
           file: pay-ci/ci/tasks/parse-candidate-tag.yml
           input_mapping:
-            ecr-repo: adminusers-candidate-ecr-registry-test
+            ecr-repo: adminusers-candidate
         - load_var: candidate_image_tag
-          file: adminusers-candidate-ecr-registry-test/tag
+          file: adminusers-candidate/tag
         - task: assume-role
           file: pay-ci/ci/tasks/assume-role.yml
           params:
@@ -1433,14 +1433,14 @@ jobs:
         - do:
           - put: adminusers-ecr-registry-test
             params:
-              image: adminusers-candidate-ecr-registry-test/image.tar
+              image: adminusers-candidate/image.tar
               additional_tags: parse-candidate-tags/release-tag
-          - put: adminusers-latest-ecr-registry-test
+          - put: adminusers-latest
             params:
-              image: adminusers-candidate-ecr-registry-test/image.tar
+              image: adminusers-candidate/image.tar
         - put: adminusers-dockerhub
           params:
-              image: adminusers-candidate-ecr-registry-test/image.tar
+              image: adminusers-candidate/image.tar
 #    on_failure:
 #      put: slack-notification
 #      attempts: 10

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -264,6 +264,14 @@ resources:
       repository: govukpay/frontend
       tag: latest
       <<: *aws_test_config
+  - name: adminusers-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      tag: latest-master
+      password: ((docker-password))
+      username: ((docker-username))
   - name: adminusers-ecr-registry-test
     type: registry-image
     icon: docker
@@ -631,7 +639,7 @@ resource_types:
 groups:
   - name: adminusers
     jobs:
-      - push-adminusers-to-test-ecr
+      - push-adminusers-candidate-to-test-ecr
       - run-adminusers-e2e
       - deploy-adminusers
       - smoke-test-adminusers
@@ -1361,7 +1369,7 @@ jobs:
           image: frontend-ecr-registry-test/image.tar
           additional_tags: frontend-ecr-registry-test/tag
 
-  - name: push-adminusers-to-test-ecr
+  - name: push-adminusers-candidate-to-test-ecr
     plan:
       - get: pay-ci
       - get: adminusers-git-release
@@ -1377,15 +1385,10 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: adminusers-git-release
-      - in_parallel:
-        - put: adminusers-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/tags
-        - put: adminusers-candidate-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/candidate-tag
+      - put: adminusers-candidate-ecr-registry-test
+        params:
+          image: image/image.tar
+          additional_tags: tags/candidate-tag
 
   - name: run-adminusers-e2e
     plan:
@@ -1394,9 +1397,13 @@ jobs:
           params:
             format: oci
           trigger: true
-          passed: [push-adminusers-to-test-ecr]
+          passed: [push-adminusers-candidate-to-test-ecr]
         - get: pay-ci
       - in_parallel:
+        - task: parse-candidate-tag
+          file: pay-ci/ci/tasks/parse-candidate-tag.yml
+          input_mapping:
+            ecr-repo: adminusers-candidate-ecr-registry-test
         - load_var: candidate_image_tag
           file: adminusers-candidate-ecr-registry-test/tag
         - task: assume-role
@@ -1422,9 +1429,18 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - put: adminusers-latest-ecr-registry-test
-        params:
-          image: adminusers-candidate-ecr-registry-test/image.tar
+      - in_parallel:
+        - do:
+          - put: adminusers-ecr-registry-test
+            params:
+              image: adminusers-candidate-ecr-registry-test/image.tar
+              additional_tags: parse-candidate-tags/release-tag
+          - put: adminusers-latest-ecr-registry-test
+            params:
+              image: adminusers-candidate-ecr-registry-test/image.tar
+        - put: adminusers-dockerhub
+          params:
+              image: adminusers-candidate-ecr-registry-test/image.tar
 #    on_failure:
 #      put: slack-notification
 #      attempts: 10
@@ -1450,6 +1466,7 @@ jobs:
     plan:
       - get: adminusers-ecr-registry-test
         trigger: true
+        passed: [run-adminusers-e2e]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: telegraf-ecr-registry-test

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1434,7 +1434,7 @@ jobs:
           - put: adminusers-ecr-registry-test
             params:
               image: adminusers-candidate/image.tar
-              additional_tags: parse-candidate-tags/release-tag
+              additional_tags: parse-candidate-tag/release-tag
           - put: adminusers-latest
             params:
               image: adminusers-candidate/image.tar

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1441,24 +1441,24 @@ jobs:
         - put: adminusers-dockerhub
           params:
               image: adminusers-candidate/image.tar
-#    on_failure:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-announce'
-#        silent: true
-#        text: ':red-circle: adminusers candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
-#    on_success:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-activity'
-#        silent: true
-#        text: ':green-circle: adminusers candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: adminusers candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: adminusers candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: deploy-adminusers
     serial: true


### PR DESCRIPTION
This will:

1. Rename `push-adminusers-to-test-ecr` to `push-adminusers-candidate-to-test-ecr`
2. Push X-release to test ecr only _after_ e2e tests are complete
3. Require e2e tests before running deploy-adminusers
4. Push latest-master to dockerhub after e2e-tests
5. Rename the canididate and latest ecr resources to just `adminusers-(latest|candidate)` I didn't rename the release since that would lose the deploy history and could trigger a redeploy of lots of old versions

New pipeline layout:
<img width="1318" alt="Screenshot 2022-03-04 at 09 37 21" src="https://user-images.githubusercontent.com/2170030/156738676-10ebf10f-22e9-4ed5-988d-5706a8ef0072.png">


https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test?group=adminusers
