### PR TITLE
Pp 9234 require e2e test for products UI and publicauth

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -424,6 +424,14 @@ resources:
       repository: govukpay/products
       tag: latest
       <<: *aws_test_config      
+  - name: products-ui-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/products-ui
+      tag: latest-master
+      password: ((docker-password))
+      username: ((docker-username))
   - name: products-ui-ecr-registry-test
     type: registry-image
     icon: docker
@@ -431,14 +439,14 @@ resources:
       repository: govukpay/products-ui
       variant: release
       <<: *aws_test_config
-  - name: products-ui-candidate-ecr-registry-test
+  - name: products-ui-candidate
     type: registry-image
     icon: docker
     source:
       repository: govukpay/products-ui
       variant: candidate
       <<: *aws_test_config
-  - name: products-ui-latest-ecr-registry-test
+  - name: products-ui-latest
     type: registry-image
     icon: docker
     source:
@@ -751,7 +759,7 @@ groups:
       - products-db-migration
   - name: products-ui
     jobs:
-      - push-products-ui-to-test-ecr
+      - push-products-ui-candidate-to-test-ecr
       - run-products-ui-e2e
       - deploy-products-ui
       - smoke-test-products-ui
@@ -2589,7 +2597,7 @@ jobs:
           image: products-ecr-registry-test/image.tar
           additional_tags: products-ecr-registry-test/tag
 
-  - name: push-products-ui-to-test-ecr
+  - name: push-products-ui-candidate-to-test-ecr
     plan:
       - get: pay-ci
       - get: products-ui-git-release
@@ -2605,28 +2613,29 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: products-ui-git-release
-      - in_parallel:
-        - put: products-ui-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/tags
-        - put: products-ui-candidate-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/candidate-tag    
+      - put: products-ui-candidate
+        params:
+          image: image/image.tar
+          additional_tags: tags/candidate-tag
+        get_params:
+          skip_download: true
 
   - name: run-products-ui-e2e
     plan:
       - in_parallel:
-        - get: products-ui-candidate-ecr-registry-test
+        - get: products-ui-candidate
           params:
             format: oci
           trigger: true
-          passed: [push-products-ui-to-test-ecr]
+          passed: [push-products-ui-candidate-to-test-ecr]
         - get: pay-ci
       - in_parallel:
+        - task: parse-candidate-tag
+          file: pay-ci/ci/tasks/parse-candidate-tag.yml
+          input_mapping:
+            ecr-repo: products-ui-candidate
         - load_var: candidate_image_tag
-          file: products-ui-candidate-ecr-registry-test/tag
+          file: products-ui-candidate/tag
         - task: assume-role
           file: pay-ci/ci/tasks/assume-role.yml
           params:
@@ -2650,27 +2659,42 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))          
-      - put: products-ui-latest-ecr-registry-test
-        params:
-          image: products-ui-candidate-ecr-registry-test/image.tar
-#    on_failure:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-announce'
-#        silent: true
-#        text: ':red-circle: products-ui candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
-#    on_success:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-activity'
-#        silent: true
-#        text: ':green-circle: products-ui candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse       
+      - in_parallel:
+        - do:
+          - put: products-ui-ecr-registry-test
+            params:
+              image: products-ui-candidate/image.tar
+              additional_tags: parse-candidate-tag/release-tag
+            get_params:
+              skip_download: true
+          - put: products-ui-latest
+            params:
+              image: products-ui-candidate/image.tar
+            get_params:
+              skip_download: true
+        - put: products-ui-dockerhub
+          params:
+            image: products-ui-candidate/image.tar
+          get_params:
+            skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: products-ui candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: products-ui candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: deploy-products-ui
     serial: true
@@ -2678,6 +2702,7 @@ jobs:
     plan:
       - get: products-ui-ecr-registry-test
         trigger: true
+        passed: [run-products-ui-e2e]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: telegraf-ecr-registry-test

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -482,6 +482,14 @@ resources:
       repository: govukpay/publicapi
       tag: latest
       <<: *aws_test_config      
+  - name: publicauth-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/publicauth
+      tag: latest-master
+      password: ((docker-password))
+      username: ((docker-username))
   - name: publicauth-ecr-registry-test
     type: registry-image
     icon: docker
@@ -489,14 +497,14 @@ resources:
       repository: govukpay/publicauth
       variant: release
       <<: *aws_test_config
-  - name: publicauth-candidate-ecr-registry-test
+  - name: publicauth-candidate
     type: registry-image
     icon: docker
     source:
       repository: govukpay/publicauth
       variant: candidate
       <<: *aws_test_config
-  - name: publicauth-latest-ecr-registry-test
+  - name: publicauth-latest
     type: registry-image
     icon: docker
     source:
@@ -775,7 +783,7 @@ groups:
       - push-publicapi-to-staging-ecr
   - name: publicauth
     jobs:
-      - push-publicauth-to-test-ecr
+      - push-publicauth-candidate-to-test-ecr
       - run-publicauth-e2e
       - deploy-publicauth
       - smoke-test-publicauth
@@ -3102,7 +3110,7 @@ jobs:
           image: publicapi-ecr-registry-test/image.tar
           additional_tags: publicapi-ecr-registry-test/tag
 
-  - name: push-publicauth-to-test-ecr
+  - name: push-publicauth-candidate-to-test-ecr
     plan:
       - get: pay-ci
       - get: publicauth-git-release
@@ -3118,28 +3126,29 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: publicauth-git-release
-      - in_parallel:
-        - put: publicauth-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/tags
-        - put: publicauth-candidate-ecr-registry-test
-          params:
-            image: image/image.tar
-            additional_tags: tags/candidate-tag
+      - put: publicauth-candidate
+        params:
+          image: image/image.tar
+          additional_tags: tags/candidate-tag
+        get_params:
+          skip_download: true
 
   - name: run-publicauth-e2e
     plan:
       - in_parallel:
-        - get: publicauth-candidate-ecr-registry-test
+        - get: publicauth-candidate
           params:
             format: oci
           trigger: true
-          passed: [push-publicauth-to-test-ecr]
+          passed: [push-publicauth-candidate-to-test-ecr]
         - get: pay-ci
       - in_parallel:
+        - task: parse-candidate-tag
+          file: pay-ci/ci/tasks/parse-candidate-tag.yml
+          input_mapping:
+            ecr-repo: publicauth-candidate
         - load_var: candidate_image_tag
-          file: publicauth-candidate-ecr-registry-test/tag
+          file: publicauth-candidate/tag
         - task: assume-role
           file: pay-ci/ci/tasks/assume-role.yml
           params:
@@ -3171,27 +3180,42 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - put: publicauth-latest-ecr-registry-test
-        params:
-          image: publicauth-candidate-ecr-registry-test/image.tar
-#    on_failure:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-announce'
-#        silent: true
-#        text: ':red-circle: publicauth candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
-#    on_success:
-#      put: slack-notification
-#      attempts: 10
-#      params:
-#        channel: '#govuk-pay-activity'
-#        silent: true
-#        text: ':green-circle: publicauth candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-#        icon_emoji: ":concourse:"
-#        username: pay-concourse
+      - in_parallel:
+        - do:
+          - put: publicauth-ecr-registry-test
+            params:
+              image: publicauth-candidate/image.tar
+              additional_tags: parse-candidate-tag/release-tag
+            get_params:
+              skip_download: true
+          - put: publicauth-latest
+            params:
+              image: publicauth-candidate/image.tar
+            get_params:
+              skip_download: true
+        - put: publicauth-dockerhub
+          params:
+            image: publicauth-candidate/image.tar
+          get_params:
+            skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: publicauth candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: publicauth candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: deploy-publicauth
     serial: true
@@ -3199,6 +3223,7 @@ jobs:
     plan:
       - get: publicauth-ecr-registry-test
         trigger: true
+        passed: [run-publicauth-e2e]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: telegraf-ecr-registry-test


### PR DESCRIPTION
Require end to end tests for products and publicapi.

Added skip_download on the ecr and docker PUT's I added in the previous PRs, saves time and there is no need to pull them given then are the final steps in the jobs.

# Connector
1. Rename `push-Y-to-test-ecr` to `push-Y-candidate-to-test-ecr`
2. Push X-release to test ecr only _after_ e2e tests are complete
3. Require e2e tests before running deploy-Y
4. Push latest-master to dockerhub after e2e-tests
5. Rename the canididate and latest ecr resources to just `Y-(latest|candidate)` I didn't rename the release since that would lose the deploy history and could trigger a redeploy of lots of old versions

Pipeline after update

# products-ui

<img width="2509" alt="Screenshot 2022-03-07 at 15 16 59" src="https://user-images.githubusercontent.com/2170030/157062345-bf07bcd8-4fb0-4812-92a2-1dd05215c686.png">

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test?group=products-ui

# publicauth

<img width="2514" alt="Screenshot 2022-03-07 at 15 17 05" src="https://user-images.githubusercontent.com/2170030/157062374-f67988bb-f502-4d90-ac77-d0cc7f77859d.png">

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test?group=publicauth