### PR TITLE
Pp 9998 scale webhooks for perf tests

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -236,6 +236,25 @@ definitions:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - do:
+        - task: scale-down-webhooks
+          file: pay-ci/ci/tasks/scale-fargate-service.yml
+          params:
+            SERVICE_NAME: webhooks
+            SCALE_DIRECTION: in
+            DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_down_to.webhooks))
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        - task: scale-down-webhooks-egress
+          file: pay-ci/ci/tasks/scale-fargate-service.yml
+          params:
+            SERVICE_NAME: webhooks-egress
+            SCALE_DIRECTION: in
+            DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_down_to.webhooks-egress))
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - &scale-down-databases
     in_parallel:
@@ -380,6 +399,26 @@ definitions:
           command: scale
           app_name: pay-stubs
           instances: ((.:service-volumes.scale_up_to.stubs))
+      - do:
+        - task: scale-up-webhooks-egress
+          file: pay-ci/ci/tasks/scale-fargate-service.yml
+          params:
+            SERVICE_NAME: webhooks-egress
+            SCALE_DIRECTION: out
+            DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_up_to.webhooks-egress))
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        - task: scale-up-webhooks
+          file: pay-ci/ci/tasks/scale-fargate-service.yml
+          params:
+            SERVICE_NAME: webhooks
+            SCALE_DIRECTION: out
+            DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_up_to.webhooks))
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+
   - &scale-up-databases
     in_parallel:
       - task: start-adminusers-db

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -251,6 +251,7 @@ definitions:
           params:
             SERVICE_NAME: webhooks-egress
             SCALE_DIRECTION: in
+            TARGET_GROUP_NAME_SUFFIX: 'tg'
             DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_down_to.webhooks-egress))
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
@@ -405,6 +406,7 @@ definitions:
           params:
             SERVICE_NAME: webhooks-egress
             SCALE_DIRECTION: out
+            TARGET_GROUP_NAME_SUFFIX: 'tg'
             DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_up_to.webhooks-egress))
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))

--- a/ci/tasks/scale-fargate-service.yml
+++ b/ci/tasks/scale-fargate-service.yml
@@ -11,6 +11,7 @@ params:
   AWS_DEFAULT_REGION: eu-west-1
   MAX_ATTEMPTS: 40
   ECS_CLUSTER: test-perf-1-fargate
+  TARGET_GROUP_NAME_SUFFIX: 'lb-tg'
 run:
   path: /bin/bash
   args:
@@ -24,7 +25,7 @@ run:
       fi
 
       # The bash ${ECS_CLUSTER%-fargate} means the ECS_CLUSTER env var with -fargate removed from the end
-      TARGET_GROUP_NAME="${ECS_CLUSTER%-fargate}-${SERVICE_NAME}-lb-tg"
+      TARGET_GROUP_NAME="${ECS_CLUSTER%-fargate}-${SERVICE_NAME}-${TARGET_GROUP_NAME_SUFFIX}"
       TARGET_GROUP_ARN=$(
         aws elbv2 describe-target-groups  \
           --query TargetGroups[?TargetGroupName==\`${TARGET_GROUP_NAME}\`].TargetGroupArn \


### PR DESCRIPTION
Have perf tests scale webhooks and webhooks-egress scaled for perf tests.

Currently they are set for 0 up and down, but having this means it's easy to change by just adjusting https://github.com/alphagov/pay-perftests/blob/master/ci/scale-service-volumes.yml

I had to allow the target group suffix to be overridden since the webhooks-egress target group exceeded the maximum allowed TG name length and had to be truncated.

Given webhooks relies on webhooks-egress I've also put the scale up and down in an order so that webhooks-egress is alive before webhooks tries to scale (and scaled down in reverse)

Successful scale up: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-all/builds/20
Successful scale down: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-all/builds/7