### PR TITLE
PP-8337: Add tasks to start and stop RDS instances

### DIFF
--- a/ci/tasks/start-rds-instance.yml
+++ b/ci/tasks/start-rds-instance.yml
@@ -1,0 +1,40 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/concourse-runner
+params:
+  RDS_INSTANCE_NAME:
+  AWS_DEFAULT_REGION: eu-west-1
+run:
+  path: /bin/bash
+  args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      CURRENT_STATE=$(
+        aws rds describe-db-instances \
+          --db-instance-identifier "${RDS_INSTANCE_NAME}" \
+          --query "DBInstances[0].DBInstanceStatus" \
+          --output text
+      )
+
+      if [ "${CURRENT_STATE}" == "available" ]; then
+        echo "RDS instance ${RDS_INSTANCE_NAME} is already available"
+        exit 0
+      elif [ "${CURRENT_STATE}" == "starting" ]; then
+        echo "RDS instance ${RDS_INSTANCE_NAME} is already starting up"
+      elif [ "${CURRENT_STATE}" != "stopped" ]; then
+        echo "RDS instance ${RDS_INSTANCE_NAME} is not in a state that can be started." \
+          "It's currently in ${CURRENT_STATE}, manual intervention will be required to resolve this."
+
+        exit 1
+      else
+        echo "Starting RDS instance ${RDS_INSTANCE_NAME}"
+        aws rds start-db-instance --db-instance-identifier "${RDS_INSTANCE_NAME}" >> /dev/null
+      fi
+
+      echo "Waiting for RDS instance ${RDS_INSTANCE_NAME} to be available"
+      aws rds wait db-instance-available --db-instance-identifier "${RDS_INSTANCE_NAME}"

--- a/ci/tasks/start-rds-instance.yml
+++ b/ci/tasks/start-rds-instance.yml
@@ -38,3 +38,5 @@ run:
 
       echo "Waiting for RDS instance ${RDS_INSTANCE_NAME} to be available"
       aws rds wait db-instance-available --db-instance-identifier "${RDS_INSTANCE_NAME}"
+
+      echo "RDS instance ${RDS_INSTANCE_NAME} is now available"

--- a/ci/tasks/stop-rds-instance.yml
+++ b/ci/tasks/stop-rds-instance.yml
@@ -1,0 +1,56 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govukpay/concourse-runner
+params:
+  RDS_INSTANCE_NAME:
+  AWS_DEFAULT_REGION: eu-west-1
+  MAX_ATTEMPTS: 100
+run:
+  path: /bin/bash
+  args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      function db_instance_state() {
+        aws rds describe-db-instances --db-instance-identifier "${RDS_INSTANCE_NAME}" --query "DBInstances[0].DBInstanceStatus" --output text
+      }
+
+      CURRENT_STATE=$(db_instance_state)
+
+      if [ "${CURRENT_STATE}" == "stopped" ]; then
+        echo "RDS instance ${RDS_INSTANCE_NAME} is already stopped"
+        exit 0
+      elif [ "${CURRENT_STATE}" == "stopping" ]; then
+        echo "RDS instance ${RDS_INSTANCE_NAME} is already stopping"
+      elif [ "${CURRENT_STATE}" != "available" ]; then
+        echo "RDS instance ${RDS_INSTANCE_NAME} is not in a state which can be stopped. " \
+          "It's currently in state ${CURRENT_STATE}, manual intervention will be required"
+        exit  1
+      else
+        echo "Stopping RDS instance ${RDS_INSTANCE_NAME}"
+        aws rds stop-db-instance --db-instance-identifier "${RDS_INSTANCE_NAME}" >> /dev/null
+      fi
+
+      TOTAL_WAIT_TIME_IN_MINUTES=$((MAX_ATTEMPTS * 15 / 60))
+
+      echo "Starting to wait up to ${TOTAL_WAIT_TIME_IN_MINUTES} minutes for RDS instance ${RDS_INSTANCE_NAME} to stop"
+
+      for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+        CURRENT_STATE=$(db_instance_state)
+
+        if [ "${CURRENT_STATE}" == "stopped" ]; then
+          echo "The RDS instance ${RDS_INSTANCE_NAME} is now stopped"
+          exit 0
+        fi
+
+        echo "The RDS instance ${RDS_INSTANCE_NAME} is currently in state ${CURRENT_STATE}." \
+            "Waiting 15 seconds before checking again. Attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+        sleep 15
+      done
+
+      echo "RDS instance ${RDS_INSTANCE_NAME} did not reach the stopped state within ${TOTAL_WAIT_TIME_IN_MINUTES} minutes"
+      exit 1


### PR DESCRIPTION
Added tasks to:

1. Start an rds instance and wait for it to reach the available state
2. Stop an rds instance and wait for it to reach the stopped state

# Examples of running:
## Start RDS instance

Where databases were started from a stopped state: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-databases/builds/9

Where databases were already starting: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-databases/builds/8

Where databases were already started: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-databases/builds/10


## Stop RDS instance

Where databases were stopped from an available state: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-databases/builds/8

Where some databases were already stopped and some were already stopping: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-databases/builds/7