### PR TITLE
PP-9211 Add webhooks egress deploy to test and push to staging ecr

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -675,6 +675,12 @@ resources:
     source:
       repository: govukpay/egress
       <<: *aws_staging_config
+  - name: webhooks-egress-ecr-registry-staging
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/webhooks-egress
+      <<: *aws_staging_config
   - name: frontend-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -910,6 +916,8 @@ groups:
   - name: webhooks-egress
     jobs:
       - build-and-push-webhooks-egress-to-test-ecr
+      - deploy-webhooks-egress
+      - push-webhooks-egress-to-staging-ecr
   - name: nginx-forward-proxy
     jobs:
       - deploy-frontend
@@ -5213,6 +5221,72 @@ jobs:
         text: ':hammer: webhooks-egress image ((.:release-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
         icon_emoji: ":concourse:"
         username: pay-concourse
+
+  - name: deploy-webhooks-egress
+    serial: true
+    serial_groups: [deploy-application]
+    plan:
+      - get: webhooks-egress-ecr-registry-test
+        passed: [build-and-push-webhooks-egress-to-test-ecr]
+        trigger: true
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: webhooks-egress-ecr-registry-test/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
+        params:
+          ACTION_NAME: Deployment
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ENV: test-12
+      - load_var: failure_snippet
+        file: snippet/failure
+      - load_var: success_snippet
+        file: snippet/success  
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: check-release-versions
+        file: pay-ci/ci/tasks/check-release-versions.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          CLUSTER_NAME: "test-12-fargate"
+          APP_NAME: webhooks-egress
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+      - task: deploy-to-test
+        file: pay-ci/ci/tasks/deploy-webhooks-egress.yml
+        params:
+          <<: *aws_assumed_role_creds
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ACCOUNT: test
+          ENVIRONMENT: test-12
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: webhooks-egress
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          <<: *aws_assumed_role_creds
+          ENVIRONMENT: test-12
+    <<: *put_success_slack_notification      
+    <<: *put_failure_slack_notification
+  
+  - name: push-webhooks-egress-to-staging-ecr
+    plan:
+      - get: webhooks-egress-ecr-registry-test
+        passed: [smoke-test-webhooks-egress]
+        params:
+          format: oci
+        trigger: true
+      - put: webhooks-egress-ecr-registry-staging
+        params:
+          image: webhooks-egress-ecr-registry-test/image.tar
+          additional_tags: webhooks-egress-ecr-registry-test/tag
 
   - name: push-nginx-proxy-to-staging-ecr
     plan:

--- a/ci/tasks/deploy-webhooks-egress.yml
+++ b/ci/tasks/deploy-webhooks-egress.yml
@@ -1,0 +1,27 @@
+---
+platform: linux
+inputs:
+  - name: pay-infra
+image_resource:
+  type: registry-image
+  source:
+    repository: hashicorp/terraform
+    tag: 1.0.8
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:
+  AWS_REGION: eu-west-1
+  APPLICATION_IMAGE_TAG:
+  ACCOUNT:
+  ENVIRONMENT:
+run:
+  path: /bin/sh
+  args:
+    - -ec
+    - |
+      cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/webhooks_egress
+      terraform init
+      terraform apply \
+        -var application_image_tag=${APPLICATION_IMAGE_TAG} \
+        -auto-approve


### PR DESCRIPTION
Webhooks egress post merge is tagged as a release prefixed with
""webhooks_egress_" -- this is picked up by a deploy to test pipeline
that currently builds the image and pushes it to test ecr.

Add jobs to deploy this image in the `test-12-fargate` cluster and
subsequently push it to staging ecr to be picked up by a future
pipeline.