### PR TITLE
BAU: Require build before deploy

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1410,6 +1410,7 @@ jobs:
         passed: [build-and-push-toolbox-to-test-ecr]
       - get: telegraf-ecr-registry-test
         trigger: true
+        passed: [build-and-push-telegraf-to-test-ecr]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: pay-infra
@@ -1737,6 +1738,7 @@ jobs:
         passed: [run-frontend-e2e]
       - get: nginx-forward-proxy-ecr-registry-test
         trigger: true
+        passed: [build-and-push-nginx-forward-proxy-to-test-ecr]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
         passed: [build-and-push-nginx-proxy-to-test-ecr]
@@ -5548,6 +5550,7 @@ jobs:
     plan:
       - get: notifications-ecr-registry-test
         trigger: true
+        passed: [build-and-push-notifications-to-test-ecr]
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag


### PR DESCRIPTION
Require build of applications in deploy-to-test before they are deployed.

This helps make the pipelines make more sense and show a joined up pipeline:

From:
<img width="1339" alt="Screenshot 2022-06-24 at 10 43 30 1" src="https://user-images.githubusercontent.com/2170030/175509939-e3df49c4-466a-4b93-99ae-f9e515bc54ab.png">
<img width="1307" alt="Screenshot 2022-06-24 at 10 43 48" src="https://user-images.githubusercontent.com/2170030/175509943-e0b34138-500e-446f-9502-8abaede7cdb1.png">
<img width="1323" alt="Screenshot 2022-06-24 at 10 43 53" src="https://user-images.githubusercontent.com/2170030/175509948-1ed0c694-f5eb-48b9-ad9e-582c1112d94b.png">

To
<img width="1318" alt="Screenshot 2022-06-24 at 10 44 08" src="https://user-images.githubusercontent.com/2170030/175509978-1350b429-1d5c-4d2a-9137-4f9f79444730.png">
<img width="1383" alt="Screenshot 2022-06-24 at 10 44 13" src="https://user-images.githubusercontent.com/2170030/175509980-f1ec9daa-dfd8-47ed-aaa0-b08b405616f2.png">
<img width="1369" alt="Screenshot 2022-06-24 at 10 44 18" src="https://user-images.githubusercontent.com/2170030/175509981-4878b0e5-5fa2-44d3-8130-92c24ae20660.png">

