### PR TITLE
PP-9645: CardIDSimulation and PublicAuthSimulation have been deleted

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -429,31 +429,6 @@ definitions:
           - pipefail
           - -c
           - |
-            echo "CardIDSimulation"
-            echo "------------------------------------------------------------------"
-            cat <<EOF | tee ./run-codebuild-configuration/perf-tests-CardIDSimulation.json
-            {
-              "projectName": "perf-tests-test-perf-1",
-              "sourceVersion": "",
-              "secondarySourcesVersions": {},
-              "environmentVariables": {
-                "PERF_TESTS_VERSION": "((.:release-tag))",
-                "GATLING_CLASS": "uk.gov.pay.CardIDSimulation",
-                "USE_CONCURRENT": "((.:gatling-simulation-settings.CardIDSimulation.USE_CONCURRENT))",
-                "RAMPUP_USERS_FROM": "((.:gatling-simulation-settings.CardIDSimulation.RAMPUP_USERS_FROM))",
-                "RAMPUP_USERS_TO": "((.:gatling-simulation-settings.CardIDSimulation.RAMPUP_USERS_TO))",
-                "RAMPUP_DURATION_IN_SECONDS": "((.:gatling-simulation-settings.CardIDSimulation.RAMPUP_DURATION_IN_SECONDS))",
-                "INITIAL_THROUGHPUT_RPS": "((.:gatling-simulation-settings.CardIDSimulation.INITIAL_THROUGHPUT_RPS))",
-                "INITIAL_THROUGHPUT_RAMPUP_SECONDS": "((.:gatling-simulation-settings.CardIDSimulation.INITIAL_THROUGHPUT_RAMPUP_SECONDS))",
-                "INITIAL_THROUGHPUT_DURATION_MINUTES": "((.:gatling-simulation-settings.CardIDSimulation.INITIAL_THROUGHPUT_DURATION_MINUTES))",
-                "THROUGHPUT_TO_MAINTAIN": "((.:gatling-simulation-settings.CardIDSimulation.THROUGHPUT_TO_MAINTAIN))",
-                "FINAL_THROUGHPUT_DURATION_MINUTES": "((.:gatling-simulation-settings.CardIDSimulation.FINAL_THROUGHPUT_DURATION_MINUTES))",
-                "CONSTANT_USERS_AFTER_RAMPUP": "((.:gatling-simulation-settings.CardIDSimulation.CONSTANT_USERS_AFTER_RAMPUP))",
-                "CONSTANT_DURATION_AFTER_RAMPUP": "((.:gatling-simulation-settings.CardIDSimulation.CONSTANT_DURATION_AFTER_RAMPUP))"
-              }
-            }
-            EOF
-
             echo "PaymentSimulation"
             echo "------------------------------------------------------------------"
             cat <<EOF | tee ./run-codebuild-configuration/perf-tests-PaymentSimulation.json
@@ -475,31 +450,6 @@ definitions:
                 "FINAL_THROUGHPUT_DURATION_MINUTES": "((.:gatling-simulation-settings.PaymentSimulation.FINAL_THROUGHPUT_DURATION_MINUTES))",
                 "CONSTANT_USERS_AFTER_RAMPUP": "((.:gatling-simulation-settings.PaymentSimulation.CONSTANT_USERS_AFTER_RAMPUP))",
                 "CONSTANT_DURATION_AFTER_RAMPUP": "((.:gatling-simulation-settings.PaymentSimulation.CONSTANT_DURATION_AFTER_RAMPUP))"
-              }
-            }
-            EOF
-
-            echo "PublicAuthSimulation"
-            echo "------------------------------------------------------------------"
-            cat <<EOF | tee ./run-codebuild-configuration/perf-tests-PublicAuthSimulation.json
-            {
-              "projectName": "perf-tests-test-perf-1",
-              "sourceVersion": "",
-              "secondarySourcesVersions": {},
-              "environmentVariables": {
-                "PERF_TESTS_VERSION": "((.:release-tag))",
-                "GATLING_CLASS": "uk.gov.pay.PublicAuthSimulation",
-                "USE_CONCURRENT": "((.:gatling-simulation-settings.PublicAuthSimulation.USE_CONCURRENT))",
-                "RAMPUP_USERS_FROM": "((.:gatling-simulation-settings.PublicAuthSimulation.RAMPUP_USERS_FROM))",
-                "RAMPUP_USERS_TO": "((.:gatling-simulation-settings.PublicAuthSimulation.RAMPUP_USERS_TO))",
-                "RAMPUP_DURATION_IN_SECONDS": "((.:gatling-simulation-settings.PublicAuthSimulation.RAMPUP_DURATION_IN_SECONDS))",
-                "INITIAL_THROUGHPUT_RPS": "((.:gatling-simulation-settings.PublicAuthSimulation.INITIAL_THROUGHPUT_RPS))",
-                "INITIAL_THROUGHPUT_RAMPUP_SECONDS": "((.:gatling-simulation-settings.PublicAuthSimulation.INITIAL_THROUGHPUT_RAMPUP_SECONDS))",
-                "INITIAL_THROUGHPUT_DURATION_MINUTES": "((.:gatling-simulation-settings.PublicAuthSimulation.INITIAL_THROUGHPUT_DURATION_MINUTES))",
-                "THROUGHPUT_TO_MAINTAIN": "((.:gatling-simulation-settings.PublicAuthSimulation.THROUGHPUT_TO_MAINTAIN))",
-                "FINAL_THROUGHPUT_DURATION_MINUTES": "((.:gatling-simulation-settings.PublicAuthSimulation.FINAL_THROUGHPUT_DURATION_MINUTES))",
-                "CONSTANT_USERS_AFTER_RAMPUP": "((.:gatling-simulation-settings.PublicAuthSimulation.CONSTANT_USERS_AFTER_RAMPUP))",
-                "CONSTANT_DURATION_AFTER_RAMPUP": "((.:gatling-simulation-settings.PublicAuthSimulation.CONSTANT_DURATION_AFTER_RAMPUP))"
               }
             }
             EOF


### PR DESCRIPTION
These simulations have been deleted, see https://github.com/alphagov/pay-perftests/pull/121.

The [scale-and-run-all-simulations job](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-and-run-all-simulations/builds/33) is passing now.