### PR TITLE
PP-9392: Install npm packages globally

### DIFF
--- a/ci/docker/node-runner/Dockerfile.node16
+++ b/ci/docker/node-runner/Dockerfile.node16
@@ -3,5 +3,5 @@ FROM node:16.14.0-alpine3.15@sha256:425c81a04546a543da824e67c91d4a603af16fbc3d87
 # As of node 15 the docker container fails to npm install without either a WORKDIR or -g
 WORKDIR /node-runner
 
-RUN npm install aws-sdk@^2.x.x
-RUN npm install @octokit/rest@^18.x.x
+RUN npm install -g aws-sdk@^2.x.x
+RUN npm install -g @octokit/rest@^18.x.x


### PR DESCRIPTION
We've seen concourse builds fail with the error
```
selected worker: ip-10-1-11-96
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'aws-sdk'
Require stack:
- /tmp/build/c6eb4761/pay-ci/ci/scripts/assume-role.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/tmp/build/c6eb4761/pay-ci/ci/scripts/assume-role.js:4:13)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/tmp/build/c6eb4761/pay-ci/ci/scripts/assume-role.js' ]
}
```
We think this can be resolved by installing npm packages globally so they are available when a node script is run from any directory.