### PR TITLE
PP-9236: Workflow for running a provider contract test

### DIFF
--- a/.github/workflows/_run-provider-contract-tests.yml
+++ b/.github/workflows/_run-provider-contract-tests.yml
@@ -1,0 +1,43 @@
+# This workflow is meant to be run on a pact provider build. It will run
+# all the consumers that depend on it against itself.
+#
+name: Provider Contract Tests
+
+on:
+  workflow_call:
+    secrets:
+      pact_broker_username:
+        required: true
+      pact_broker_password:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  provider-contract-tests:
+    name: Provider contract tests
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Set up JDK 11
+        uses: actions/setup-java@f69f00b5e5324696b07f6b1c92f0470a6df00780
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Pull docker image dependencies
+        run: |
+          docker pull govukpay/postgres:11.1
+      - name: Run provider contract tests
+        run: |
+          mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master \
+          -DPACT_BROKER_USERNAME=${{ secrets.pact_broker_username }} \
+          -DPACT_BROKER_PASSWORD=${{ secrets.pact_broker_password }} \
+          -Dpact.verifier.publishResults=true


### PR DESCRIPTION
The pro of having this workflow is that the maven command to run this test is
the same across all our providers.

The cons:
* The providers must be in Java
* The provider project must have a pom.xml which defines a `runContractTests` profile

[adminusers PR](https://github.com/alphagov/pay-adminusers/pull/1287) that proves the use of this workflow.

I've tested that we don't need to pass `-Dpact.provider.version=${commit}` to
the `mvn test -DrunContractTests` command as the pact library will pull out the
latest sha of the provider when publishing the result.