### PR TITLE
PP-9306: Copy selenium/standalone-chrome:3.141.59 into ECR

### DIFF
--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -201,23 +201,23 @@ resources:
       aws_ecr_registry_id: "((pay_aws_test_account_id))"
       aws_region: eu-west-1
 
-  - name: selenium-standalone-chrome-3-141-59-iron
+  - name: selenium-standalone-chrome-3-141-59
     type: registry-image
     icon: docker
     check_every: 1h
     source:
       repository: selenium/standalone-chrome
-      tag: 3.141.59-iron
+      tag: 3.141.59
       username: ((docker-username))
       password: ((docker-password))
 
-  - name: ecr-selenium-standalone-chrome-3-141-59-iron
+  - name: ecr-selenium-standalone-chrome-3-141-59
     type: registry-image
     icon: docker
     check_every: never
     source:
       repository: selenium/standalone-chrome
-      tag: 3.141.59-iron
+      tag: 3.141.59
       aws_access_key_id: ((readonly_access_key_id))
       aws_secret_access_key: ((readonly_secret_access_key))
       aws_session_token: ((readonly_session_token))
@@ -730,22 +730,22 @@ jobs:
         icon_emoji: ":concourse:"
         username: pay-concourse
 
-  - name: copy-selenium-standalone-chrome-3-141-59-iron
+  - name: copy-selenium-standalone-chrome-3-141-59
     plan:
-      - get: selenium-standalone-chrome-3-141-59-iron
+      - get: selenium-standalone-chrome-3-141-59
         trigger: true
         params:
           format: oci
-      - put: ecr-selenium-standalone-chrome-3-141-59-iron
+      - put: ecr-selenium-standalone-chrome-3-141-59
         params:
-          image: selenium-standalone-chrome-3-141-59-iron/image.tar
+          image: selenium-standalone-chrome-3-141-59/image.tar
     on_failure:
       put: slack-notification
       attempts: 10
       params:
         channel: '#govuk-pay-starling'
         silent: true
-        text: ':red-circle: Failed copying selenium/standalone-chrome:3-141-59-iron image from Docker Hub to ECR - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        text: ':red-circle: Failed copying selenium/standalone-chrome:3-141-59 image from Docker Hub to ECR - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
         icon_emoji: ":concourse:"
         username: pay-concourse
     on_success:
@@ -754,6 +754,6 @@ jobs:
       params:
         channel: '#govuk-pay-activity'
         silent: true
-        text: ':green-circle: Copied selenium/standalone-chrome:3-141-59-iron image from Docker Hub to ECR - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        text: ':green-circle: Copied selenium/standalone-chrome:3-141-59 image from Docker Hub to ECR - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
         icon_emoji: ":concourse:"
         username: pay-concourse


### PR DESCRIPTION
Copy this version in preparation for
https://github.com/alphagov/pay-ci/pull/636.
If it turns out selenium/standalone-chrome:3.141.59 doesn't work with our e2e
tests we can revert this commit.