### PR TITLE
PP-9373: Build node12 and node16 node-runner images

### DIFF
--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:12.22.10-alpine3.15@sha256:f150ebf9402f0dd6a9c4cb208ed64884cfa7c8a6ccae3f749a7b12156c25ad88
+# See the container_image_versions.json file for the currently in-use versions
+ARG SOURCE_CONTAINER_IMAGE_VERSION
+FROM node:${SOURCE_CONTAINER_IMAGE_VERSION}
 
 RUN npm install aws-sdk@^2.x.x
 RUN npm install @octokit/rest@^18.x.x
-

--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -1,8 +1,1 @@
-# See the source_container_image_versions.json file for the currently in-use versions
-ARG SOURCE_CONTAINER_IMAGE_VERSION
-FROM node:${SOURCE_CONTAINER_IMAGE_VERSION}
-
-WORKDIR /node-runner
-
-RUN npm install aws-sdk@^2.x.x
-RUN npm install @octokit/rest@^18.x.x
+Dockerfile.node12

--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -1,6 +1,8 @@
-# See the container_image_versions.json file for the currently in-use versions
+# See the source_container_image_versions.json file for the currently in-use versions
 ARG SOURCE_CONTAINER_IMAGE_VERSION
 FROM node:${SOURCE_CONTAINER_IMAGE_VERSION}
+
+WORKDIR /node-runner
 
 RUN npm install aws-sdk@^2.x.x
 RUN npm install @octokit/rest@^18.x.x

--- a/ci/docker/node-runner/Dockerfile.node12
+++ b/ci/docker/node-runner/Dockerfile.node12
@@ -1,0 +1,4 @@
+FROM node:12.22.10-alpine3.15@sha256:f150ebf9402f0dd6a9c4cb208ed64884cfa7c8a6ccae3f749a7b12156c25ad88
+
+RUN npm install aws-sdk@^2.x.x
+RUN npm install @octokit/rest@^18.x.x

--- a/ci/docker/node-runner/Dockerfile.node16
+++ b/ci/docker/node-runner/Dockerfile.node16
@@ -1,0 +1,7 @@
+FROM node:16.14.0-alpine3.15@sha256:425c81a04546a543da824e67c91d4a603af16fbc3d875ee2f276acf8ec2b1577
+
+# As of node 15 the docker container fails to npm install without either a WORKDIR or -g
+WORKDIR /node-runner
+
+RUN npm install aws-sdk@^2.x.x
+RUN npm install @octokit/rest@^18.x.x

--- a/ci/docker/node-runner/README.md
+++ b/ci/docker/node-runner/README.md
@@ -10,8 +10,9 @@ To build this image you will need to provide a build argument to choose which so
 For the currently in use versions see the `container_image_versions.json` file.
 
 ```
-NODE12_AMD64_VERSION=$(jq '.node12.amd64' < source_container_image_verisons.json)
-docker build --build-arg "SOURCE_CONTAINER_IMAGE_VERSION=$NODE12_AMD64_VERSION" govukpay/node-runner:local .
+NODE12_AMD64_VERSION=$(jq -r '.node12.amd64' < source_container_image_versions.json)
+NODE16_AMD64_VERSION=$(jq -r '.node16.amd64' < source_container_image_versions.json)
+docker build --build-arg "SOURCE_CONTAINER_IMAGE_VERSION=$NODE12_AMD64_VERSION" -t govukpay/node-runner:local .
 ```
 
 As part of the deployment pipeline both node12 and node16 versions will be produced, the source container versions will

--- a/ci/docker/node-runner/README.md
+++ b/ci/docker/node-runner/README.md
@@ -3,17 +3,11 @@
 This Docker container is used to run [JS scripts](https://github.com/alphagov/pay-ci/tree/master/ci/scripts)
 within tasks on Concourse CI.
 
-## Building
+Note there are 2 Dockerfiles in this repository for now, one is for node12 and one for node16. The symbolic link of
+Dockerfile to Dockerfile.node12 ensures node12 is still the default.
 
-To build this image you will need to provide a build argument to choose which source image version you want.
-
-For the currently in use versions see the `source_container_image_versions.json` file.
+You can build the node16 version by providing the `--file` flag to docker build:
 
 ```
-NODE12_AMD64_VERSION=$(jq -r '.node12.amd64' < source_container_image_versions.json)
-NODE16_AMD64_VERSION=$(jq -r '.node16.amd64' < source_container_image_versions.json)
-docker build --build-arg "SOURCE_CONTAINER_IMAGE_VERSION=$NODE12_AMD64_VERSION" -t govukpay/node-runner:local .
+docker build -f Dockerfile.node16 -t govukpay/node-runner:node16-local .
 ```
-
-As part of the deployment pipeline both node12 and node16 versions will be produced, the source container versions will
-be read from the `source_container_image_versions.json` file.

--- a/ci/docker/node-runner/README.md
+++ b/ci/docker/node-runner/README.md
@@ -7,7 +7,7 @@ within tasks on Concourse CI.
 
 To build this image you will need to provide a build argument to choose which source image version you want.
 
-For the currently in use versions see the `container_image_versions.json` file.
+For the currently in use versions see the `source_container_image_versions.json` file.
 
 ```
 NODE12_AMD64_VERSION=$(jq -r '.node12.amd64' < source_container_image_versions.json)

--- a/ci/docker/node-runner/README.md
+++ b/ci/docker/node-runner/README.md
@@ -2,3 +2,17 @@
 
 This Docker container is used to run [JS scripts](https://github.com/alphagov/pay-ci/tree/master/ci/scripts)
 within tasks on Concourse CI.
+
+## Building
+
+To build this image you will need to provide a build argument to choose which source image version you want.
+
+For the currently in use versions see the `container_image_versions.json` file.
+
+```
+NODE12_AMD64_VERSION=$(jq '.node12.amd64' < source_container_image_verisons.json)
+docker build --build-arg "SOURCE_CONTAINER_IMAGE_VERSION=$NODE12_AMD64_VERSION" govukpay/node-runner:local .
+```
+
+As part of the deployment pipeline both node12 and node16 versions will be produced, the source container versions will
+be read from the `source_container_image_versions.json` file.

--- a/ci/docker/node-runner/source_container_image_versions.json
+++ b/ci/docker/node-runner/source_container_image_versions.json
@@ -1,8 +1,0 @@
-{
-  "node12": {
-    "amd64": "12.22.10-alpine3.15@sha256:f150ebf9402f0dd6a9c4cb208ed64884cfa7c8a6ccae3f749a7b12156c25ad88"
-  },
-  "node16": {
-    "amd64": "16.14.0-alpine3.15@sha256:425c81a04546a543da824e67c91d4a603af16fbc3d875ee2f276acf8ec2b1577"
-  }
-}

--- a/ci/docker/node-runner/source_container_image_versions.json
+++ b/ci/docker/node-runner/source_container_image_versions.json
@@ -1,0 +1,8 @@
+{
+  "node12": {
+    "amd64": "12.22.10-alpine3.15@sha256:f150ebf9402f0dd6a9c4cb208ed64884cfa7c8a6ccae3f749a7b12156c25ad88"
+  },
+  "node16": {
+    "amd64": "16.14.0-alpine3.15@sha256:425c81a04546a543da824e67c91d4a603af16fbc3d875ee2f276acf8ec2b1577"
+  }
+}

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -9,14 +9,14 @@ resources:
       paths:
         - ci/docker/node-runner/*
 
-#  - name: node-runner-latest
-#    type: registry-image
-#    icon: docker
-#    source:
-#      repository: govukpay/node-runner
-#      username: ((docker-username))
-#      password: ((docker-password))
-#      tag: latest
+  - name: node-runner-latest
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/node-runner
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: latest
 
   - name: node-runner-node12
     type: registry-image
@@ -51,7 +51,7 @@ jobs:
           privileged: true
           output_mapping:
             image: node12-image
-          params: 
+          params:
             CONTEXT: node-runner-src/ci/docker/node-runner
             BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_versions.node12.amd64))"
           config:
@@ -70,7 +70,7 @@ jobs:
           privileged: true
           output_mapping:
             image: node16-image
-          params: 
+          params:
             CONTEXT: node-runner-src/ci/docker/node-runner
             BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_versions.node16.amd64))"
           config:
@@ -88,17 +88,17 @@ jobs:
       - in_parallel:
         - do:
           - put: node-runner-node12
-            params: 
+            params:
               image: node12-image/image.tar
             get_params:
               skip_download: true
-          # - put: node-runner-latest
-          #   params: 
-          #     image: node12-image/image.tar
-          #   get_params:
-          #     skip_download: true
+          - put: node-runner-latest
+            params:
+              image: node12-image/image.tar
+            get_params:
+              skip_download: true
         - put: node-runner-node16
-          params: 
+          params:
             image: node16-image/image.tar
           get_params:
             skip_download: true

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -42,10 +42,6 @@ jobs:
     plan:
       - get: node-runner-src
         trigger: true
-      - load_var: source_container_image_versions
-        file: node-runner-src/ci/docker/node-runner/source_container_image_versions.json
-        format: json
-        reveal: true
       - in_parallel:
         - task: build-node-12
           privileged: true
@@ -53,7 +49,7 @@ jobs:
             image: node12-image
           params:
             CONTEXT: node-runner-src/ci/docker/node-runner
-            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_image_versions.node12.amd64))"
+            DOCKERFILE: node-runner-src/ci/docker/node-runner/Dockerfile.node12
           config:
             platform: linux
             image_resource:
@@ -72,7 +68,7 @@ jobs:
             image: node16-image
           params:
             CONTEXT: node-runner-src/ci/docker/node-runner
-            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_image_versions.node16.amd64))"
+            DOCKERFILE: node-runner-src/ci/docker/node-runner/Dockerfile.node16
           config:
             platform: linux
             image_resource:

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -42,7 +42,7 @@ jobs:
     plan:
       - get: node-runner-src
         trigger: true
-      - load_var: source_container_versions
+      - load_var: source_container_image_versions
         file: node-runner-src/ci/docker/node-runner/source_container_image_versions.json
         format: json
         reveal: true
@@ -53,7 +53,7 @@ jobs:
             image: node12-image
           params:
             CONTEXT: node-runner-src/ci/docker/node-runner
-            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_versions.node12.amd64))"
+            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_image_versions.node12.amd64))"
           config:
             platform: linux
             image_resource:
@@ -72,7 +72,7 @@ jobs:
             image: node16-image
           params:
             CONTEXT: node-runner-src/ci/docker/node-runner
-            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_versions.node16.amd64))"
+            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_image_versions.node16.amd64))"
           config:
             platform: linux
             image_resource:

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -9,7 +9,7 @@ resources:
       paths:
         - ci/docker/node-runner/*
 
-  - name: node-runner
+  - name: node-runner-latest
     type: registry-image
     icon: docker
     source:
@@ -18,27 +18,87 @@ resources:
       password: ((docker-password))
       tag: latest
 
+  - name: node-runner-node12
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/node-runner
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: node16
+
+  - name: node-runner-node16
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/node-runner
+      username: ((docker-username))
+      password: ((docker-password))
+      tag: node16
+
 # Builds and pushes the node-runner Docker image used by various Concourse CI pipelines
 jobs:
   - name: build-and-push
     plan:
       - get: node-runner-src
         trigger: true
-      - task: build
-        privileged: true
-        params: 
-          CONTEXT: node-runner-src/ci/docker/node-runner
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: vito/oci-build-task
-          inputs:
-          - name: node-runner-src
-          outputs:
-          - name: image
-          run:
-            path: build
-      - put: node-runner
-        params: {image: image/image.tar}
+      - load_var: source_container_versions
+        file: node-runner-src/ci/docker/node-runner/source_container_image_versions.json
+        format: json
+        reveal: true
+      - in_parallel:
+        - task: build-node-12
+          privileged: true
+          output_mapping:
+            image: node12-image
+          params: 
+            CONTEXT: node-runner-src/ci/docker/node-runner
+            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_versions.node12.amd64))"
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source:
+                repository: concourse/oci-build-task
+            inputs:
+            - name: node-runner-src
+            outputs:
+            - name: image
+            run:
+              path: build
+        - task: build-node-16
+          privileged: true
+          output_mapping:
+            image: node16-image
+          params: 
+            CONTEXT: node-runner-src/ci/docker/node-runner
+            BUILD_ARG_SOURCE_CONTAINER_IMAGE_VERSION: "((.:source_container_versions.node16.amd64))"
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source:
+                repository: concourse/oci-build-task
+            inputs:
+            - name: node-runner-src
+            outputs:
+            - name: image
+            run:
+              path: build
+      - in_parallel:
+        - do:
+          - put: node-runner-node12
+            params: 
+              image: node12-image/image.tar
+            get_params:
+              skip_download: true
+          - put: node-runner-latest
+            params: 
+              image: node12-image/image.tar
+            get_params:
+              skip_download: true
+        - put: node-runner-node16
+          params: 
+            image: node16-image/image.tar
+          get_params:
+            skip_download: true

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -9,14 +9,14 @@ resources:
       paths:
         - ci/docker/node-runner/*
 
-  - name: node-runner-latest
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/node-runner
-      username: ((docker-username))
-      password: ((docker-password))
-      tag: latest
+#  - name: node-runner-latest
+#    type: registry-image
+#    icon: docker
+#    source:
+#      repository: govukpay/node-runner
+#      username: ((docker-username))
+#      password: ((docker-password))
+#      tag: latest
 
   - name: node-runner-node12
     type: registry-image
@@ -25,7 +25,7 @@ resources:
       repository: govukpay/node-runner
       username: ((docker-username))
       password: ((docker-password))
-      tag: node16
+      tag: node12
 
   - name: node-runner-node16
     type: registry-image
@@ -92,11 +92,11 @@ jobs:
               image: node12-image/image.tar
             get_params:
               skip_download: true
-          - put: node-runner-latest
-            params: 
-              image: node12-image/image.tar
-            get_params:
-              skip_download: true
+          # - put: node-runner-latest
+          #   params: 
+          #     image: node12-image/image.tar
+          #   get_params:
+          #     skip_download: true
         - put: node-runner-node16
           params: 
             image: node16-image/image.tar


### PR DESCRIPTION
UPDATE: Changed to using two dockerfiles to ensure we still get dependabot updates

~* Change node-runner to use a build-arg to decide the source container image version~
~* Include a json file which has the versions we want to use~
* Created separate dockerfiles for node12 and node16 and symlinked Dockerfile to the node12 dockerfile
* Update the node-runner node16 container to set a work-dir (since node-15 if you don't set a workdir npm install doesn't work, an alternative is to `npm install -g ...`)
* Update the node-runner README to explain how to build it locally
* Update the concourse node-runner pipeline to
    * run a build for both node12 and node16 
    * push node12, node16, and latest tagged images

A working version of this pipeline (which had the push latest disabled so I didn't affect the in-use image before approval) is https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/node-runner-test/jobs/build-and-push/builds/7

You can see the node12 and node16 tags pushed to the dockerhub repo: https://hub.docker.com/repository/docker/govukpay/node-runner

Of note: Changing to a build arg will mean we do not get dependabot updates for the alpine container anymore! The only way around this is to have 2 separate docker files (one for each node version)