### PR TITLE
PP-10135: Send release metrics to HG for staging and prod apps

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -520,6 +520,7 @@ groups:
   - name: adminusers
     jobs:
       - deploy-adminusers-to-prod
+      - record-adminusers-release-number
       - smoke-test-adminusers-on-prod
       - retag-adminusers-image-for-test-perf
       - adminusers-pact-tag
@@ -528,12 +529,14 @@ groups:
   - name: cardid
     jobs:
       - deploy-cardid-to-prod
+      - record-cardid-release-number
       - smoke-test-cardid-on-prod
       - cardid-pact-tag
       - retag-cardid-image-for-test-perf
   - name: connector
     jobs:
       - deploy-connector-to-prod
+      - record-connector-release-number
       - smoke-test-connector-on-prod
       - retag-connector-image-for-test-perf
       - connector-pact-tag
@@ -542,17 +545,20 @@ groups:
   - name: egress
     jobs:
       - deploy-egress-to-prod
+      - record-egress-release-number
       - smoke-test-egress-on-prod
       - retag-egress-image-for-test-perf
   - name: frontend
     jobs:
       - deploy-frontend-to-prod
+      - record-frontend-release-number
       - smoke-test-frontend-on-prod
       - frontend-pact-tag
       - retag-frontend-image-for-test-perf
   - name: ledger
     jobs:
       - deploy-ledger-to-prod
+      - record-ledger-release-number
       - smoke-test-ledger-on-prod
       - retag-ledger-image-for-test-perf
       - ledger-pact-tag
@@ -561,6 +567,7 @@ groups:
   - name: products
     jobs:
       - deploy-products-to-prod
+      - record-products-release-number
       - smoke-test-products-on-prod
       - retag-products-image-for-test-perf
       - products-pact-tag
@@ -569,18 +576,21 @@ groups:
   - name: products-ui
     jobs:
       - deploy-products-ui-to-prod
+      - record-products-ui-release-number
       - smoke-test-products-ui-on-prod
       - products-ui-pact-tag
       - retag-products-ui-image-for-test-perf
   - name: publicapi
     jobs:
       - deploy-publicapi-to-prod
+      - record-publicapi-release-number
       - smoke-test-publicapi-on-prod
       - publicapi-pact-tag
       - retag-publicapi-image-for-test-perf
   - name: publicauth
     jobs:
       - deploy-publicauth-to-prod
+      - record-publicauth-release-number
       - smoke-test-publicauth-on-prod
       - retag-publicauth-image-for-test-perf
       - publicauth-db-migration-prod
@@ -588,16 +598,19 @@ groups:
   - name: selfservice
     jobs:
       - deploy-selfservice-to-prod
+      - record-selfservice-release-number
       - smoke-test-selfservice-on-prod
       - selfservice-pact-tag
       - retag-selfservice-image-for-test-perf
   - name: toolbox
     jobs:
       - deploy-toolbox-to-prod
+      - record-toolbox-release-number
       - retag-toolbox-image-for-test-perf
   - name: webhooks
     jobs:
       - deploy-webhooks-to-prod
+      - record-webhooks-release-number
       - smoke-test-webhooks-on-prod
       - webhooks-pact-tag
       - webhooks-db-migration-prod
@@ -606,6 +619,7 @@ groups:
   - name: webhooks-egress
     jobs:
       - deploy-webhooks-egress-to-prod
+      - record-webhooks-egress-release-number
       - smoke-test-webhooks-egress-on-prod
       - retag-webhooks-egress-image-for-test-perf
   - name: alpine
@@ -632,6 +646,7 @@ groups:
   - name: notifications
     jobs:
       - deploy-notifications-to-prod
+      - record-notifications-release-number
       - smoke-test-notifications-on-prod
       - retag-notifications-for-test-perf
   - name: stream-s3-sqs
@@ -706,6 +721,22 @@ jobs:
           ENVIRONMENT: production-2
     <<: *put_success_slack_notification_p1      
     <<: *put_failure_slack_notification
+
+  - name: record-egress-release-number
+    plan:
+      - get: egress-ecr-registry-prod
+        trigger: true
+        passed: [deploy-egress-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: egress-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "egress"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-egress-on-prod
     serial_groups: [smoke-test]
@@ -823,6 +854,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-selfservice-release-number
+    plan:
+      - get: selfservice-ecr-registry-prod
+        trigger: true
+        passed: [deploy-selfservice-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: selfservice-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "selfservice"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-selfservice-on-prod
     serial_groups: [smoke-test]
@@ -973,6 +1020,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-connector-release-number
+    plan:
+      - get: connector-ecr-registry-prod
+        trigger: true
+        passed: [deploy-connector-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: connector-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "connector"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-connector-on-prod
     serial_groups: [smoke-test]
@@ -1268,6 +1331,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-toolbox-release-number
+    plan:
+      - get: toolbox-ecr-registry-prod
+        trigger: true
+        passed: [deploy-toolbox-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: toolbox-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "toolbox"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: retag-telegraf-image-for-test-perf
     plan:
       - get: pay-ci
@@ -1391,6 +1470,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-frontend-release-number
+    plan:
+      - get: frontend-ecr-registry-prod
+        trigger: true
+        passed: [deploy-frontend-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: frontend-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "frontend"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-frontend-on-prod
     serial_groups: [smoke-test]
@@ -1562,6 +1657,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-adminusers-release-number
+    plan:
+      - get: adminusers-ecr-registry-prod
+        trigger: true
+        passed: [deploy-adminusers-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: adminusers-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "adminusers"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: adminusers-db-migration-prod
     plan:
@@ -1775,6 +1886,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-products-release-number
+    plan:
+      - get: products-ecr-registry-prod
+        trigger: true
+        passed: [deploy-products-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: products-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "products"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-products-on-prod
     serial_groups: [smoke-test]
     plan:
@@ -1987,6 +2114,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-products-ui-release-number
+    plan:
+      - get: products-ui-ecr-registry-prod
+        trigger: true
+        passed: [deploy-products-ui-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: products-ui-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "products-ui"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-products-ui-on-prod
     serial_groups: [smoke-test]
     plan:
@@ -2123,6 +2266,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-publicauth-release-number
+    plan:
+      - get: publicauth-ecr-registry-prod
+        trigger: true
+        passed: [deploy-publicauth-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: publicauth-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "publicauth"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: publicauth-db-migration-prod
     plan:
@@ -2302,6 +2461,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-cardid-release-number
+    plan:
+      - get: cardid-ecr-registry-prod
+        trigger: true
+        passed: [deploy-cardid-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: cardid-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "cardid"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-cardid-on-prod
     serial_groups: [smoke-test]
     plan:
@@ -2451,6 +2626,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-publicapi-release-number
+    plan:
+      - get: publicapi-ecr-registry-prod
+        trigger: true
+        passed: [deploy-publicapi-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: publicapi-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "publicapi"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-publicapi-on-prod
     serial_groups: [smoke-test]
@@ -2602,6 +2793,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-ledger-release-number
+    plan:
+      - get: ledger-ecr-registry-prod
+        trigger: true
+        passed: [deploy-ledger-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: ledger-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "ledger"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-ledger-on-prod
     serial_groups: [smoke-test]
@@ -2828,6 +3035,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-notifications-release-number
+    plan:
+      - get: notifications-ecr-registry-prod
+        trigger: true
+        passed: [deploy-notifications-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "notifications"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-notifications-on-prod
     serial_groups: [smoke-test]
     plan:
@@ -3027,6 +3250,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-webhooks-release-number
+    plan:
+      - get: webhooks-ecr-registry-prod
+        trigger: true
+        passed: [deploy-webhooks-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: webhooks-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "webhooks"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-webhooks-on-prod
     serial_groups: [smoke-test]
@@ -3229,6 +3468,22 @@ jobs:
           ENVIRONMENT: production-2
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-webhooks-egress-release-number
+    plan:
+      - get: webhooks-egress-ecr-registry-prod
+        trigger: true
+        passed: [deploy-webhooks-egress-to-prod]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: webhooks-egress-ecr-registry-prod/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "production-2"
+          APP_NAME: "webhooks-egress"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-webhooks-egress-on-prod
     serial_groups: [smoke-test]

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -524,6 +524,7 @@ groups:
   - name: adminusers
     jobs:
       - deploy-adminusers-to-staging
+      - record-adminusers-release-number
       - smoke-test-adminusers-on-staging
       - adminusers-pact-tag
       - push-adminusers-to-production-ecr
@@ -531,12 +532,14 @@ groups:
   - name: cardid
     jobs:
       - deploy-cardid-to-staging
+      - record-cardid-release-number
       - smoke-test-cardid-on-staging
       - cardid-pact-tag
       - push-cardid-to-production-ecr
   - name: connector
     jobs:
       - deploy-connector-to-staging
+      - record-connector-release-number
       - smoke-test-connector-on-staging
       - connector-pact-tag
       - push-connector-to-production-ecr
@@ -544,17 +547,20 @@ groups:
   - name: egress
     jobs:
       - deploy-egress-to-staging
+      - record-egress-release-number
       - smoke-test-egress-on-staging
       - push-egress-to-production-ecr
   - name: frontend
     jobs:
       - deploy-frontend-to-staging
+      - record-frontend-release-number
       - smoke-test-frontend-on-staging
       - frontend-pact-tag
       - push-frontend-to-production-ecr
   - name: ledger
     jobs:
       - deploy-ledger-to-staging
+      - record-ledger-release-number
       - smoke-test-ledger-on-staging
       - ledger-pact-tag
       - push-ledger-to-production-ecr
@@ -562,6 +568,7 @@ groups:
   - name: products
     jobs:
       - deploy-products-to-staging
+      - record-products-release-number
       - smoke-test-products-on-staging
       - products-pact-tag
       - push-products-to-production-ecr
@@ -569,34 +576,40 @@ groups:
   - name: products-ui
     jobs:
       - deploy-products-ui-to-staging
+      - record-products-ui-release-number
       - smoke-test-products-ui-on-staging
       - products-ui-pact-tag
       - push-products-ui-to-production-ecr
   - name: publicapi
     jobs:
       - deploy-publicapi-to-staging
+      - record-publicapi-release-number
       - smoke-test-publicapi-on-staging
       - publicapi-pact-tag
       - push-publicapi-to-production-ecr
   - name: publicauth
     jobs:
       - deploy-publicauth-to-staging
+      - record-publicauth-release-number
       - smoke-test-publicauth-on-staging
       - push-publicauth-to-production-ecr
       - publicauth-db-migration-staging
   - name: selfservice
     jobs:
       - deploy-selfservice-to-staging
+      - record-selfservice-release-number
       - smoke-test-selfservice-on-staging
       - selfservice-pact-tag
       - push-selfservice-to-production-ecr
   - name: toolbox
     jobs:
       - deploy-toolbox-to-staging
+      - record-toolbox-release-number
       - push-toolbox-to-production-ecr
   - name: webhooks
     jobs:
       - deploy-webhooks-to-staging
+      - record-webhooks-release-number
       - smoke-test-webhooks-on-staging
       - webhooks-pact-tag
       - push-webhooks-to-production-ecr
@@ -604,6 +617,7 @@ groups:
   - name: webhooks-egress
     jobs:
       - deploy-webhooks-egress-to-staging
+      - record-webhooks-egress-release-number
       - smoke-test-webhooks-egress-on-staging
       - push-webhooks-egress-to-production-ecr
   - name: alpine
@@ -631,6 +645,7 @@ groups:
   - name: notifications
     jobs:
       - deploy-notifications-to-staging
+      - record-notifications-release-number
       - smoke-test-notifications-on-staging
       - push-notifications-to-production-ecr
   - name: stream-s3-sqs
@@ -879,6 +894,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-selfservice-release-number
+    plan:
+      - get: selfservice-ecr-registry-staging
+        trigger: true
+        passed: [deploy-selfservice-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: selfservice-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "selfservice"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-selfservice-on-staging
     serial_groups: [smoke-test]
     plan:
@@ -1023,6 +1054,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-connector-release-number
+    plan:
+      - get: connector-ecr-registry-staging
+        trigger: true
+        passed: [deploy-connector-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: connector-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "connector"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-connector-on-staging
     serial_groups: [smoke-test]
@@ -1205,6 +1252,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-toolbox-release-number
+    plan:
+      - get: toolbox-ecr-registry-staging
+        trigger: true
+        passed: [deploy-toolbox-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: toolbox-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "toolbox"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: push-toolbox-to-production-ecr
     plan:
       - get: toolbox-ecr-registry-staging
@@ -1272,6 +1335,22 @@ jobs:
           ENVIRONMENT: staging-2
     <<: *put_success_slack_notification_p1      
     <<: *put_failure_slack_notification
+
+  - name: record-egress-release-number
+    plan:
+      - get: egress-ecr-registry-staging
+        trigger: true
+        passed: [deploy-egress-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: egress-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "egress"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-egress-on-staging
     serial_groups: [smoke-test]
@@ -1373,6 +1452,22 @@ jobs:
           ENVIRONMENT: staging-2
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-webhooks-egress-release-number
+    plan:
+      - get: webhooks-egress-ecr-registry-staging
+        trigger: true
+        passed: [deploy-webhooks-egress-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: webhooks-egress-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "webhooks-egress"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-webhooks-egress-on-staging
     serial_groups: [smoke-test]
@@ -1490,6 +1585,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-frontend-release-number
+    plan:
+      - get: frontend-ecr-registry-staging
+        trigger: true
+        passed: [deploy-frontend-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: frontend-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "frontend"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-frontend-on-staging
     serial_groups: [smoke-test]
@@ -1639,6 +1750,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-adminusers-release-number
+    plan:
+      - get: adminusers-ecr-registry-staging
+        trigger: true
+        passed: [deploy-adminusers-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: adminusers-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "adminusers"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: adminusers-db-migration-staging
     plan:
@@ -1830,6 +1957,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-products-release-number
+    plan:
+      - get: products-ecr-registry-staging
+        trigger: true
+        passed: [deploy-products-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: products-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "products"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-products-on-staging
     serial_groups: [smoke-test]
     plan:
@@ -2020,6 +2163,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-products-ui-release-number
+    plan:
+      - get: products-ui-ecr-registry-staging
+        trigger: true
+        passed: [deploy-products-ui-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: products-ui-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "products-ui"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-products-ui-on-staging
     serial_groups: [smoke-test]
     plan:
@@ -2151,6 +2310,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-publicauth-release-number
+    plan:
+      - get: publicauth-ecr-registry-staging
+        trigger: true
+        passed: [deploy-publicauth-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: publicauth-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "publicauth"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-publicauth-on-staging
     serial_groups: [smoke-test]
@@ -2308,6 +2483,22 @@ jobs:
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
 
+  - name: record-cardid-release-number
+    plan:
+      - get: cardid-ecr-registry-staging
+        trigger: true
+        passed: [deploy-cardid-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: cardid-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "cardid"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
   - name: smoke-test-cardid-on-staging
     serial_groups: [smoke-test]
     plan:
@@ -2452,6 +2643,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-publicapi-release-number
+    plan:
+      - get: publicapi-ecr-registry-staging
+        trigger: true
+        passed: [deploy-publicapi-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: publicapi-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "publicapi"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-publicapi-on-staging
     serial_groups: [smoke-test]
@@ -2598,6 +2805,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-ledger-release-number
+    plan:
+      - get: ledger-ecr-registry-staging
+        trigger: true
+        passed: [deploy-ledger-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: ledger-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "ledger"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-ledger-on-staging
     serial_groups: [smoke-test]
@@ -2783,6 +3006,22 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_notification_p1
     <<: *put_failure_slack_notification
+
+  - name: record-webhooks-release-number
+    plan:
+      - get: webhooks-ecr-registry-staging
+        trigger: true
+        passed: [deploy-webhooks-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: webhooks-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "webhooks"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-webhooks-on-staging
     serial_groups: [smoke-test]
@@ -3021,6 +3260,22 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     <<: *put_success_slack_notification 
     <<: *put_failure_slack_notification
+
+  - name: record-notifications-release-number
+    plan:
+      - get: notifications-ecr-registry-staging
+        trigger: true
+        passed: [deploy-notifications-to-staging]
+      - get: pay-ci
+      - load_var: application_image_tag
+        file: notifications-ecr-registry-staging/tag
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "staging-2"
+          APP_NAME: "notifications"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
 
   - name: smoke-test-notifications-on-staging
     serial_groups: [smoke-test]


### PR DESCRIPTION
Following on from https://github.com/alphagov/pay-ci/pull/763, send release info metrics to Hosted Graphite following successful deploys to staging and production.