### PR TITLE
PP-8337: Add task to scale fargate services

### DIFF
--- a/ci/tasks/scale-fargate-service.yml
+++ b/ci/tasks/scale-fargate-service.yml
@@ -1,0 +1,63 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/concourse-runner
+params:
+  SERVICE_NAME:
+  SCALE_DIRECTION:
+  DESIRED_HEALTHY_INSTANCES:
+  AWS_DEFAULT_REGION: eu-west-1
+  MAX_ATTEMPTS: 40
+  ECS_CLUSTER: test-perf-1-fargate
+run:
+  path: /bin/bash
+  args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      if [ "${SCALE_DIRECTION}" != "out" ] && [ "${SCALE_DIRECTION}" != "in" ]; then
+        echo "Unkown SCALE_DIRECTION env var, must be either 'in' or 'out', is set to '${SCALE_DIRECTION}'"
+        exit 1
+      fi
+
+      # The bash ${ECS_CLUSTER%-fargate} means the ECS_CLUSTER env var with -fargate removed from the end
+      TARGET_GROUP_NAME="${ECS_CLUSTER%-fargate}-${SERVICE_NAME}-lb-tg"
+      TARGET_GROUP_ARN=$(
+        aws elbv2 describe-target-groups  \
+          --query TargetGroups[?TargetGroupName==\`${TARGET_GROUP_NAME}\`].TargetGroupArn \
+          --output text
+      )
+
+      echo "Updating ${SERVICE_NAME} in ECS cluster ${ECS_CLUSTER} to have ${DESIRED_HEALTHY_INSTANCES} desired instances"
+      aws ecs update-service --cluster "$ECS_CLUSTER" --service "$SERVICE_NAME" --desired-count "$DESIRED_HEALTHY_INSTANCES" >> /dev/null
+
+      function healthy_instance_count() {
+        aws elbv2 describe-target-health --target-group-arn "${TARGET_GROUP_ARN}" --query 'TargetHealthDescriptions[?TargetHealth.State==`healthy`]' | jq 'length'
+      }
+
+      TOTAL_WAIT_TIME_IN_MINUTES=$((MAX_ATTEMPTS * 15 / 60))
+
+      echo "Starting to wait up to ${TOTAL_WAIT_TIME_IN_MINUTES} minutes for target group ${TARGET_GROUP_NAME} " \
+          "to scale-${SCALE_DIRECTION} to ${DESIRED_HEALTHY_INSTANCES} healthy instances"
+
+      for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+        HEALTHY_INSTANCES=$(healthy_instance_count)
+
+        if [ "${SCALE_DIRECTION}" == "out" ] && [ "${HEALTHY_INSTANCES}" -ge "${DESIRED_HEALTHY_INSTANCES}" ]; then
+          echo "There are ${HEALTHY_INSTANCES} healthy now, this is greater than or equal to ${DESIRED_HEALTHY_INSTANCES}"
+          exit 0
+        elif [ "${SCALE_DIRECTION}" == "in" ] && [ "${HEALTHY_INSTANCES}" -le "${DESIRED_HEALTHY_INSTANCES}" ]; then
+          echo "There are ${HEALTHY_INSTANCES} healthy now, this is less than or equal to ${DESIRED_HEALTHY_INSTANCES}"
+          exit 0
+        fi
+
+        echo "There are currently ${HEALTHY_INSTANCES} healthy instances with ${DESIRED_HEALTHY_INSTANCES} desired." \
+            "Waiting 15 seconds before checking again. Attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+        sleep 15
+      done
+
+      echo "Max attempts reached, target group failed to get to ${DESIRED_HEALTHY_INSTANCES} healthy instances"
+      exit 1


### PR DESCRIPTION
Add a task to scale up and down fargate services. This is based on (copy and pasted with a small modification to run the scale command first) https://github.com/alphagov/pay-concourse/blob/main/pipelines/tasks/wait-for-targetgroup-health.yml which has proven to be extremely robust over many months.
# How?
## Scaling up
Where services are at lower capacity to start with: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-services/builds/4

Where services are already scaled up: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-services/builds/3

## Scaling down

See it in action:

Where there are more running tasks than desired: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-services/builds/3

Where the tasks are already scaled down: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-services/builds/4

