### PR TITLE
PP-9307 add adminusers - ledger pact test pipeline

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -238,6 +238,7 @@ groups:
       - adminusers-integration-test
       - adminusers-e2e
       - adminusers-as-provider-pact-test
+      - adminusers-as-consumer-pact-test
       - record-adminusers-build-time
 
   - name: cardid
@@ -990,6 +991,47 @@ jobs:
       put: adminusers-pull-request
 
   - <<: *job-definition
+    name: adminusers-as-consumer-pact-test
+    serial_groups: [ pact-test ]
+    plan:
+      - <<: *get-ci
+      - <<: *get-pull-request
+        resource: adminusers-pull-request
+        passed: [ adminusers-unit-test, adminusers-integration-test ]
+      - put: adminusers-pull-request
+        get_params:
+          skip_download: true
+        params:
+          path: src
+          status: pending
+          context: app-as-consumer pact verification
+      - get: ledger-master
+      - get: adminusers-master
+        params: { submodules: none }
+      - <<: *pact-provider-test-preflight-check
+        params:
+          consumer: adminusers
+      - in_parallel:
+          - <<: *pact-provider-verification
+            task: ledger-provider-pact-verification
+            input_mapping:
+              test_target: ledger-master
+            params:
+              consumer: adminusers
+              provider: ledger
+        on_failure:
+          put: adminusers-pull-request
+          params:
+            path: src
+            status: failure
+            context: app-as-consumer pact verification
+      - put: adminusers-pull-request
+        params:
+          path: src
+          status: success
+          context: app-as-consumer pact verification
+
+  - <<: *job-definition
     name: adminusers-e2e
     plan:
       - <<: *get-pull-request
@@ -1062,7 +1104,7 @@ jobs:
     - <<: *get-pull-request
       resource: adminusers-pull-request
       passed: [adminusers-unit-test, adminusers-integration-test,
-        adminusers-as-provider-pact-test]
+        adminusers-as-provider-pact-test, adminusers-as-consumer-pact-test]
     - <<: *send-pr-build-time
 
   - <<: *job-definition


### PR DESCRIPTION
- add Concourse PR pipeline for the new pact test, where adminusers is the consumer and ledger is the provider. deploy pipelines are already set up for pact tagging.