### PR TITLE
PP-9998: Add webhooks-rds instances to environment scaling

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -274,6 +274,13 @@ definitions:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: stop-webhooks-db
+        file: pay-ci/ci/tasks/stop-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-webhooks-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - &scale-up-services
     in_parallel:
@@ -407,6 +414,13 @@ definitions:
         file: pay-ci/ci/tasks/start-rds-instance.yml
         params:
           RDS_INSTANCE_NAME: test-perf-1-publicauth-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: start-webhooks-db
+        file: pay-ci/ci/tasks/start-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-webhooks-rds-0
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))


### PR DESCRIPTION
Add webhooks-rds instances to environment scaling.

This is important to be part of the regular tasks. Otherwise after 7 days the webhooks RDS will be started again by AWS (RDS instances can only be stopped for 7 days continuously and are automatically started after that period) and we will be paying for it continuously. This way we only pay for it for about 40 minutes a day as the perf tests run.

[A successful scale up](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-databases/builds/15)
[A successful scale down](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-databases/builds/10)