### PR TITLE
BAU: Temporarily disable SearchPayments scenarios

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -612,23 +612,25 @@ jobs:
               text: ':red-circle: Performance test PaymentSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
               icon_emoji: ":concourse:"
               username: pay-concourse
-      - try:
-          task: search-payments-simulation-perf-test
-          file: pay-ci/ci/tasks/run-codebuild.yml
-          params:
-            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/perf-tests-SearchPaymentsSimulation.json"
-            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-          on_failure:
-            put: slack-notification
-            attempts: 10
-            params:
-              channel: '#govuk-pay-announce'
-              silent: true
-              text: ':red-circle: Performance test SearchPaymentsSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-              icon_emoji: ":concourse:"
-              username: pay-concourse
+#   Temporarily disable search scenarios in daily scheduled perftests.
+#   Ledger is currently unable to fulfil these perftest requests reliably.
+#      - try:
+#          task: search-payments-simulation-perf-test
+#          file: pay-ci/ci/tasks/run-codebuild.yml
+#          params:
+#            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/perf-tests-SearchPaymentsSimulation.json"
+#            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+#            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+#            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+#          on_failure:
+#            put: slack-notification
+#            attempts: 10
+#            params:
+#              channel: '#govuk-pay-announce'
+#              silent: true
+#              text: ':red-circle: Performance test SearchPaymentsSimulation failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+#              icon_emoji: ":concourse:"
+#              username: pay-concourse
       - try:
           task: self-service-simulation-perf-test
           file: pay-ci/ci/tasks/run-codebuild.yml


### PR DESCRIPTION
Ledger is currently unable to fulfil the requests made by these scenarios. Let's turn off the daily scheduled `SearchPayments` tests until we can address the test settings (or Ledger's settings) properly, and avoid noise in the Slack channel.

We can keep the ad-hoc job that runs `SearchPayments` for now.

~Note for reviewers: I've repeated the explanatory comment due to the large amount of YAML in this file - it's not always easy to determine whether a comment in one place also applies somewhere else in the file, so I've gone for verbosity.~ Ignore this - I've kept the `run-search-payment-simulation-perf-test` in the `all-job` group anyway, so it's only the task in the `scale-and-run-all-simulations` that needs commenting out.