### PR TITLE
BAU: Add fly cli installed from our own concourse

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker:20.10.10
 
+ARG FLY_CLI_SHA256SUM=908066a7adddfaf49b7352a2440203422547f25fd6d3121168b0142a55984ec0
+
 RUN apk add --no-cache \
   aws-cli \
   bash \
@@ -31,6 +33,12 @@ RUN ln -s /pact/bin/pact /usr/local/bin \
     && ln -s /pact/bin/pact-provider-verifier /usr/local/bin \
     && ln -s /pact/bin/pact-publish /usr/local/bin \
     && ln -s /pact/bin/pact-stub-service /usr/local/bin
+
+RUN echo "$FLY_CLI_SHA256SUM  /tmp/fly" >> /tmp/fly.sha256 \
+  && wget -O /tmp/fly 'https://pay-cd.deploy.payments.service.gov.uk/api/v1/cli?arch=amd64&platform=linux' \
+  && sha256sum -c /tmp/fly.sha256 \
+  && mv /tmp/fly /usr/local/bin/ \
+  && chmod 555 /usr/local/bin/fly
 
 COPY ./docker-helpers.sh /
 COPY ./docker-wrapper /usr/local/bin/


### PR DESCRIPTION
The concourse/concourse-pipeline-resource image has been deprecated and finally failed when the signatures signing the apk indexes have been updated and the new ones are no longer in the final build of this registry image. We (mis)use that resource as a fly cli executor. There is a fly cli resource but that lists it's last compatibility as concourse 5.x.

As such this PR adds the fly CLI installed from our concourse instance, and sha256 sum checked against the known correct sha256 sum.