### PR TITLE
PP-8337: Add notifications to slack for performance test failures

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -603,6 +603,15 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          on_failure:
+            put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-announce'
+              silent: true
+              text: ':red-circle: Performance test PaymentSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
       - try:
           task: search-payments-simulation-perf-test
           file: pay-ci/ci/tasks/run-codebuild.yml
@@ -611,6 +620,15 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          on_failure:
+            put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-announce'
+              silent: true
+              text: ':red-circle: Performance test SearchPaymentsSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
       - try:
           task: self-service-simulation-perf-test
           file: pay-ci/ci/tasks/run-codebuild.yml
@@ -619,6 +637,35 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          on_failure:
+            put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-announce'
+              silent: true
+              text: ':red-circle: Performance test SelfServiceSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        # This one failure goes to starling since it's the daily performance test run and this is a notification that the actual execution of
+        # those tests is failing (as opposed to bad results from the performance test itself)
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Failed to execute performance test - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Performance test execution completed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
     ensure:
       do:
         - <<: *scale-down-services
@@ -662,6 +709,34 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          on_failure:
+            put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-announce'
+              silent: true
+              text: ':red-circle: Performance test SearchPaymentsSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: Failed to execute individual performance test SearchPaymentsSimulation - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Individual performance test execution of SearchPaymentsSimulation completed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
 
   - name: run-payment-simulation-perf-test
     serial: true
@@ -694,6 +769,35 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          on_failure:
+            put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-announce'
+              silent: true
+              text: ':red-circle: Performance test PaymentSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: Failed to execute individual performance test PaymentSimulation - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Individual performance test execution of PaymentSimulation completed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
+
 
   - name: run-self-service-simulation-perf-test
     serial: true
@@ -726,6 +830,34 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          on_failure:
+            put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-announce'
+              silent: true
+              text: ':red-circle: Performance test SelfServiceSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: Failed to execute individual performance test SelfServiceSimulation - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Individual performance test execution of SelfServiceSimulation completed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
 
   - name: scale-up-databases
     serial: true


### PR DESCRIPTION
Add notifications for performance tests.

There are 2 distinct kinds of notifications here.

* Notifications that the execution of the tests has passed/failed (meaning the scale up/down, starting the codebuild job etc)
* Notifications that the test run received a bad result

For the daily performance test run ONLY I've sent the test execution failure to starling since this represents some infrastructure problem.

All the others just go to announce.

I'm running a full perf test here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-and-run-all-simulations/builds/10

The search payment simulation always fails so it should give us a notification to validate (et. voila: https://gds.slack.com/archives/CAEN2AVLP/p1654080442118789)
<img width="417" alt="Screenshot 2022-06-01 at 11 48 26" src="https://user-images.githubusercontent.com/2170030/171387606-a9e87060-aa9a-47f0-8d0f-cb4e37bad438.png">

