### PR TITLE
PP-9256: Add simple pipeline to build and push perftests with self-updating

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -70,7 +70,6 @@ groups:
     jobs:
       - update-perf-tests-pipeline
 
-# Builds the Docker images used by end-to-end tests and pushes to ECR (and Dockerhub)
 jobs:
   - name: build-and-push-perf-tests
     plan:


### PR DESCRIPTION
Add a perf-tests pipeline which includes:

1. Building and pushing the perftests image to:
    1. ecr as XX-release and latest.
    2. dockerhub as XX-release and latest-master
2. Pipeline self update job

Successful build and push https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/build-and-push-perf-tests/builds/1
Successful self-update: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/update-perf-tests-pipeline/builds/2