### PR TITLE
PP-921 Add webhooks database migration pipeline for test

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -864,6 +864,7 @@ groups:
     jobs:
       - build-webhooks
       - deploy-webhooks
+      - webhooks-db-migration
   - name: carbon-relay
     jobs:
       - deploy-carbon-relay
@@ -4786,6 +4787,50 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
+
+  - name: webhooks-db-migration
+    plan:
+      - get: pay-ci
+      - get: webhooks-ecr-registry-test
+        params:
+          format: oci
+        trigger: false
+        passed: [deploy-webhooks]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: webhooks-ecr-registry-test/tag
+      - <<: *put_db_migration_slack_notification
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "test-12-fargate"
+            APP_NAME: "webhooks"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js
+    <<: *put_db_migration_success_slack_notification
+    <<: *put_db_migration_failure_slack_notification
 
   - name: build-and-push-nginx-proxy-to-test-ecr
     plan:


### PR DESCRIPTION
Allow the webhooks service to be deployed with database migration flags
in order to run liquibase migration sets.

This task should require a successful webhooks deploy and should be
triggered by the ecr registry test. Add this task to the webhooks job.