### PR TITLE
PP-9406 Add pact tasks to cardid deploy pipelines

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -456,6 +456,7 @@ groups:
     jobs:
       - deploy-cardid-to-prod
       - smoke-test-cardid-on-prod
+      - cardid-pact-tag
       - retag-cardid-image-for-test-perf
   - name: connector
     jobs:
@@ -2081,6 +2082,19 @@ jobs:
       - load_var: start_snippet
         file: snippet/start
       - <<: *put_start_slack_notification
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: cardid
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: check-pact-compatibility
+        file: pay-ci/ci/tasks/check-pact-compatibility.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: cardid
+          PACT_TAG: production-fargate
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2139,13 +2153,47 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
+  - name: cardid-pact-tag
+    plan:
+      - get: cardid-ecr-registry-prod
+        passed: [smoke-test-cardid-on-prod]
+        trigger: true
+      - load_var: application_image_tag
+        file: cardid-ecr-registry-prod/tag
+      - get: pay-ci
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          APP_NAME: cardid
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: cardid
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: cardid
+          PACT_TAG: production-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: retag-cardid-image-for-test-perf
     plan:
       - get: pay-ci
       - get: cardid-ecr-registry-prod
         params:
           format: oci
-        passed: [smoke-test-cardid-on-prod]
+        passed: [cardid-pact-tag]
         trigger: true
       - task: parse-perf-release-tag
         file: pay-ci/ci/tasks/parse-perf-release-tag.yml
@@ -2154,7 +2202,7 @@ jobs:
       - put: cardid-ecr-registry-test
         params:
           image: cardid-ecr-registry-prod/image.tar
-          additional_tags: parse-perf-release-tag/tag      
+          additional_tags: parse-perf-release-tag/tag
 
   - name: deploy-publicapi-to-prod
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -471,6 +471,7 @@ groups:
     jobs:
       - deploy-cardid-to-staging
       - smoke-test-cardid-on-staging
+      - cardid-pact-tag
       - push-cardid-to-production-ecr
   - name: connector
     jobs:
@@ -2010,6 +2011,19 @@ jobs:
       - load_var: start_snippet
         file: snippet/start  
       - <<: *put_start_slack_notification
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: cardid
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: check-pact-compatibility
+        file: pay-ci/ci/tasks/check-pact-compatibility.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: cardid
+          PACT_TAG: staging-fargate
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2068,13 +2082,47 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
+  - name: cardid-pact-tag
+    plan:
+      - get: cardid-ecr-registry-staging
+        passed: [smoke-test-cardid-on-staging]
+        trigger: true
+      - load_var: application_image_tag
+        file: cardid-ecr-registry-staging/tag
+      - get: pay-ci
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          APP_NAME: cardid
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: cardid
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: cardid
+          PACT_TAG: staging-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: push-cardid-to-production-ecr
     plan:
       - get: cardid-ecr-registry-staging
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-cardid-on-staging]
+        passed: [cardid-pact-tag]
       - put: cardid-ecr-registry-prod
         params:
           image: cardid-ecr-registry-staging/image.tar

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -745,6 +745,7 @@ groups:
       - run-cardid-e2e
       - deploy-cardid
       - smoke-test-cardid
+      - cardid-pact-tag
       - push-cardid-to-staging-ecr
   - name: connector
     jobs:
@@ -4478,6 +4479,19 @@ jobs:
         file: snippet/success
       - load_var: failure_snippet
         file: snippet/failure
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: cardid
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: check-pact-compatibility
+        file: pay-ci/ci/tasks/check-pact-compatibility.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: cardid
+          PACT_TAG: test-fargate
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -4536,13 +4550,47 @@ jobs:
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
+  - name: cardid-pact-tag
+    plan:
+      - get: cardid-ecr-registry-test
+        passed: [smoke-test-cardid]
+        trigger: true
+      - load_var: application_image_tag
+        file: cardid-ecr-registry-test/tag
+      - get: pay-ci
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          APP_NAME: cardid
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
+      - load_var: success_snippet
+        file: snippet/success
+      - load_var: failure_snippet
+        file: snippet/failure
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: cardid
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: cardid
+          PACT_TAG: test-fargate
+    <<: *put_success_slack_notification
+    <<: *put_failure_slack_notification
+
   - name: push-cardid-to-staging-ecr
     plan:
       - get: cardid-ecr-registry-test
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-cardid]
+        passed: [cardid-pact-tag]
       - put: cardid-ecr-registry-staging
         params:
           image: cardid-ecr-registry-test/image.tar


### PR DESCRIPTION
Add the check-pact-compatibility step in the deploy-cardid-to-xxxx job on each environment.

Add a cardid-pact-tag job to the deploy pipeline for each environment after running smoke tests.