### PR TITLE
PP-9428 Retry Worldpay smoke test failures

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -104,24 +104,28 @@ definitions:
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_prod"
       - task: run_create_card_payment_worldpay_with_3ds-production
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds_prod"
       - task: run_create_card_payment_worldpay_with_3ds2-production
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds2_prod"
       - task: run_create_card_payment_worldpay_with_3ds2_exemption-production
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds2ex_prod"
       - task: run_create_card_payment_worldpay_without_3ds-production
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -113,24 +113,28 @@ definitions:
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_stag"
       - task: run_create_card_payment_worldpay_with_3ds-staging
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds_stag"
       - task: run_create_card_payment_worldpay_with_3ds2-staging
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds2_stag"
       - task: run_create_card_payment_worldpay_with_3ds2_exemption-staging
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds2ex_stag"
       - task: run_create_card_payment_worldpay_without_3ds-staging
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -883,24 +883,28 @@ definitions:
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_test"
       - task: run_create_card_payment_worldpay_with_3ds-test
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds_test"
       - task: run_create_card_payment_worldpay_with_3ds2-test
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds2_test"
       - task: run_create_card_payment_worldpay_with_3ds2_exemption-test
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_3ds2ex_test"
       - task: run_create_card_payment_worldpay_without_3ds-test
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds


### PR DESCRIPTION
Allow up to 10 attempts for the Worldpay post-deploy smoke tests before failing. This should reduce noise in the release slack channel and enable more continuous deployment without developer intervention. 

We will still have visibility on continued failures through the scheduled staging smoke tests. 