### PR TITLE
Pp 9234 require e2e test for products and publicapi

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -395,6 +395,14 @@ resources:
       repository: govukpay/webhooks
       variant: release
       <<: *aws_test_config
+  - name: products-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/products
+      tag: latest-master
+      password: ((docker-password))
+      username: ((docker-username))
   - name: products-ecr-registry-test
     type: registry-image
     icon: docker
@@ -402,14 +410,14 @@ resources:
       repository: govukpay/products
       variant: release
       <<: *aws_test_config
-  - name: products-candidate-ecr-registry-test
+  - name: products-candidate
     type: registry-image
     icon: docker
     source:
       repository: govukpay/products
       variant: candidate
       <<: *aws_test_config
-  - name: products-latest-ecr-registry-test
+  - name: products-latest
     type: registry-image
     icon: docker
     source:
@@ -437,6 +445,14 @@ resources:
       repository: govukpay/products-ui
       tag: latest
       <<: *aws_test_config  
+  - name: publicapi-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/publicapi
+      tag: latest-master
+      password: ((docker-password))
+      username: ((docker-username))
   - name: publicapi-ecr-registry-test
     type: registry-image
     icon: docker
@@ -444,14 +460,14 @@ resources:
       repository: govukpay/publicapi
       variant: release
       <<: *aws_test_config
-  - name: publicapi-candidate-ecr-registry-test
+  - name: publicapi-candidate
     type: registry-image
     icon: docker
     source:
       repository: govukpay/publicapi
       variant: candidate
       <<: *aws_test_config
-  - name: publicapi-latest-ecr-registry-test
+  - name: publicapi-latest
     type: registry-image
     icon: docker
     source:
@@ -726,7 +742,7 @@ groups:
       - ledger-db-migration
   - name: products
     jobs:
-      - push-products-to-test-ecr
+      - push-products-candidate-to-test-ecr
       - run-products-e2e
       - deploy-products
       - smoke-test-products
@@ -743,7 +759,7 @@ groups:
       - push-products-ui-to-staging-ecr
   - name: publicapi
     jobs:
-      - push-publicapi-to-test-ecr
+      - push-publicapi-candidate-to-test-ecr
       - run-publicapi-e2e
       - deploy-publicapi
       - smoke-test-publicapi
@@ -2286,7 +2302,7 @@ jobs:
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
 
-  - name: push-products-to-test-ecr
+  - name: push-products-candidate-to-test-ecr
     plan:
       - get: pay-ci
       - get: products-git-release
@@ -2302,28 +2318,27 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: products-git-release
-      - in_parallel:
-        - put: products-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/tags
-        - put: products-candidate-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/candidate-tag
+      - put: products-candidate
+        params:
+          image: image/image.tar
+          additional_tags: tags/candidate-tag
 
   - name: run-products-e2e
     plan:
       - in_parallel:
-        - get: products-candidate-ecr-registry-test
+        - get: products-candidate
           params:
             format: oci
           trigger: true
-          passed: [push-products-to-test-ecr]
+          passed: [push-products-candidate-to-test-ecr]
         - get: pay-ci
       - in_parallel:
+        - task: parse-candidate-tag
+          file: pay-ci/ci/tasks/parse-candidate-tag.yml
+          input_mapping:
+            ecr-repo: products-candidate
         - load_var: candidate_image_tag
-          file: products-candidate-ecr-registry-test/tag
+          file: products-candidate/tag
         - task: assume-role
           file: pay-ci/ci/tasks/assume-role.yml
           params:
@@ -2347,27 +2362,36 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))          
-      - put: products-latest-ecr-registry-test
-        params:
-          image: products-candidate-ecr-registry-test/image.tar
-#    on_failure:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-announce'
-#        silent: true
-#        text: ':red-circle: products candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
-#    on_success:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-activity'
-#        silent: true
-#        text: ':green-circle: products candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
+      - in_parallel:
+        - do:
+          - put: products-ecr-registry-test
+            params:
+              image: products-candidate/image.tar
+              additional_tags: parse-candidate-tag/release-tag
+          - put: products-latest
+            params:
+              image: products-candidate/image.tar
+        - put: products-dockerhub
+          params:
+            image: products-candidate/image.tar
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: products candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: products candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: deploy-products
     serial: true
@@ -2375,6 +2399,7 @@ jobs:
     plan:
       - get: products-ecr-registry-test
         trigger: true
+        passed: [run-products-e2e]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: telegraf-ecr-registry-test
@@ -2783,7 +2808,7 @@ jobs:
           image: products-ui-ecr-registry-test/image.tar
           additional_tags: products-ui-ecr-registry-test/tag
 
-  - name: push-publicapi-to-test-ecr
+  - name: push-publicapi-candidate-to-test-ecr
     plan:
       - get: pay-ci
       - get: publicapi-git-release
@@ -2799,28 +2824,27 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: publicapi-git-release
-      - in_parallel:
-        - put: publicapi-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/tags
-        - put: publicapi-candidate-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/candidate-tag
+      - put: publicapi-candidate
+        params:
+          image: image/image.tar
+          additional_tags: tags/candidate-tag
 
   - name: run-publicapi-e2e
     plan:
       - in_parallel:
-        - get: publicapi-candidate-ecr-registry-test
+        - get: publicapi-candidate
           params:
             format: oci
           trigger: true
-          passed: [push-publicapi-to-test-ecr]
+          passed: [push-publicapi-candidate-to-test-ecr]
         - get: pay-ci
       - in_parallel:
+        - task: parse-candidate-tag
+          file: pay-ci/ci/tasks/parse-candidate-tag.yml
+          input_mapping:
+            ecr-repo: publicapi-candidate
         - load_var: candidate_image_tag
-          file: publicapi-candidate-ecr-registry-test/tag
+          file: publicapi-candidate/tag
         - task: assume-role
           file: pay-ci/ci/tasks/assume-role.yml
           params:
@@ -2859,27 +2883,36 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - put: publicapi-latest-ecr-registry-test
-        params:
-          image: publicapi-candidate-ecr-registry-test/image.tar
-#    on_failure:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-announce'
-#        silent: true
-#        text: ':red-circle: publicapi candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
-#    on_success:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-activity'
-#        silent: true
-#        text: ':green-circle: publicapi candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
+      - in_parallel:
+        - do:
+          - put: publicapi-ecr-registry-test
+            params:
+              image: publicapi-candidate/image.tar
+              additional_tags: parse-candidate-tag/release-tag
+          - put: publicapi-latest
+            params:
+              image: publicapi-candidate/image.tar
+        - put: publicapi-dockerhub
+          params:
+            image: publicapi-candidate/image.tar
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: publicapi candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: publicapi candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: deploy-publicapi
     serial: true
@@ -2887,6 +2920,7 @@ jobs:
     plan:
       - get: publicapi-ecr-registry-test
         trigger: true
+        passed: [run-publicapi-e2e]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: telegraf-ecr-registry-test

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -2322,6 +2322,8 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: tags/candidate-tag
+        get_params:
+          skip_download: true
 
   - name: run-products-e2e
     plan:
@@ -2368,12 +2370,19 @@ jobs:
             params:
               image: products-candidate/image.tar
               additional_tags: parse-candidate-tag/release-tag
+            get_params:
+              skip_download: true
           - put: products-latest
             params:
               image: products-candidate/image.tar
+            get_params:
+              skip_download: true
         - put: products-dockerhub
           params:
             image: products-candidate/image.tar
+          get_params:
+            skip_download: true
+
     on_failure:
       put: slack-notification
       attempts: 10
@@ -2828,6 +2837,8 @@ jobs:
         params:
           image: image/image.tar
           additional_tags: tags/candidate-tag
+        get_params:
+          skip_download: true
 
   - name: run-publicapi-e2e
     plan:
@@ -2889,12 +2900,18 @@ jobs:
             params:
               image: publicapi-candidate/image.tar
               additional_tags: parse-candidate-tag/release-tag
+            get_params:
+              skip_download: true
           - put: publicapi-latest
             params:
               image: publicapi-candidate/image.tar
+            get_params:
+              skip_download: true
         - put: publicapi-dockerhub
           params:
             image: publicapi-candidate/image.tar
+          get_params:
+            skip_download: true
     on_failure:
       put: slack-notification
       attempts: 10


### PR DESCRIPTION
Require end to end tests for products and publicapi.

Added skip_download on the ecr and docker PUT's I added in the previous PRs, saves time and there is no need to pull them given then are the final steps in the jobs.

# Connector
1. Rename `push-Y-to-test-ecr` to `push-Y-candidate-to-test-ecr`
2. Push X-release to test ecr only _after_ e2e tests are complete
3. Require e2e tests before running deploy-Y
4. Push latest-master to dockerhub after e2e-tests
5. Rename the canididate and latest ecr resources to just `Y-(latest|candidate)` I didn't rename the release since that would lose the deploy history and could trigger a redeploy of lots of old versions

Pipeline after update

# products

<img width="2344" alt="Screenshot 2022-03-07 at 09 18 36" src="https://user-images.githubusercontent.com/2170030/157005759-8516aa31-9e87-4b39-8a1f-2087dca58a00.png">

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test?group=products

# publicapi

<img width="2374" alt="Screenshot 2022-03-07 at 09 38 02" src="https://user-images.githubusercontent.com/2170030/157005828-f054f02f-1f47-4e47-acad-25c9cd7611a1.png">

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test?group=publicapi
