### PR TITLE
Revert control plane to push deploy

### DIFF
--- a/ci/pipelines/control-plane.yml
+++ b/ci/pipelines/control-plane.yml
@@ -157,8 +157,8 @@ jobs:
           skip_download: true
     - put: pay-control-plane-paas
       params:
-        command: zero-downtime-push
-        current_app_name: pay-control-plane
+        command: push
+        app_name: pay-control-plane
         docker_image: govukpay/control-plane:latest
         manifest: pay-control-plane-src/manifest.yml
     on_failure:


### PR DESCRIPTION
Making this a zero downtime push requires additional work which we don't have time for at the moment, it's an internal tool which isn't used a lot so a couple of seconds of downtime during deploys seems ok.