### PR TITLE
Pp 9998 add webhooks perf deployment

### DIFF
--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -237,6 +237,13 @@ resources:
       repository: govukpay/egress
       variant: egress-perf
       <<: *aws_test_config
+  - name: webhooks-egress-ecr-registry-perf
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/webhooks-egress
+      variant: perf
+      <<: *aws_test_config
   - name: notifications-ecr-registry-perf
     type: registry-image
     icon: docker
@@ -343,6 +350,9 @@ groups:
   - name: toolbox
     jobs:
       - deploy-toolbox-to-perf
+  - name: webhooks-egress
+    jobs:
+      - deploy-webhooks-egress-to-perf
   - name: alpine
     jobs:
       - deploy-scheduled-tasks
@@ -1414,6 +1424,59 @@ jobs:
         icon_emoji: ":fargate:"
         username: pay-concourse
         text: ":red_circle: Deployment of egress to perf failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+  - name: deploy-webhooks-egress-to-perf
+    serial: true
+    plan:
+      - get: webhooks-egress-ecr-registry-perf
+        trigger: true
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: webhooks-egress-ecr-registry-perf/tag
+      - put: slack-notification
+        params:
+          channel: '#govuk-pay-activity'
+          icon_emoji: ":fargate:"
+          username: pay-concourse
+          text: ':rocket: Starting webhooks-egress deployment to perf - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-perf
+        file: pay-ci/ci/tasks/deploy-webhooks-egress.yml
+        params:
+          <<: *aws_assumed_role_creds
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          ACCOUNT: test
+          ENVIRONMENT: test-perf-1
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: webhooks-egress
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          <<: *aws_assumed_role_creds
+          ENVIRONMENT: test-perf-1
+    on_success:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-activity'
+        icon_emoji: ":fargate:"
+        username: pay-concourse
+        text: ":green-circle: Deployment of webhooks-egress to perf success - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    on_failure:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-announce'
+        icon_emoji: ":fargate:"
+        username: pay-concourse
+        text: ":red_circle: Deployment of webhooks-egress to perf failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
 
   - name: deploy-notifications-to-perf
     serial: true

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -265,6 +265,20 @@ resources:
       repository: govukpay/stream-s3-sqs
       variant: perf
       <<: *aws_test_config
+  - name: webhooks-ecr-registry-perf
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/webhooks
+      variant: perf
+      <<: *aws_test_config
+  - name: webhooks-db-ecr-registry-perf
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/webhooks
+      variant: perf-db
+      <<: *aws_test_config
   - name: pay-stubs-manifest
     type: git
     icon: github
@@ -350,6 +364,9 @@ groups:
   - name: toolbox
     jobs:
       - deploy-toolbox-to-perf
+  - name: webhooks
+    jobs:
+      - deploy-webhooks-to-perf
   - name: webhooks-egress
     jobs:
       - deploy-webhooks-egress-to-perf
@@ -505,6 +522,64 @@ jobs:
         AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
         AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
         AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+
+  - name: deploy-webhooks-to-perf
+    serial: true
+    plan:
+      - get: webhooks-ecr-registry-perf
+        trigger: true
+      - get: webhooks-db-ecr-registry-perf
+        trigger: true
+      - get: nginx-proxy-ecr-registry-perf
+        trigger: true
+      - get: telegraf-ecr-registry-perf
+        trigger: true
+      - get: pay-infra
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: webhooks-ecr-registry-perf/tag
+      - load_var: nginx_image_tag
+        file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: telegraf_image_tag
+        file: telegraf-ecr-registry-perf/tag
+      - put: slack-notification
+        params:
+          channel: '#govuk-pay-activity'
+          icon_emoji: ":fargate:"
+          username: pay-concourse
+          text: ':rocket: Starting webhooks deployment to perf - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: terraform-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: deploy-to-perf
+        file: pay-ci/ci/tasks/deploy-app.yml
+        params:
+          APP_NAME: webhooks
+          <<: *deploy_params
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          APP_NAME: webhooks
+          <<: *wait_for_deploy_params
+    on_success:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-activity'
+        icon_emoji: ":fargate:"
+        username: pay-concourse
+        text: ":green-circle: Deployment of webhooks to perf success - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    on_failure:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-announce'
+        icon_emoji: ":fargate:"
+        username: pay-concourse
+        text: ":red_circle: Deployment of webhooks to perf failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
   - name: deploy-selfservice-to-perf
     serial: true

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -367,6 +367,7 @@ groups:
   - name: webhooks
     jobs:
       - deploy-webhooks-to-perf
+      - webhooks-db-migration-perf
   - name: webhooks-egress
     jobs:
       - deploy-webhooks-egress-to-perf
@@ -580,6 +581,65 @@ jobs:
         icon_emoji: ":fargate:"
         username: pay-concourse
         text: ":red_circle: Deployment of webhooks to perf failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+  - name: webhooks-db-migration-perf
+    plan:
+      - get: pay-ci
+      - get: webhooks-db-ecr-registry-perf
+        params:
+          format: oci
+        trigger: true
+        passed: [deploy-webhooks-to-perf]
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: db-migration-perf-test-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: application_image_tag
+        file: webhooks-db-ecr-registry-perf/tag
+      - task: start-webhooks-db
+        file: pay-ci/ci/tasks/start-rds-instance.yml
+        params:
+          RDS_INSTANCE_NAME: test-perf-1-webhooks-rds-0
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - <<: *put_db_migration_slack_notification
+      - task: run-db-migration
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: govukpay/node-runner
+          inputs:
+            - name: pay-ci
+          params:
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            AWS_PAGER: ""
+            AWS_REGION: "eu-west-1"
+            CLUSTER_NAME: "test-perf-1-fargate"
+            APP_NAME: "webhooks"
+            APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/run-ecs-db-migration.js
+    <<: *put_db_migration_success_slack_notification
+    <<: *put_db_migration_failure_slack_notification
+    ensure:
+      task: stop-webhooks-db
+      file: pay-ci/ci/tasks/stop-rds-instance.yml
+      params:
+        RDS_INSTANCE_NAME: test-perf-1-webhooks-rds-0
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: deploy-selfservice-to-perf
     serial: true


### PR DESCRIPTION
Add in deploy-to-perf:

* Webhooks deployment
* Webhooks db migration
* Webhooks egress deployment

Requires: https://github.com/alphagov/pay-infra/pull/3953

Successful runs can be see in the [webhooks group in the deploy-to-perf pipeline](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-perf?group=webhooks) and the [webhooks-egress group in the deploy-to-perf pipeline](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-perf?group=webhooks-egress)

Notifications to slack:


<img width="514" alt="Screenshot 2022-09-12 at 12 07 27" src="https://user-images.githubusercontent.com/2170030/189638828-beb96ea7-cc5e-4db0-8951-6ca9ec3b887d.png">

<img width="573" alt="Screenshot 2022-09-12 at 12 07 33" src="https://user-images.githubusercontent.com/2170030/189638841-2b77fb30-ad03-4b4a-a0b4-43bb045a26f9.png">

<img width="592" alt="Screenshot 2022-09-12 at 12 08 17" src="https://user-images.githubusercontent.com/2170030/189638856-1af69040-d9e2-4d7a-ac54-2411ae6ba463.png">



