### PR TITLE
PP-9234: Require e2e tests for cardid

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -293,6 +293,14 @@ resources:
       repository: govukpay/adminusers
       tag: latest
       <<: *aws_test_config
+  - name: cardid-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/cardid
+      tag: latest-master
+      password: ((docker-password))
+      username: ((docker-username))
   - name: cardid-ecr-registry-test
     type: registry-image
     icon: docker
@@ -300,14 +308,14 @@ resources:
       repository: govukpay/cardid
       variant: release
       <<: *aws_test_config
-  - name: cardid-candidate-ecr-registry-test
+  - name: cardid-candidate
     type: registry-image
     icon: docker
     source:
       repository: govukpay/cardid
       variant: candidate
       <<: *aws_test_config
-  - name: cardid-latest-ecr-registry-test
+  - name: cardid-latest
     type: registry-image
     icon: docker
     source:
@@ -648,7 +656,7 @@ groups:
       - adminusers-db-migration
   - name: cardid
     jobs:
-      - push-cardid-to-test-ecr
+      - push-cardid-candidate-to-test-ecr
       - run-cardid-e2e
       - deploy-cardid
       - smoke-test-cardid
@@ -3394,7 +3402,7 @@ jobs:
           image: selfservice-ecr-registry-test/image.tar
           additional_tags: selfservice-ecr-registry-test/tag
 
-  - name: push-cardid-to-test-ecr
+  - name: push-cardid-candidate-to-test-ecr
     plan:
       - get: pay-ci
       - get: cardid-git-release
@@ -3445,28 +3453,27 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
          git-release: cardid-git-release
-      - in_parallel:
-        - put: cardid-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/tags
-        - put: cardid-candidate-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/candidate-tag         
+      - put: cardid-candidate
+        params:
+          image: image/image.tar
+          additional_tags: tags/candidate-tag         
 
   - name: run-cardid-e2e
     plan:
       - in_parallel:
-        - get: cardid-candidate-ecr-registry-test
+        - get: cardid-candidate
           params:
             format: oci
           trigger: true
-          passed: [push-cardid-to-test-ecr]
+          passed: [push-cardid-candidate-to-test-ecr]
         - get: pay-ci
       - in_parallel:
+        - task: parse-candidate-tag
+          file: pay-ci/ci/tasks/parse-candidate-tag.yml
+          input_mapping:
+            ecr-repo: cardid-candidate
         - load_var: candidate_image_tag
-          file: cardid-candidate-ecr-registry-test/tag
+          file: cardid-candidate/tag
         - task: assume-role
           file: pay-ci/ci/tasks/assume-role.yml
           params:
@@ -3498,27 +3505,36 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - put: cardid-latest-ecr-registry-test
-        params:
-          image: cardid-candidate-ecr-registry-test/image.tar
-#    on_failure:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-announce'
-#        silent: true
-#        text: ':red-circle: cardid candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
-#    on_success:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-activity'
-#        silent: true
-#        text: ':green-circle: cardid candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
+      - in_parallel:
+        - do:
+          - put: cardid-ecr-registry-test
+            params:
+              image: cardid-candidate/image.tar
+              additional_tags: parse-candidate-tag/release-tag
+          - put: cardid-latest
+            params:
+              image: cardid-candidate/image.tar
+        - put: cardid-dockerhub
+          params:
+            image: cardid-candidate/image.tar
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: cardid candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: cardid candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: deploy-cardid
     serial: true
@@ -3526,6 +3542,7 @@ jobs:
     plan:
       - get: cardid-ecr-registry-test
         trigger: true
+        passed: [run-cardid-e2e]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: telegraf-ecr-registry-test


### PR DESCRIPTION
This will:

1. Rename `push-cardid-to-test-ecr` to `push-cardid-candidate-to-test-ecr`
2. Push X-release to test ecr only _after_ e2e tests are complete
3. Require e2e tests before running deploy-cardid
4. Push latest-master to dockerhub after e2e-tests
5. Rename the canididate and latest ecr resources to just `cardid-(latest|candidate)` I didn't rename the release since that would lose the deploy history and could trigger a redeploy of lots of old versions

Same change as https://github.com/alphagov/pay-ci/pull/633 but for cardid

New pipeline layout:
<img width="1270" alt="Screenshot 2022-03-04 at 11 39 24" src="https://user-images.githubusercontent.com/2170030/156757021-8ca2e46c-dcf1-4f6a-b550-b37f5aa597db.png">

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test?group=cardid
