### PR TITLE
Pp 9213 cardid build

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -3797,9 +3797,10 @@ jobs:
 
   - name: build-and-push-selfservice-candidate
     plan:
-      - get: pay-ci
-      - get: selfservice-git-release
-        trigger: true
+      - in_parallel:
+        - get: pay-ci
+        - get: selfservice-git-release
+          trigger: true
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -741,7 +741,7 @@ groups:
       - adminusers-db-migration
   - name: cardid
     jobs:
-      - push-cardid-candidate-to-test-ecr
+      - build-and-push-cardid-candidate
       - run-cardid-e2e
       - deploy-cardid
       - smoke-test-cardid
@@ -4090,13 +4090,14 @@ jobs:
           image: selfservice-ecr-registry-test/image.tar
           additional_tags: selfservice-ecr-registry-test/tag
 
-  - name: push-cardid-candidate-to-test-ecr
+  - name: build-and-push-cardid-candidate
     plan:
-      - get: pay-ci
-      - get: cardid-git-release
-        trigger: true
-        params:
-          submodules: none
+      - in_parallel:
+        - get: pay-ci
+        - get: cardid-git-release
+          trigger: true
+          params:
+            submodules: none
       - task: update-submodule
         config:
           container_limits: {}
@@ -4104,19 +4105,20 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/concourse-runner
+              repository: alpine
           inputs:
             - name: cardid-git-release
           params:
             GH_ACCESS_TOKEN: ((github-access-token))
           outputs:
-            - name: image
+            - name: cardid-git-release-with-submodules
           run:
-            path: bash
+            path: ash
             dir: cardid-git-release
             args:
               - -ec
               - |
+                apk add --quiet --no-progress git
                 # cardid-data submodule's url is defined as ssh yet concourse
                 # is using oauth. Furthermore we need to avoid the password
                 # prompt from the git cli. Therefore rewrite the url for https
@@ -4130,23 +4132,85 @@ jobs:
                 git submodule update data
                 sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
                 sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
-    # Temporarily fetch image from Dockerhub until Concourse can build its own
-      - <<: *pull-image-from-dockerhub
-        input_mapping:
-          git-release: cardid-git-release
-        params:
-          DOCKER_REPOSITORY: govukpay/cardid
-          <<: *docker_credentials
+
+                cp -r . ../cardid-git-release-with-submodules
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
-         git-release: cardid-git-release
+          git-release: cardid-git-release
+      - in_parallel:
+        - load_var: release-number
+          file: tags/release-number
+        - load_var: release-name
+          file: cardid-git-release-with-submodules/.git/ref
+        - load_var: release-sha
+          file: tags/release-sha
+        - load_var: candidate-image-tag
+          file: tags/candidate-tag
+      - task: build-jar
+        config:
+          container_limits: {}
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: maven
+              tag: 3-openjdk-11
+          inputs:
+            - name: cardid-git-release-with-submodules
+          outputs:
+            - name: build-jar
+          run:
+            path: bash
+            dir: cardid-git-release-with-submodules
+            args:
+            - -ec
+            - |
+              mvn clean package
+              cp -r . ../build-jar
+      - task: build-image
+        privileged: true
+        params:
+          LABEL_release_number: ((.:release-number))
+          LABEL_release_name: ((.:release-name))
+          LABEL_release_sha: ((.:release-sha))
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: build-jar
+              path: .
+          outputs:
+            - name: image
+          run:
+            path: build
       - put: cardid-candidate
         params:
           image: image/image.tar
-          additional_tags: tags/candidate-tag         
+          additional_tags: tags/candidate-tag
         get_params:
           skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: cardid candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':hammer: cardid candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: run-cardid-e2e
     plan:
@@ -4155,7 +4219,7 @@ jobs:
           params:
             format: oci
           trigger: true
-          passed: [push-cardid-candidate-to-test-ecr]
+          passed: [build-and-push-cardid-candidate]
         - get: pay-ci
       - in_parallel:
         - task: parse-candidate-tag


### PR DESCRIPTION
Build cardid in concourse.
Bonus to make the selfservice gets in parallel

This is slightly different than the other java apps since it has a submodule in a private repo. The release checkout is done with `submodules: none` and then a task is run which actually gets the submodule using https basic auth instead of oath. This code was already written I just changed the image it used from concourse-runner (which is huge) to alpine and did apk add git (as we discovered the other day this is about 2 seconds, instead of around a minute pulling the concourse-runner image).

The whole repo is then copied into cardid-git-release-with-submodules output directory to be passed to later tasks. The later tasks all use this with-submodules version of the repo instead of the plain cardid-git-release repo.

Everything else is the same as the other moves to build in concourse.

I've done the same testing we did on our first one and created an additional build job and e2e test job in order to validate this is ok.

The build job: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-cardid-candidate/builds/1
The e2e test job: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/run-cardid-e2e-starling-test/builds/1

I also pulled the image from ECR and checked it included the cardid-data submodule data and it does.