### PR TITLE
PP-9418: Add start notification to notifications deploy to staging

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -2463,6 +2463,9 @@ jobs:
         file: snippet/failure
       - load_var: success_snippet
         file: snippet/success 
+      - load_var: start_snippet
+        file: snippet/start
+      - <<: *put_start_slack_notification
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:


### PR DESCRIPTION
Add the starting slack notification to the deploy-notifications-to-staging job.

All other deploy jobs in staging and production pipelines have the correct start notification already.