### PR TITLE
PP-9827: Concourse runner with java 17

### DIFF
--- a/ci/docker/concourse-runner-with-java-17/Dockerfile
+++ b/ci/docker/concourse-runner-with-java-17/Dockerfile
@@ -1,0 +1,46 @@
+FROM docker:20.10.16
+
+ARG FLY_CLI_SHA256SUM=908066a7adddfaf49b7352a2440203422547f25fd6d3121168b0142a55984ec0
+
+RUN apk add --no-cache \
+  aws-cli \
+  bash \
+  curl \
+  docker-compose \
+  netcat-openbsd \
+  git \
+  python3 \
+  ca-certificates \
+  jq \
+  openjdk17 \
+  maven \
+  tini \
+  # dockerd dependencies
+  iptables \
+  util-linux
+
+RUN apk add --virtual build-dependencies build-base
+
+RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.86.0/pact-1.86.0-linux-x86_64.tar.gz \
+    && tar xzf pact-1.86.0-linux-x86_64.tar.gz \
+    && rm -f pact-1.86.0-linux-x86_64.tar.gz
+
+RUN ln -s /pact/bin/pact /usr/local/bin \
+    && ln -s /pact/bin/pact-broker /usr/local/bin \
+    && ln -s /pact/bin/pact-message /usr/local/bin \
+    && ln -s /pact/bin/pact-mock-service /usr/local/bin \
+    && ln -s /pact/bin/pact-provider-verifier /usr/local/bin \
+    && ln -s /pact/bin/pact-publish /usr/local/bin \
+    && ln -s /pact/bin/pact-stub-service /usr/local/bin
+
+RUN echo "$FLY_CLI_SHA256SUM  /tmp/fly" >> /tmp/fly.sha256 \
+  && wget -O /tmp/fly 'https://pay-cd.deploy.payments.service.gov.uk/api/v1/cli?arch=amd64&platform=linux' \
+  && sha256sum -c /tmp/fly.sha256 \
+  && mv /tmp/fly /usr/local/bin/ \
+  && chmod 555 /usr/local/bin/fly
+
+COPY ./docker-helpers.sh /
+COPY ./docker-wrapper /usr/local/bin/
+ENTRYPOINT [ "docker-wrapper" ]
+
+CMD "ash"

--- a/ci/docker/concourse-runner-with-java-17/README.md
+++ b/ci/docker/concourse-runner-with-java-17/README.md
@@ -1,0 +1,3 @@
+# Pay Concourse Runner with java 17
+
+This Docker image identical to the original [govukpay/concourse-runner](https://github.com/alphagov/pay-ci/tree/master/ci/docker/concourse-runner) but with Java 17. The requirement for Java 17 comes from the fact that [webhooks](https://github.com/alphagov/pay-webhooks) uses it.

--- a/ci/docker/concourse-runner-with-java-17/docker-helpers.sh
+++ b/ci/docker/concourse-runner-with-java-17/docker-helpers.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Based on https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+# See https://github.com/meAmidos/dcind
+
+LOG_FILE=${LOG_FILE:-/tmp/docker.log}
+SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
+
+sanitize_cgroups() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+
+start_docker() {
+  echo "Starting Docker..."
+
+  if [ -f /tmp/docker.pid ]; then
+    echo "Docker is already running"
+    return
+  fi
+
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  if [ "$SKIP_PRIVILEGED" = "false" ]; then
+    sanitize_cgroups
+
+    # check for /proc/sys being mounted readonly, as systemd does
+    if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+      mount -o remount,rw /proc/sys
+    fi
+  fi
+
+  local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
+  local server_args="--mtu ${mtu}"
+  local registry=""
+
+  for registry in $1; do
+    server_args="${server_args} --insecure-registry ${registry}"
+  done
+
+  if [ -n "$2" ]; then
+    server_args="${server_args} --registry-mirror $2"
+  fi
+
+  export server_args LOG_FILE
+
+  try_start() {
+    dockerd --data-root /scratch/docker ${server_args} >$LOG_FILE 2>&1 &
+    echo $! > /tmp/docker.pid
+
+    sleep 1
+
+    echo waiting for docker to come up...
+    until docker info >/dev/null 2>&1; do
+      sleep 1
+      if ! kill -0 "$(cat /tmp/docker.pid)" 2>/dev/null; then
+        return 1
+      fi
+    done
+  }
+
+  if [ "$(command -v declare)" ]; then
+    declare -fx try_start
+
+    if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+      echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+      return 1
+    fi
+  else
+    try_start
+  fi
+}
+
+stop_docker() {
+  echo "Stopping Docker..."
+
+  if [ ! -f /tmp/docker.pid ]; then
+    return 0
+  fi
+
+  local pid=$(cat /tmp/docker.pid)
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  kill -TERM $pid
+  rm /tmp/docker.pid
+}
+
+clean_docker() {
+  [[ ! -f /tmp/docker.pid ]] && return 0;
+  echo "cleaning up docker"
+  docker system prune -af --volumes || true
+}

--- a/ci/docker/concourse-runner-with-java-17/docker-wrapper
+++ b/ci/docker/concourse-runner-with-java-17/docker-wrapper
@@ -1,0 +1,16 @@
+#!/sbin/tini /bin/bash
+
+{
+  . /docker-helpers.sh
+  function cleanup_docker() {
+    # prune docker data to work around garbage collection not being consistent
+    clean_docker || true
+    # explicitly kill docker in our own special way defined in docker-helpers,
+    # instead of using dumb-init to propagate different signals up
+    stop_docker || true
+  }
+  trap cleanup_docker EXIT
+}
+
+# This deliberately doesn't use 'exec', as this will prevent the above signal handling from working
+"$@"


### PR DESCRIPTION
This is identical to the original
[govukpay/concourse-runner](https://github.com/alphagov/pay-ci/tree/master/ci/docker/concourse-runner)
but with Java 17. The requirement for Java 17 comes from the fact that
[webhooks](https://github.com/alphagov/pay-webhooks) uses it.

Note that docker engine 20.10.17 was originally used but this did not work as dockerd seems to be missing.

This produces a running webhooks integration test: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/webhooks-integration-test/builds/18.

There will be another PR to add this to concourse runner build.