### PR TITLE
PP-9737: Add generate-docker-config-file.yml task from EngineerBetter and use in 1 job as a demo

### DIFF
--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -42,7 +42,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: vito/oci-build-task
+              repository: concourse/oci-build-task
           inputs:
           - name: concourse-runner-src
           outputs:

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -254,19 +254,27 @@ jobs:
         - get: endtoend-git-release
           trigger: true
         - get: pay-ci
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - in_parallel:
         - task: build-endtoend-image
           privileged: true
           params:
             CONTEXT: endtoend-git-release
+            DOCKER_CONFIG: docker_creds
           config:
             platform: linux
             image_resource:
               type: registry-image
               source:
-                repository: vito/oci-build-task
+                repository: concourse/oci-build-task
             inputs:
               - name: endtoend-git-release
+              - name: docker_creds
             outputs:
               - name: image
             run:
@@ -430,7 +438,7 @@ jobs:
               image_resource:
                 type: registry-image
                 source:
-                  repository: vito/oci-build-task
+                  repository: concourse/oci-build-task
               inputs:
               - name: reverse-proxy-git-release
               outputs:
@@ -570,7 +578,7 @@ jobs:
             image_resource:
               type: registry-image
               source:
-                repository: vito/oci-build-task
+                repository: concourse/oci-build-task
             inputs:
             - name: stubs-git-release
             outputs:

--- a/ci/tasks/generate-docker-config-file.yml
+++ b/ci/tasks/generate-docker-config-file.yml
@@ -1,0 +1,49 @@
+---
+# Task from https://github.com/EngineerBetter/concourse-tasks/tree/main/generate-docker-config-file at commit e7b2b43756c828c8c13df1f4512349e9febe0da4 on main branch under the MIT license below.
+#
+# MIT License
+#
+# Copyright (c) 2020 EngineerBetter
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+platform: linux
+image_resource:
+  type: registry-image
+  source: { repository: alpine }
+
+outputs:
+- name: docker_creds
+
+run:
+  path: ash
+  args:
+  - -c
+  - |
+    : "${USERNAME:?USERNAME param must be set and not empty}"
+    : "${PASSWORD:?PASSWORD param must be set and not empty}"
+    : "${EMAIL:?EMAIL param must be set and not empty}"
+    AUTH="$(echo -n "$USERNAME:$PASSWORD" | base64)"
+    cat > docker_creds/config.json <<EOF
+    { "auths": { "https://index.docker.io/v1/": { "auth": "$AUTH", "email": "$EMAIL" } } }
+    EOF
+    echo "Wrote auth to docker_creds/config.json"
+params:
+  USERNAME:
+  PASSWORD:
+  EMAIL:


### PR DESCRIPTION
Enable dockerhub authentication on oci-build-task using the generate-docker-config-file task from EngineerBetter under the MIT license.

Also switch usage of vito/oci-build-task with concourse/oci-build-task

Add a single usage of this on the build-and-push-endtoend-candidate job in the e2e-helpers pipeline to demonstrate it works.

As a test I added a job which creates a dockerfile where the image in the FROM requires authentication. When I didn't provide the DOCKER_CONFIG param you can see the failure requiring authentication in this build: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/test-authenticated-build/builds/1
Once I added the DOCKER_CONFIG param to the oci-build-task you can see the same Dockerfile being built successfully in this build: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/test-authenticated-build/builds/2

<details><summary>Configuration of test-authenticated-build job</summary>

```
  251   - name: test-authenticated-build
  252     plan:
  253       - get: pay-ci
  254       - task: create-dockerfile-requiring-auth
  255         config:
  256           platform: linux
  257           image_resource:
  258             type: registry-image
  259             source:
  260               repository: alpine
  261           outputs:
  262             - name: test-dockerfile
  263           run:
  264             path: /bin/sh
  265             args:
  266               - -ec
  267               - |
  268                 cat <<EOF | tee test-dockerfile/Dockerfile
  269                 FROM govukpay/cardid:latest-master
  270
  271                 CMD ['sh']
  272                 EOF
  273       - task: generate-docker-creds-config
  274         file: pay-ci/ci/tasks/generate-docker-config-file.yml
  275         params:
  276           USERNAME: ((docker-username))
  277           PASSWORD: ((docker-password))
  278           EMAIL: ((docker-email))
  279       - task: build-test-dockerfile
  280         privileged: true
  281         params:
  282           CONTEXT: test-dockerfile
  283           DOCKER_CONFIG: docker_creds
  284         config:
  285           platform: linux
  286           image_resource:
  287             type: registry-image
  288             source:
  289               repository: concourse/oci-build-task
  290           inputs:
  291             - name: test-dockerfile
  292             - name: docker_creds
  293           outputs:
  294             - name: image
  295           run:
  296             path: build
  ```
</details>

This proves the authentication works and is being used by the oci-build-task

You can also see the build-and-push-endtoend-candidate job succeeding here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/build-and-push-endtoend-candidate/builds/26