### PR TITLE
PP-9373: Update run-codebuild to node16

### DIFF
--- a/.github/workflows/test-run-codebuild.yml
+++ b/.github/workflows/test-run-codebuild.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'ci/scripts/run-codebuild/**'
+      - '.github/workflows/test-run-codebuild.yml'
   push:
     branches:
       - master
@@ -17,20 +18,13 @@ jobs:
     env:
       working-directory: ci/scripts/run-codebuild
 
-    strategy:
-      matrix:
-        node-version:
-          - "12.22.7"
-          - "14"
-          - "16"
-
     steps:
       - name: Checkout
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - name: Setup Node.js
         uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16.14.0
       - name: Install dependencies
         run: npm ci
         working-directory: 'ci/scripts/run-codebuild'

--- a/ci/tasks/run-codebuild.yml
+++ b/ci/tasks/run-codebuild.yml
@@ -4,6 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: govukpay/node-runner
+    tag: node16
 inputs:
   - name: pay-ci
   - name: run-codebuild-configuration


### PR DESCRIPTION
1. Update run-codebuild to use node16 version of node-runner.
2. Update the workflow to only do node16 unit tests
3. Update the workflow to run on pull-requests where the workflow has changed