### PR TITLE
PP-9392: Make WORKDIR at the root directory

### DIFF
--- a/ci/docker/node-runner/Dockerfile.node16
+++ b/ci/docker/node-runner/Dockerfile.node16
@@ -1,7 +1,7 @@
 FROM node:16.14.0-alpine3.15@sha256:425c81a04546a543da824e67c91d4a603af16fbc3d875ee2f276acf8ec2b1577
 
 # As of node 15 the docker container fails to npm install without either a WORKDIR or -g
-WORKDIR /node-runner
+WORKDIR /
 
 RUN npm install aws-sdk@^2.x.x
 RUN npm install @octokit/rest@^18.x.x


### PR DESCRIPTION
Making the WORKDIR at /node-runner broke the concourse build with the message:
```
selected worker: ip-10-1-11-96
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'aws-sdk'
Require stack:
- /tmp/build/c6eb4761/pay-ci/ci/scripts/assume-role.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/tmp/build/c6eb4761/pay-ci/ci/scripts/assume-role.js:4:13)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/tmp/build/c6eb4761/pay-ci/ci/scripts/assume-role.js' ]
```

Using `fly hijack`, I looked into the build and I could see the node_modules directory was under the /node-runner directory:
```
> fly hijack --target pay-dev -u https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/adminusers-db-migration/builds/19
1: build #19, step: assume-role, type: task
2: build #19, step: image, type: check, expires in:
3: build #19, step: pay-ci, type: get
4: build #19, step: registry-image, type: check, expires in:
5: build #19, step: slack-notification, type: check, expires in:
choose a container: 1
Couldn't find "bash" on container, retrying with "sh"
/tmp/build/c6eb4761 # ls /node-runner/node_modules/
@octokit              buffer                is-plain-object       once                  tr46                  webidl-conversions    xmlbuilder
aws-sdk               deprecation           isarray               punycode              universal-user-agent  whatwg-url
base64-js             events                jmespath              querystring           url                   wrappy
before-after-hook     ieee754               node-fetch            sax                   uuid                  xml2js
```

Comparing with a build that passed using node12:
```
> fly hijack --target pay-dev -u https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/adminusers-db-migration/builds/18
1: build #18, step: adminusers-ecr-registry-test, type: get
2: build #18, step: assume-role, type: task
3: build #18, step: image, type: check, expires in:
4: build #18, step: registry-image, type: check, expires in:
choose a container: 2
Couldn't find "bash" on container, retrying with "sh"
/tmp/build/c6eb4761 # ls
assume-role  pay-ci
/tmp/build/c6eb4761 # ls /node_modules/
@octokit              buffer                is-plain-object       once                  tr46                  webidl-conversions    xmlbuilder
aws-sdk               deprecation           isarray               punycode              universal-user-agent  whatwg-url
base64-js             events                jmespath              querystring           url                   wrappy
before-after-hook     ieee754               node-fetch            sax                   uuid                  xml2js
```

So I think the node process is trying to look at /node_modules.