### PR TITLE
BAU: Exclude version check from test-perf-1 DB migrations

### DIFF
--- a/ci/scripts/run-ecs-db-migration.js
+++ b/ci/scripts/run-ecs-db-migration.js
@@ -93,7 +93,7 @@ const run = async function run () {
     console.log(`Current task definition is using release: ${currentAppRelease}`)
     const jobAppRelease = APPLICATION_IMAGE_TAG.split('-')[0]
 
-    if (currentAppRelease !== jobAppRelease) {
+    if (currentAppRelease !== jobAppRelease && CLUSTER_NAME != "test-perf-1-fargate") {
       throw new Error(`The input release ${jobAppRelease} number does not match the
         release number of the app currently running in the environment ${currentAppRelease}.
         Run the version of this job with the correct app release number.`)

--- a/ci/scripts/run-ecs-db-migration.js
+++ b/ci/scripts/run-ecs-db-migration.js
@@ -93,7 +93,7 @@ const run = async function run () {
     console.log(`Current task definition is using release: ${currentAppRelease}`)
     const jobAppRelease = APPLICATION_IMAGE_TAG.split('-')[0]
 
-    if (currentAppRelease !== jobAppRelease && CLUSTER_NAME != "test-perf-1-fargate") {
+    if (currentAppRelease !== jobAppRelease && CLUSTER_NAME !== "test-perf-1-fargate") {
       throw new Error(`The input release ${jobAppRelease} number does not match the
         release number of the app currently running in the environment ${currentAppRelease}.
         Run the version of this job with the correct app release number.`)


### PR DESCRIPTION
We ran into problems with this as the image tagged 2856-perf-db had not been deployed as an app release (which was still on 2855-perf).

We don't carry out version checks for test-perf-1 deployments elsewhere, as it's low risk given the perf environment should be up to date with production deployments.

The alternative would be some more complex changes to our application deployment script, or an additional app deployment job just for the *-perf-db tagged images (which would probably cause different problems for this check anyway).