### PR TITLE
PP-8337: Start RDS before migration and stop after migration in deploy-to-perf

### DIFF
--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -462,15 +462,16 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
-      - task: stop-adminusers-db
-        file: pay-ci/ci/tasks/stop-rds-instance.yml
-        params:
-          RDS_INSTANCE_NAME: test-perf-1-adminusers-rds-0
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
+    ensure:
+      task: stop-adminusers-db
+      file: pay-ci/ci/tasks/stop-rds-instance.yml
+      params:
+        RDS_INSTANCE_NAME: test-perf-1-adminusers-rds-0
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: deploy-selfservice-to-perf
     serial: true
@@ -631,15 +632,16 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
-      - task: stop-connector-db
-        file: pay-ci/ci/tasks/stop-rds-instance.yml
-        params:
-          RDS_INSTANCE_NAME: test-perf-1-connector-rds-0
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
+    ensure:
+      task: stop-connector-db
+      file: pay-ci/ci/tasks/stop-rds-instance.yml
+      params:
+        RDS_INSTANCE_NAME: test-perf-1-connector-rds-0
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: deploy-toolbox-to-perf
     serial: true
@@ -862,15 +864,16 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
-      - task: stop-products-db
-        file: pay-ci/ci/tasks/stop-rds-instance.yml
-        params:
-          RDS_INSTANCE_NAME: test-perf-1-products-rds-0
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
+    ensure:
+      task: stop-products-db
+      file: pay-ci/ci/tasks/stop-rds-instance.yml
+      params:
+        RDS_INSTANCE_NAME: test-perf-1-products-rds-0
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: deploy-products-ui-to-perf
     serial: true
@@ -1031,15 +1034,16 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
-      - task: stop-publicauth-db
-        file: pay-ci/ci/tasks/stop-rds-instance.yml
-        params:
-          RDS_INSTANCE_NAME: test-perf-1-publicauth-rds-0
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
+    ensure:
+      task: stop-publicauth-db
+      file: pay-ci/ci/tasks/stop-rds-instance.yml
+      params:
+        RDS_INSTANCE_NAME: test-perf-1-publicauth-rds-0
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: deploy-cardid-to-perf
     serial: true
@@ -1200,15 +1204,16 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
-      - task: stop-ledger-db
-        file: pay-ci/ci/tasks/stop-rds-instance.yml
-        params:
-          RDS_INSTANCE_NAME: test-perf-1-ledger-rds-0
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
+    ensure:
+      task: stop-ledger-db
+      file: pay-ci/ci/tasks/stop-rds-instance.yml
+      params:
+        RDS_INSTANCE_NAME: test-perf-1-ledger-rds-0
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: deploy-publicapi-to-perf
     serial: true

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -432,6 +432,13 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: adminusers-db-ecr-registry-perf/tag
+      - task: start-adminusers-db
+        file: pay-ci/ci/tasks/start-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-adminusers-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -455,6 +462,13 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
+      - task: stop-adminusers-db
+        file: pay-ci/ci/tasks/stop-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-adminusers-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
 
@@ -587,6 +601,13 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: connector-db-ecr-registry-perf/tag
+      - task: start-connector-db
+        file: pay-ci/ci/tasks/start-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-connector-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -610,6 +631,13 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
+      - task: stop-connector-db
+        file: pay-ci/ci/tasks/stop-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-connector-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
 
@@ -804,6 +832,13 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: products-db-ecr-registry-perf/tag
+      - task: start-products-db
+        file: pay-ci/ci/tasks/start-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-products-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -827,6 +862,13 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
+      - task: stop-products-db
+        file: pay-ci/ci/tasks/stop-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-products-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
 
@@ -959,6 +1001,13 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: publicauth-db-ecr-registry-perf/tag
+      - task: start-publicauth-db
+        file: pay-ci/ci/tasks/start-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-publicauth-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -982,6 +1031,13 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
+      - task: stop-publicauth-db
+        file: pay-ci/ci/tasks/stop-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-publicauth-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
 
@@ -1114,6 +1170,13 @@ jobs:
         format: json
       - load_var: application_image_tag
         file: ledger-db-ecr-registry-perf/tag
+      - task: start-ledger-db
+        file: pay-ci/ci/tasks/start-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-ledger-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -1137,6 +1200,13 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/run-ecs-db-migration.js
+      - task: stop-ledger-db
+        file: pay-ci/ci/tasks/stop-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-ledger-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_db_migration_success_slack_notification
     <<: *put_db_migration_failure_slack_notification
 


### PR DESCRIPTION
As part of the strategy to run test-perf-1 totally scaled down and only scale up when perf tests run or DB migrations need to happen this starts the db that needs migration and stops it after migration.

# How?
You can see in this build that the start db task ran, then after the migration (which fails for unrelated reasons) it stops the DB: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-perf/jobs/adminusers-db-migration-perf/builds/5