### PR TITLE
PP-9392: Add NODE_PATH env var

### DIFF
--- a/ci/docker/node-runner/Dockerfile.node16
+++ b/ci/docker/node-runner/Dockerfile.node16
@@ -5,3 +5,5 @@ WORKDIR /node-runner
 
 RUN npm install -g aws-sdk@^2.x.x
 RUN npm install -g @octokit/rest@^18.x.x
+
+ENV NODE_PATH=/usr/local/lib/node_modules


### PR DESCRIPTION
It turns out that https://github.com/alphagov/pay-ci/pull/755 didn't quite do the trick to get the assume-role task within a concourse job working. Upon hijacking the concourse docker container, we found that setting the `NODE_PATH` env variable to `/usr/local/lib/node_modules` enabled a node script to be run from anywhere which resolves our issues.