### PR TITLE
PP-9737: Add docker auth to all oci-build-tasks

### DIFF
--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -27,16 +27,32 @@ resources:
       password: ((docker-password))
       tag: latest
 
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+
 # Builds and pushes the concourse-runner Docker image used by various Concourse CI pipelines
 jobs:
   - name: build-and-push
     plan:
-      - get: concourse-runner-src
-        trigger: true
+      - in_parallel:
+        - get: concourse-runner-src
+          trigger: true
+        - get: pay-ci
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build
         privileged: true
         params: 
           CONTEXT: concourse-runner-src/ci/docker/concourse-runner
+          DOCKER_CONFIG: docker_creds
         config:
           platform: linux
           image_resource:

--- a/ci/pipelines/control-plane.yml
+++ b/ci/pipelines/control-plane.yml
@@ -63,6 +63,13 @@ resources:
     source:
       url: https://hooks.slack.com/services/((slack-notification-secret))
 
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+
 resource_types:
   - name: cf-cli
     type: docker-image
@@ -106,10 +113,20 @@ jobs:
   - name: deploy-control-plane
     serial: true
     plan:
-    - get: pay-control-plane-src
-      trigger: true
+    - in_parallel:
+      - get: pay-control-plane-src
+        trigger: true
+      - get: pay-ci
+    - task: generate-docker-creds-config
+      file: pay-ci/ci/tasks/generate-docker-config-file.yml
+      params:
+        USERNAME: ((docker-username))
+        PASSWORD: ((docker-password))
+        EMAIL: ((docker-email))
     - task: build-control-plane-image
       privileged: true
+      params:
+        DOCKER_CONFIG: docker_creds
       output_mapping:
         image: pay-control-plane-image
       config:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1036,10 +1036,17 @@ jobs:
           file: tags/release-number
         - load_var: release-sha
           file: tags/release-sha
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-alpine-image
         privileged: true
         params:
           CONTEXT: pay-alpine-git-release/images/docker/govukpay/alpine
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -1157,10 +1164,17 @@ jobs:
           git-release: stream-s3-sqs-git-release
       - load_var: release-tag
         file: tags/tags
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-stream-s3-sqs-proxy-image
         privileged: true
         params:
             CONTEXT: stream-s3-sqs-git-release
+            DOCKER_CONFIG: docker_creds
         config:
           platform: linux
           image_resource:
@@ -1238,9 +1252,16 @@ jobs:
           file: tags/release-sha
         - load_var: release-tag
           file: tags/tags
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -1543,9 +1564,16 @@ jobs:
           file: tags/release-sha
         - load_var: candidate-image-tag
           file: tags/candidate-tag
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -1876,9 +1904,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -2227,9 +2262,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -2578,9 +2620,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -2929,9 +2978,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -3259,9 +3315,16 @@ jobs:
           file: tags/release-sha
         - load_var: candidate-image-tag
           file: tags/candidate-tag
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -3565,9 +3628,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -3887,9 +3957,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -4178,9 +4255,16 @@ jobs:
           file: tags/release-sha
         - load_var: candidate-image-tag
           file: tags/candidate-tag
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -4533,9 +4617,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -4848,9 +4939,16 @@ jobs:
             - |
               mvn clean package
               cp -r . ../build-jar
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
@@ -5002,9 +5100,16 @@ jobs:
           git-release: nginx-proxy-git-release
       - load_var: release-tag
         file: tags/tags
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-nginx-proxy-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           CONTEXT: nginx-proxy-git-release
         config:
           platform: linux
@@ -5052,9 +5157,16 @@ jobs:
           git-release: webhooks-egress-git-release
       - load_var: release-tag
         file: tags/tags
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-webhooks-egress-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           CONTEXT: webhooks-egress-git-release/production/webhooks-egress/
         config:
           platform: linux
@@ -5115,10 +5227,17 @@ jobs:
           git-release: nginx-forward-proxy-git-release
       - load_var: release-tag
         file: tags/tags
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-nginx-forward-proxy-image
         privileged: true
         params:
-            CONTEXT: nginx-forward-proxy-git-release
+          DOCKER_CONFIG: docker_creds
+          CONTEXT: nginx-forward-proxy-git-release
         config:
           platform: linux
           image_resource:
@@ -5198,10 +5317,17 @@ jobs:
           git-release: telegraf-git-release
       - load_var: release-tag
         file: tags/tags
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-telegraf-image
         privileged: true
         params:
-            CONTEXT: telegraf-git-release
+          DOCKER_CONFIG: docker_creds
+          CONTEXT: telegraf-git-release
         config:
           platform: linux
           image_resource:
@@ -5262,10 +5388,17 @@ jobs:
           git-release: notifications-git-release
       - load_var: release-tag
         file: tags/tags
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-notifications-image
         privileged: true
         params:
-            CONTEXT: notifications-git-release
+          DOCKER_CONFIG: docker_creds
+          CONTEXT: notifications-git-release
         config:
           platform: linux
           image_resource:

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -429,10 +429,17 @@ jobs:
                     # See https://github.com/alphagov/pay-scripts/blob/master/images/proxy/build-latest-master.sh
                     prod_naxsi_rules_source=../../../pay-infra-src/provisioning/terraform/modules/pay_microservices_v2
                     find "$prod_naxsi_rules_source" -name \*.naxsi -exec cp {} target \;
+          - task: generate-docker-creds-config
+            file: pay-ci/ci/tasks/generate-docker-config-file.yml
+            params:
+              USERNAME: ((docker-username))
+              PASSWORD: ((docker-password))
+              EMAIL: ((docker-email))
           - task: build-reverse-proxy-image
             privileged: true
             params:
               CONTEXT: reverse-proxy-git-release/images/reverse_proxy/
+              DOCKER_CONFIG: docker_creds
             config:
               platform: linux
               image_resource:
@@ -568,11 +575,18 @@ jobs:
         - get: stubs-git-release
           trigger: true
         - get: pay-ci
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - in_parallel:
         - task: build-stubs-image
           privileged: true
           params:
             CONTEXT: stubs-git-release
+            DOCKER_CONFIG: docker_creds
           config:
             platform: linux
             image_resource:

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -45,12 +45,27 @@ resources:
       password: ((docker-password))
       tag: node16
 
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+
 # Builds and pushes the node-runner Docker image used by various Concourse CI pipelines
 jobs:
   - name: build-and-push
     plan:
-      - get: node-runner-src
-        trigger: true
+      - in_parallel:
+        - get: node-runner-src
+          trigger: true
+        - get: pay-ci
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - in_parallel:
         - task: build-node-12
           privileged: true
@@ -59,6 +74,7 @@ jobs:
           params:
             CONTEXT: node-runner-src/ci/docker/node-runner
             DOCKERFILE: node-runner-src/ci/docker/node-runner/Dockerfile.node12
+            DOCKER_CONFIG: docker_creds
           config:
             platform: linux
             image_resource:
@@ -78,6 +94,7 @@ jobs:
           params:
             CONTEXT: node-runner-src/ci/docker/node-runner
             DOCKERFILE: node-runner-src/ci/docker/node-runner/Dockerfile.node16
+            DOCKER_CONFIG: docker_creds
           config:
             platform: linux
             image_resource:

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -1024,9 +1024,16 @@ jobs:
           file: perf-tests-git-release/.git/ref
         - load_var: release-sha
           file: tags/release-sha
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-password))
+          EMAIL: ((docker-email))
       - task: build-perf-tests-image
         privileged: true
         params:
+          DOCKER_CONFIG: docker_creds
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))            


### PR DESCRIPTION
Following on from https://github.com/alphagov/pay-ci/pull/714 add dockerhub authentication to oci-build-task builds.

# Successful builds
## e2e-helpers
reverse-proxy: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/build-and-push-reverse-proxy-candidate/builds/5
stubs: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/build-and-push-stubs-candidate/builds/30

## node-runner
build-and-push https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/node-runner/jobs/build-and-push/builds/7

## perf-tests
build-and-push-perf-tests: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/build-and-push-perf-tests/builds/10

## Control-plane
deploy-control-plane: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/control-plane/jobs/deploy-control-plane/builds/12

## concourse-runner
build-and-push https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/concourse-runner/jobs/build-and-push/builds/5

## deploy-to-test

adminusers: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-adminusers-candidate/builds/87
cardid: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-cardid-candidate/builds/45
connector: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-connector-candidate/builds/166
frontend: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-frontend-candidate/builds/97
ledger: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-ledger-candidate/builds/94
products: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-products-candidate/builds/56
products-ui: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-products-ui-candidate/builds/110
publicapi: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-publicapi-candidate/builds/70
publicauth: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-publicauth-candidate/builds/48
selfservice: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-selfservice-candidate/builds/64
toolbox: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-toolbox-to-test-ecr/builds/43
webhooks: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-webhooks/builds/115

alpine: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-alpine-to-ecr/builds/6
nginx-proxy: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-nginx-proxy-to-test-ecr/builds/10
webhooks-egress: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-webhooks-egress-to-test-ecr/builds/2
nginx-forward-proxy: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-nginx-forward-proxy-to-test-ecr/builds/15
notifications: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-notifications-to-test-ecr/builds/13
stream-s3-sqs: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-stream-s3-sqs-to-test-ecr/builds/33
telegraf: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-telegraf-to-test-ecr/builds/19