### PR TITLE
PP-9292 Run ledger integration tests before consumer tests

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1472,7 +1472,7 @@ jobs:
       - <<: *get-ci
       - <<: *get-pull-request
         resource: ledger-pull-request
-        passed: [ledger-consumer-pact-test]
+        passed: [ledger-consumer-pact-test, ledger-integration-test]
       - put: ledger-pull-request
         get_params:
           skip_download: true


### PR DESCRIPTION
We're going to move the ledger consumer tests, which generate the Pact file, to be run as part of the integration test suite.

Wait for ledger-integration-test to pass before running ledger-as-consumer-pact-test as this job needs the pacts to have been published to the broker before running.