### PR TITLE
BAU: Increase deploy timeout to 15 minutes

### DIFF
--- a/ci/scripts/wait-for-deploy.js
+++ b/ci/scripts/wait-for-deploy.js
@@ -2,7 +2,7 @@
 
 const AWS = require('aws-sdk')
 const ecs = new AWS.ECS()
-const MAX_RETRIES = 120
+const MAX_RETRIES = 180
 const EGRESS_MAX_RETRIES = 180
 const CHECK_INTERVAL = 5000
 const {


### PR DESCRIPTION
We've seen a significant number of deployments take between 10-13 minutes to show as completed in ECS.

Until we can determine the cause of the delay in achieving the stable state (see PP-10154), let's increase the timeout to 15 minutes, to avoid noisy error messages appearing in Slack for deployments that have actually been successful.