### PR TITLE
BAU: Allow 3 attempts for flaky card e2e tests

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1408,6 +1408,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -1732,6 +1733,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: run-codebuild-card
+        attempts: 3
         file: pay-ci/ci/tasks/run-codebuild.yml
         params:
           PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -2080,6 +2082,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: run-codebuild-card
+        attempts: 3
         file: pay-ci/ci/tasks/run-codebuild.yml
         params:
           PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -2427,6 +2430,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: run-codebuild-card
+        attempts: 3
         file: pay-ci/ci/tasks/run-codebuild.yml
         params:
           PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -3416,6 +3420,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -3730,6 +3735,7 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:    
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -4025,6 +4031,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -4371,6 +4378,7 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:    
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -326,6 +326,7 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -492,6 +493,7 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"
@@ -630,6 +632,7 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:
         - task: run-codebuild-card
+          attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
             PATH_TO_CONFIG: "../../../../run-codebuild-configuration/card.json"

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -651,6 +651,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: run-card-e2e-tests
+        attempts: 3
         file: ci/ci/tasks/run-codebuild.yml
         input_mapping:
           pay-ci: ci
@@ -726,6 +727,7 @@ jobs:
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:
         - task: run-card-e2e-tests
+          attempts: 3
           file: ci/ci/tasks/run-codebuild.yml
           input_mapping:
             pay-ci: ci
@@ -856,6 +858,7 @@ jobs:
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:
         - task: run-card-e2e-tests
+          attempts: 3
           file: ci/ci/tasks/run-codebuild.yml
           input_mapping:
             pay-ci: ci
@@ -1097,6 +1100,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: run-card-e2e-tests
+        attempts: 3
         file: ci/ci/tasks/run-codebuild.yml
         input_mapping:
           pay-ci: ci
@@ -1243,6 +1247,7 @@ jobs:
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:      
         - task: run-card-e2e-tests
+          attempts: 3
           file: ci/ci/tasks/run-codebuild.yml
           input_mapping:
             pay-ci: ci
@@ -1474,6 +1479,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: run-card-e2e-tests
+        attempts: 3
         file: ci/ci/tasks/run-codebuild.yml
         input_mapping:
           pay-ci: ci
@@ -1587,6 +1593,7 @@ jobs:
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:      
         - task: run-card-e2e-tests
+          attempts: 3
           file: ci/ci/tasks/run-codebuild.yml
           input_mapping:
             pay-ci: ci
@@ -1823,6 +1830,7 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     - in_parallel:
       - task: run-card-e2e-tests
+        attempts: 3
         file: ci/ci/tasks/run-codebuild.yml
         input_mapping:
           pay-ci: ci
@@ -1959,6 +1967,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     - task: run-card-e2e-tests
+      attempts: 3
       file: ci/ci/tasks/run-codebuild.yml
       input_mapping:
         pay-ci: ci


### PR DESCRIPTION
Adds retries for the deploy-to-test, e2e-helpers and pr-ci pipelines.

These retries can be removed once the flaky EPDQ scenario is no longer required.