### PR TITLE
PP-8295: Tag image with XXX-perf for adminusers

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -184,7 +184,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-8295-tag-image-with-xxx-perf
+      branch: master
   - name: pay-infra
     type: git
     icon: github

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -35,6 +35,14 @@ definitions:
     aws_ecr_registry_id: "((pay_aws_prod_account_id))"
     aws_region: eu-west-1
 
+  aws_test_config: &aws_test_config
+    aws_access_key_id: ((readonly_access_key_id))
+    aws_secret_access_key: ((readonly_secret_access_key))
+    aws_session_token: ((readonly_session_token))
+    aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse_deploy_worker_ecr_access
+    aws_ecr_registry_id: "((pay_aws_test_account_id))"
+    aws_region: eu-west-1
+
   put_start_slack_notification: &put_start_slack_notification
     put: slack-notification
     params:
@@ -176,7 +184,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: PP-8295-tag-image-with-xxx-perf
   - name: pay-infra
     type: git
     icon: github
@@ -227,6 +235,13 @@ resources:
       repository: govukpay/adminusers
       variant: release
       <<: *aws_prod_config
+  - name: adminusers-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      variant: release
+      <<: *aws_test_config
   - name: products-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -335,6 +350,7 @@ groups:
       - smoke-test-adminusers-on-prod
       - adminusers-pact-tag
       - adminusers-db-migration-prod
+      - retag-adminusers-image-for-test-perf
   - name: cardid
     jobs:
       - deploy-cardid-to-prod
@@ -1210,6 +1226,23 @@ jobs:
           <<: *smoke-test-run-all-on-production
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
+
+  - name: retag-adminusers-image-for-test-perf
+    plan:
+      - get: pay-ci
+      - get: adminusers-ecr-registry-prod
+        params:
+          format: oci
+        passed: [smoke-test-adminusers-on-prod]
+        trigger: true
+      - task: parse-perf-release-tag
+        file: pay-ci/ci/tasks/parse-perf-release-tag.yml
+        input_mapping:
+          ecr-repo: adminusers-ecr-registry-prod        
+      - put: adminusers-ecr-registry-test
+        params:
+          image: adminusers-ecr-registry-prod/image.tar
+          additional_tags: parse-perf-release-tag/tag        
 
   - name: adminusers-pact-tag
     plan:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -240,7 +240,6 @@ resources:
     icon: docker
     source:
       repository: govukpay/adminusers
-      variant: release
       <<: *aws_test_config
   - name: products-ecr-registry-prod
     type: registry-image

--- a/ci/tasks/parse-perf-release-tag.yml
+++ b/ci/tasks/parse-perf-release-tag.yml
@@ -1,0 +1,21 @@
+# This task parses the candidate tag from an ecr resource and turns it into a *-perf release tag
+#
+# File written:
+#   parse-perf-release-tag/tag : The perf release tag (e.g. 123-perf)
+#
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: alpine
+inputs:
+  - name: ecr-repo
+outputs:
+  - name: parse-perf-release-tag
+run:
+  path: sh
+  args:
+    - -ec
+    - |
+      RELEASE_NUMBER=$(cut -f 1 -d "-" < ecr-repo/tag)
+      echo "${RELEASE_NUMBER}-perf" | tee parse-perf-release-tag/tag


### PR DESCRIPTION
Tag image with XXX-perf in test ecr after successful deploy to prod. This is so
a future a job in the pay-dev account can deploy to test-perf environment by
listening on the XXX-perf variant.

🎉  https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-production/jobs/retag-adminusers-image-for-test-perf/builds/3

[1190-perf tag exists in test ECR too](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/223851549868/govukpay/adminusers?region=eu-west-1).