### PR TITLE
PP-9211 Notification snippets differentiate between egress and webhooks egress

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -623,6 +623,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: egress
           ACTION_NAME: Deployment
           APPLICATION_IMAGE_TAG: ((.:application_image_tag))
           ENV: production-2
@@ -678,6 +679,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: egress
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
       - load_var: success_snippet

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1209,6 +1209,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: egress
           ACTION_NAME: Deployment
           APPLICATION_IMAGE_TAG: ((.:application_image_tag))
           ENV: staging-2
@@ -1264,6 +1265,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: egress
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
       - load_var: success_snippet
@@ -1307,6 +1309,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: webhooks-egress
           ACTION_NAME: Deployment
           APPLICATION_IMAGE_TAG: ((.:application_image_tag))
           ENV: staging-2

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1481,6 +1481,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: egress
           ACTION_NAME: Deployment
           APPLICATION_IMAGE_TAG: ((.:application_image_tag))
           ENV: test-12
@@ -1533,6 +1534,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: egress
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
       - load_var: success_snippet
@@ -5256,6 +5258,7 @@ jobs:
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-egress-notification-snippets.yml
         params:
+          APP_NAME: webhooks-egress
           ACTION_NAME: Deployment
           APPLICATION_IMAGE_TAG: ((.:application_image_tag))
           ENV: test-12

--- a/ci/tasks/create-egress-notification-snippets.yml
+++ b/ci/tasks/create-egress-notification-snippets.yml
@@ -5,6 +5,7 @@ image_resource:
   source:
     repository: alpine
 params:
+  APP_NAME:
   ACTION_NAME:
   APPLICATION_IMAGE_TAG:
   ENV:
@@ -16,13 +17,13 @@ run:
     - -c
     - |
       cat <<EOT >> snippet/start
-      :rocket: ${ACTION_NAME} of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${APPLICATION_IMAGE_TAG}|egress v${APPLICATION_IMAGE_TAG}> on ${ENV} is beginning
+      :rocket: ${ACTION_NAME} of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${APPLICATION_IMAGE_TAG}|{$APP_NAME} v${APPLICATION_IMAGE_TAG}> on ${ENV} is beginning
       EOT
 
       cat <<EOT >> snippet/success
-      :green-circle: ${ACTION_NAME} of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${APPLICATION_IMAGE_TAG}|egress v${APPLICATION_IMAGE_TAG}> on ${ENV} was successful :tada:
+      :green-circle: ${ACTION_NAME} of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${APPLICATION_IMAGE_TAG}|${APP_NAME} v${APPLICATION_IMAGE_TAG}> on ${ENV} was successful :tada:
       EOT
 
       cat <<EOT >> snippet/failure
-      :red_circle: ${ACTION_NAME} of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${APPLICATION_IMAGE_TAG}|egress v${APPLICATION_IMAGE_TAG}> on ${ENV} failed. Version details:
+      :red_circle: ${ACTION_NAME} of <https://github.com/alphagov/pay-dockerfiles/releases/tag/${APPLICATION_IMAGE_TAG}|${APP_NAME} v${APPLICATION_IMAGE_TAG}> on ${ENV} failed. Version details:
       EOT


### PR DESCRIPTION
Webhooks egress is deployed using the same egress notification snippet,
both of these apps are maintained in the `pay-dockerfiles` repo.

Add a param to let the pipeline specify the image being acted on
(deployed or smoke tested, in this case).