### PR TITLE
PP-9716: Deploy scheduled tasks in other envs

### DIFF
--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -244,6 +244,20 @@ resources:
       repository: govukpay/notifications
       variant: perf
       <<: *aws_test_config
+  - name: alpine-ecr-registry-perf
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/alpine
+      variant: perf
+      <<: *aws_test_config
+  - name: stream-s3-sqs-ecr-registry-perf
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/stream-s3-sqs
+      variant: perf
+      <<: *aws_test_config
   - name: pay-stubs-manifest
     type: git
     icon: github
@@ -299,6 +313,9 @@ groups:
     jobs:
       - deploy-connector-to-perf
       - connector-db-migration-perf
+  - name: egress
+    jobs:
+      - deploy-egress-to-perf
   - name: frontend
     jobs:
       - deploy-frontend-to-perf
@@ -325,13 +342,10 @@ groups:
       - deploy-selfservice-to-perf
   - name: toolbox
     jobs:
-      - deploy-toolbox-to-perf            
-  - name: update-deploy-to-perf-pipeline
+      - deploy-toolbox-to-perf
+  - name: alpine
     jobs:
-      - update-deploy-to-perf-pipeline
-  - name: egress
-    jobs:
-      - deploy-egress-to-perf
+      - deploy-scheduled-tasks
   - name: carbon-relay
     jobs:
       - deploy-carbon-relay-to-perf
@@ -347,9 +361,15 @@ groups:
   - name: nginx-forward-proxy
     jobs:
       - deploy-frontend-to-perf
+  - name: stream-s3-sqs
+    jobs:
+      - deploy-scheduled-tasks
   - name: stubs
     jobs:
       - deploy-stubs-to-perf
+  - name: update-deploy-to-perf-pipeline
+    jobs:
+      - update-deploy-to-perf-pipeline
 
 jobs:
   - name: update-deploy-to-perf-pipeline
@@ -1474,3 +1494,53 @@ jobs:
             smartpay-expected-user: ((smartpay-expected-user))
             worldpay-expected-password: ((worldpay-expected-password))
             worldpay-expected-user: ((worldpay-expected-user))
+
+  - name: deploy-scheduled-tasks
+    plan:
+      - in_parallel:
+        - get: alpine-ecr-registry-perf
+          trigger: true
+        - get: stream-s3-sqs-ecr-registry-perf
+          trigger: true
+        - get: pay-ci
+        - get: pay-infra
+      - in_parallel:
+        - load_var: alpine_image_tag
+          file: alpine-ecr-registry-perf/tag
+        - load_var: stream_s3_sqs_image_tag
+          file: stream-s3-sqs-ecr-registry-perf/tag
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+            AWS_ROLE_SESSION_NAME: terraform-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-perf
+        file: pay-ci/ci/tasks/deploy-scheduled-tasks.yml
+        params:
+          APP_NAME: adminusers
+          ALPINE_IMAGE_TAG: ((.:alpine_image_tag))
+          STREAM_S3_SQS_IMAGE_TAG: ((.:stream_s3_sqs_image_tag))
+          ACCOUNT: test
+          ENVIRONMENT: test-perf-1
+          <<: *aws_assumed_role_creds
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: Scheduled tasks failed to deploy alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag)) - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Scheduled tasks deployed alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag)) successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -226,6 +226,32 @@ resources:
     source:
       repository: govukpay/egress
       <<: *aws_test_config      
+  - name: alpine-ecr-registry-prod
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/alpine
+      variant: release
+      <<: *aws_prod_config
+  - name: alpine-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/alpine
+      <<: *aws_test_config
+  - name: stream-s3-sqs-ecr-registry-prod
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/stream-s3-sqs
+      variant: release
+      <<: *aws_prod_config
+  - name: stream-s3-sqs-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/stream-s3-sqs
+      <<: *aws_test_config
   - name: carbon-relay-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -543,6 +569,10 @@ groups:
     jobs:
       - deploy-toolbox-to-prod
       - retag-toolbox-image-for-test-perf
+  - name: alpine
+    jobs:
+      - deploy-scheduled-tasks
+      - retag-alpine-image-for-test-perf
   - name: carbon-relay
     jobs:
       - deploy-carbon-relay-to-prod
@@ -565,6 +595,10 @@ groups:
       - deploy-notifications-to-prod
       - smoke-test-notifications-on-prod
       - retag-notifications-for-test-perf
+  - name: stream-s3-sqs
+    jobs:
+      - deploy-scheduled-tasks
+      - retag-stream-s3-sqs-image-for-test-perf
   - name: update-deploy-to-prod-pipeline
     jobs:
       - update-deploy-to-prod-pipeline
@@ -2796,3 +2830,91 @@ jobs:
         params:
           image: notifications-ecr-registry-prod/image.tar
           additional_tags: parse-perf-release-tag/tag
+
+  - name: deploy-scheduled-tasks
+    plan:
+      - in_parallel:
+        - get: alpine-ecr-registry-prod
+          trigger: true
+        - get: stream-s3-sqs-ecr-registry-prod
+          trigger: true
+        - get: pay-ci
+        - get: pay-infra
+      - in_parallel:
+        - load_var: alpine_image_tag
+          file: alpine-ecr-registry-prod/tag
+        - load_var: stream_s3_sqs_image_tag
+          file: stream-s3-sqs-ecr-registry-prod/tag
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+            AWS_ROLE_SESSION_NAME: terraform-prod-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-prod
+        file: pay-ci/ci/tasks/deploy-scheduled-tasks.yml
+        params:
+          APP_NAME: adminusers
+          ALPINE_IMAGE_TAG: ((.:alpine_image_tag))
+          STREAM_S3_SQS_IMAGE_TAG: ((.:stream_s3_sqs_image_tag))
+          ACCOUNT: production
+          ENVIRONMENT: production-2
+          <<: *aws_assumed_role_creds
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: Scheduled tasks failed to deploy alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag)) - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Scheduled tasks deployed alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag)) successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
+  - name: retag-alpine-image-for-test-perf
+    plan:
+      - get: pay-ci
+      - get: alpine-ecr-registry-prod
+        passed: [deploy-scheduled-tasks]
+        params:
+          format: oci
+        trigger: true
+      - task: parse-perf-release-tag
+        file: pay-ci/ci/tasks/parse-perf-release-tag.yml
+        input_mapping:
+          ecr-repo: alpine-ecr-registry-prod
+      - put: alpine-ecr-registry-test
+        params:
+          image: alpine-ecr-registry-prod/image.tar
+          additional_tags: parse-perf-release-tag/tag
+        get_params:
+          skip_download: true
+
+  - name: retag-stream-s3-sqs-image-for-test-perf
+    plan:
+      - get: pay-ci
+      - get: stream-s3-sqs-ecr-registry-prod
+        passed: [deploy-scheduled-tasks]
+        params:
+          format: oci
+        trigger: true
+      - task: parse-perf-release-tag
+        file: pay-ci/ci/tasks/parse-perf-release-tag.yml
+        input_mapping:
+          ecr-repo: stream-s3-sqs-ecr-registry-prod
+      - put: stream-s3-sqs-ecr-registry-test
+        params:
+          image: stream-s3-sqs-ecr-registry-prod/image.tar
+          additional_tags: parse-perf-release-tag/tag
+        get_params:
+          skip_download: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -568,6 +568,7 @@ groups:
       - push-toolbox-to-production-ecr
   - name: alpine
     jobs:
+      - deploy-scheduled-tasks
       - push-alpine-to-production-ecr
   - name: carbon-relay
     jobs:
@@ -594,6 +595,7 @@ groups:
       - push-notifications-to-production-ecr
   - name: stream-s3-sqs
     jobs:
+      - deploy-scheduled-tasks
       - push-stream-s3-sqs-to-production-ecr
   - name: update-deploy-to-staging-pipeline
     jobs:
@@ -603,6 +605,7 @@ jobs:
   - name: push-stream-s3-sqs-to-production-ecr
     plan:        
       - get: stream-s3-sqs-ecr-registry-staging
+        passed: [deploy-scheduled-tasks]
         params:
           format: oci
         trigger: true
@@ -692,9 +695,60 @@ jobs:
           image: carbon-relay-ecr-registry-staging/image.tar
           additional_tags: carbon-relay-ecr-registry-staging/tag
 
+  - name: deploy-scheduled-tasks
+    plan:
+      - in_parallel:
+        - get: alpine-ecr-registry-staging
+          trigger: true
+        - get: stream-s3-sqs-ecr-registry-staging
+          trigger: true
+        - get: pay-ci
+        - get: pay-infra
+      - in_parallel:
+        - load_var: alpine_image_tag
+          file: alpine-ecr-registry-staging/tag
+        - load_var: stream_s3_sqs_image_tag
+          file: stream-s3-sqs-ecr-registry-staging/tag
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+            AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-staging
+        file: pay-ci/ci/tasks/deploy-scheduled-tasks.yml
+        params:
+          APP_NAME: adminusers
+          ALPINE_IMAGE_TAG: ((.:alpine_image_tag))
+          STREAM_S3_SQS_IMAGE_TAG: ((.:stream_s3_sqs_image_tag))
+          ACCOUNT: staging
+          ENVIRONMENT: staging-2
+          <<: *aws_assumed_role_creds
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: Scheduled tasks failed to deploy alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag)) - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Scheduled tasks deployed alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag)) successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
   - name: push-alpine-to-production-ecr
     plan:
       - get: alpine-ecr-registry-staging
+        passed: [deploy-scheduled-tasks]
         params:
           format: oci
         trigger: true


### PR DESCRIPTION
Deploy scheduled tasks to staging, production and perf env.

I've followed the exact pattern of the other apps and had production add an X-perf tag in test, and then trigger in the deploy-to-perf pipeline to deploy that to test-perf-1.

Note: I also slightly reordered the groups in deploy-to-perf so it matches all the other pipelines (egress in with the microservices, pipeline self-update at the end)

# How?
See it in action

## staging
alpine: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-staging?group=alpine
stream-s3-sqs: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-staging?group=stream-s3-sqs

## production
alpine: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-production?group=alpine
stream-s3-sqs: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-production?group=stream-s3-sqs

## perf
alpine: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-perf?group=alpine
stream-s3-sqs: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-perf?group=stream-s3-sqs
