### PR TITLE
[PP-9241] Update Nginx Proxy Pipeline to Build...

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -834,7 +834,7 @@ groups:
       - push-stunnel-to-staging-ecr
   - name: nginx-proxy
     jobs:
-      - push-nginx-proxy-to-test-ecr
+      - build-and-push-nginx-proxy-to-test-ecr
       - deploy-toolbox
       - push-nginx-proxy-to-staging-ecr
   - name: nginx-forward-proxy
@@ -4063,26 +4063,31 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
-  - name: push-nginx-proxy-to-test-ecr
+  - name: build-and-push-nginx-proxy-to-test-ecr
     plan:
       - get: pay-ci
       - get: nginx-proxy-git-release
         trigger: true
-      # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - <<: *pull-image-from-dockerhub
-        input_mapping:
-          git-release: nginx-proxy-git-release
+      - task: build-nginx-proxy-image
+        privileged: true
         params:
-          DOCKER_REPOSITORY: govukpay/docker-nginx-proxy
-          <<: *docker_credentials
-      - task: parse-release-tag
-        file: pay-ci/ci/tasks/parse-release-tag.yml
-        input_mapping:
-          git-release: nginx-proxy-git-release
+          CONTEXT: nginx-proxy-git-release
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: nginx-proxy-git-release
+          outputs:
+            - name: image
+          run:
+            path: build
       - put: nginx-proxy-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: tags/tags
+          additional_tags: nginx-proxy-git-release/.git/ref
 
   - name: push-nginx-proxy-to-staging-ecr
     plan:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4084,10 +4084,14 @@ jobs:
             - name: image
           run:
             path: build
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: nginx-proxy-git-release
       - put: nginx-proxy-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: nginx-proxy-git-release/.git/ref
+          additional_tags: tags/tags
 
   - name: push-nginx-proxy-to-staging-ecr
     plan:


### PR DESCRIPTION
## What?
This tweaks the Nginx Proxy Pipeline so that we're no longer watching Docker Hub for images, but instead looking for changes to the master branch on GitHub and then building it and pushing it straight into ECR. This will make it function similarly to the Forward Proxy.

## How?
Running `fly -t pay-dev set-pipeline -c ci/pipelines/deploy-to-test.yml --pipeline deploy-to-test`:
```
groups:
  group nginx-proxy has changed:
  jobs:
- - push-nginx-proxy-to-test-ecr
+ - build-and-push-nginx-proxy-to-test-ecr
  - deploy-toolbox
  - push-nginx-proxy-to-staging-ecr
  name: nginx-proxy

jobs:
  job push-nginx-proxy-to-test-ecr has been removed:
- name: push-nginx-proxy-to-test-ecr
- plan:
- - get: pay-ci
- - get: nginx-proxy-git-release
-   trigger: true
- - file: pay-ci/ci/tasks/pull-image-from-dockerhub.yml
-   input_mapping:
-     git-release: nginx-proxy-git-release
-   params:
-     DOCKER_AUTH_TOKEN: ((docker-password))
-     DOCKER_REPOSITORY: govukpay/docker-nginx-proxy
-     DOCKER_USERNAME: ((docker-username))
-   privileged: true
-   task: pull-image-from-dockerhub
- - file: pay-ci/ci/tasks/parse-release-tag.yml
-   input_mapping:
-     git-release: nginx-proxy-git-release
-   task: parse-release-tag
- - params:
-     additional_tags: tags/tags
-     image: image/image.tar
-   put: nginx-proxy-ecr-registry-test

  job build-and-push-nginx-proxy-to-test-ecr has been added:
+ name: build-and-push-nginx-proxy-to-test-ecr
+ plan:
+ - get: pay-ci
+ - get: nginx-proxy-git-release
+   trigger: true
+ - config:
+     image_resource:
+       name: ""
+       source:
+         repository: concourse/oci-build-task
+       type: registry-image
+     inputs:
+     - name: nginx-proxy-git-release
+     outputs:
+     - name: image
+     platform: linux
+     run:
+       path: build
+   params:
+     CONTEXT: nginx-proxy-git-release
+   privileged: true
+   task: build-nginx-proxy-image
+ - params:
+     additional_tags: nginx-proxy-git-release/.git/ref
+     image: image/image.tar
+   put: nginx-proxy-ecr-registry-test

pipeline name: deploy-to-test
```