### PR TITLE
BAU Run Pact tag task before pushing to ECR

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -911,7 +911,7 @@ jobs:
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-selfservice-on-staging]
+        passed: [selfservice-pact-tag]
       - put: selfservice-ecr-registry-prod
         params:
           image: selfservice-ecr-registry-staging/image.tar
@@ -1101,7 +1101,7 @@ jobs:
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-connector-on-staging]
+        passed: [connector-pact-tag]
       - put: connector-ecr-registry-prod
         params:
           image: connector-ecr-registry-staging/image.tar
@@ -2379,7 +2379,7 @@ jobs:
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-publicapi-on-staging]
+        passed: [publicapi-pact-tag]
       - put: publicapi-ecr-registry-prod
         params:
           image: publicapi-ecr-registry-staging/image.tar
@@ -2568,7 +2568,7 @@ jobs:
         params:
           format: oci
         trigger: true
-        passed: [smoke-test-ledger-on-staging]
+        passed: [ledger-pact-tag]
       - put: ledger-ecr-registry-prod
         params:
           image: ledger-ecr-registry-staging/image.tar


### PR DESCRIPTION
For all pipelines on deploy-to-test and for some pipelines on
deploy-to-staging, the `push-x-to-production-ecr` needs the `x-pact-tag`
job to have completed first.

However, for a few apps on the deploy-to-staging pipeline, the
`push-x-to-production-ecr` requires the smoke test task to have
completed. This means that we might push to the production ECR without
tagging the Pact for staging if Concourse gets stuck, which might cause
confusion if we later run across Pact errors.

Fix this so the ordering of tasks across all pipelines is uniform.