### PR TITLE
PP 10148 remove old node12 version of node runner

### DIFF
--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile.node12
+Dockerfile.node16

--- a/ci/docker/node-runner/Dockerfile.node12
+++ b/ci/docker/node-runner/Dockerfile.node12
@@ -1,4 +1,0 @@
-FROM node:12.22.10-alpine3.15@sha256:f150ebf9402f0dd6a9c4cb208ed64884cfa7c8a6ccae3f749a7b12156c25ad88
-
-RUN npm install aws-sdk@^2.x.x
-RUN npm install @octokit/rest@^18.x.x

--- a/ci/docker/node-runner/README.md
+++ b/ci/docker/node-runner/README.md
@@ -3,8 +3,8 @@
 This Docker container is used to run [JS scripts](https://github.com/alphagov/pay-ci/tree/master/ci/scripts)
 within tasks on Concourse CI.
 
-Note there are 2 Dockerfiles in this repository for now, one is for node12 and one for node16. The symbolic link of
-Dockerfile to Dockerfile.node12 ensures node12 is still the default.
+Note there is only one Dockerfile in this repository for node16 for now, however the symbolic link 
+has been kept in this folder (defaulting to Dockerfile.node16), to prepare for future node updates.
 
 You can build the node16 version by providing the `--file` flag to docker build:
 

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -18,15 +18,6 @@ resources:
       paths:
         - ci/docker/node-runner/*
 
-  - name: node-runner-latest
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/node-runner
-      username: ((docker-username))
-      password: ((docker-password))
-      tag: latest
-
   - name: node-runner-node16
     type: registry-image
     icon: docker

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -27,15 +27,6 @@ resources:
       password: ((docker-password))
       tag: latest
 
-  - name: node-runner-node12
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/node-runner
-      username: ((docker-username))
-      password: ((docker-password))
-      tag: node12
-
   - name: node-runner-node16
     type: registry-image
     icon: docker
@@ -67,26 +58,6 @@ jobs:
           PASSWORD: ((docker-password))
           EMAIL: ((docker-email))
       - in_parallel:
-        - task: build-node-12
-          privileged: true
-          output_mapping:
-            image: node12-image
-          params:
-            CONTEXT: node-runner-src/ci/docker/node-runner
-            DOCKERFILE: node-runner-src/ci/docker/node-runner/Dockerfile.node12
-            DOCKER_CONFIG: docker_creds
-          config:
-            platform: linux
-            image_resource:
-              type: registry-image
-              source:
-                repository: concourse/oci-build-task
-            inputs:
-            - name: node-runner-src
-            outputs:
-            - name: image
-            run:
-              path: build
         - task: build-node-16
           privileged: true
           output_mapping:
@@ -109,16 +80,6 @@ jobs:
               path: build
       - in_parallel:
         - do:
-          - put: node-runner-node12
-            params:
-              image: node12-image/image.tar
-            get_params:
-              skip_download: true
-          - put: node-runner-latest
-            params:
-              image: node12-image/image.tar
-            get_params:
-              skip_download: true
         - put: node-runner-node16
           params:
             image: node16-image/image.tar


### PR DESCRIPTION
removed [the symbolic link](https://github.com/alphagov/pay-ci/blob/master/ci/docker/node-runner/Dockerfile) and created a new one to point to Dockerfile.node16 as a default

node12 Dockerfile is removed from pay-ci

[the pay-ci/docker/node-runner README file](https://github.com/alphagov/pay-ci/blob/master/ci/docker/node-runner/README.md) is updated to remove mention of node12

Removed build job for node12 from node-runner.yml