### PR TITLE
PP-10135 Trigger release metrics every hour

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -205,6 +205,11 @@ resources:
     source:
       uri: https://github.com/alphagov/pay-ci
       branch: master
+  - name: every-hour
+    icon: alarm
+    source:
+      interval: 1h
+    type: time
   - name: pay-infra
     type: git
     icon: github
@@ -724,6 +729,8 @@ jobs:
 
   - name: record-egress-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: egress-ecr-registry-prod
         trigger: true
         passed: [deploy-egress-to-prod]
@@ -857,6 +864,8 @@ jobs:
 
   - name: record-selfservice-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: selfservice-ecr-registry-prod
         trigger: true
         passed: [deploy-selfservice-to-prod]
@@ -1023,6 +1032,8 @@ jobs:
 
   - name: record-connector-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: connector-ecr-registry-prod
         trigger: true
         passed: [deploy-connector-to-prod]
@@ -1333,6 +1344,8 @@ jobs:
 
   - name: record-toolbox-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: toolbox-ecr-registry-prod
         trigger: true
         passed: [deploy-toolbox-to-prod]
@@ -1473,6 +1486,8 @@ jobs:
 
   - name: record-frontend-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: frontend-ecr-registry-prod
         trigger: true
         passed: [deploy-frontend-to-prod]
@@ -1660,6 +1675,8 @@ jobs:
 
   - name: record-adminusers-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: adminusers-ecr-registry-prod
         trigger: true
         passed: [deploy-adminusers-to-prod]
@@ -1888,6 +1905,8 @@ jobs:
 
   - name: record-products-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: products-ecr-registry-prod
         trigger: true
         passed: [deploy-products-to-prod]
@@ -2116,6 +2135,8 @@ jobs:
 
   - name: record-products-ui-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: products-ui-ecr-registry-prod
         trigger: true
         passed: [deploy-products-ui-to-prod]
@@ -2269,6 +2290,8 @@ jobs:
 
   - name: record-publicauth-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: publicauth-ecr-registry-prod
         trigger: true
         passed: [deploy-publicauth-to-prod]
@@ -2463,6 +2486,8 @@ jobs:
 
   - name: record-cardid-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: cardid-ecr-registry-prod
         trigger: true
         passed: [deploy-cardid-to-prod]
@@ -2629,6 +2654,8 @@ jobs:
 
   - name: record-publicapi-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: publicapi-ecr-registry-prod
         trigger: true
         passed: [deploy-publicapi-to-prod]
@@ -2796,6 +2823,8 @@ jobs:
 
   - name: record-ledger-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: ledger-ecr-registry-prod
         trigger: true
         passed: [deploy-ledger-to-prod]
@@ -3037,6 +3066,8 @@ jobs:
 
   - name: record-notifications-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: notifications-ecr-registry-prod
         trigger: true
         passed: [deploy-notifications-to-prod]
@@ -3253,6 +3284,8 @@ jobs:
 
   - name: record-webhooks-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: webhooks-ecr-registry-prod
         trigger: true
         passed: [deploy-webhooks-to-prod]
@@ -3471,6 +3504,8 @@ jobs:
 
   - name: record-webhooks-egress-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: webhooks-egress-ecr-registry-prod
         trigger: true
         passed: [deploy-webhooks-egress-to-prod]

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -206,6 +206,11 @@ resources:
     source:
       uri: https://github.com/alphagov/pay-ci
       branch: master
+  - name: every-hour
+    icon: alarm
+    source:
+      interval: 1h
+    type: time
   - name: pay-infra
     type: git
     icon: github
@@ -896,6 +901,8 @@ jobs:
 
   - name: record-selfservice-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: selfservice-ecr-registry-staging
         trigger: true
         passed: [deploy-selfservice-to-staging]
@@ -1057,6 +1064,8 @@ jobs:
 
   - name: record-connector-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: connector-ecr-registry-staging
         trigger: true
         passed: [deploy-connector-to-staging]
@@ -1254,6 +1263,8 @@ jobs:
 
   - name: record-toolbox-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: toolbox-ecr-registry-staging
         trigger: true
         passed: [deploy-toolbox-to-staging]
@@ -1338,6 +1349,8 @@ jobs:
 
   - name: record-egress-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: egress-ecr-registry-staging
         trigger: true
         passed: [deploy-egress-to-staging]
@@ -1455,6 +1468,8 @@ jobs:
 
   - name: record-webhooks-egress-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: webhooks-egress-ecr-registry-staging
         trigger: true
         passed: [deploy-webhooks-egress-to-staging]
@@ -1588,6 +1603,8 @@ jobs:
 
   - name: record-frontend-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: frontend-ecr-registry-staging
         trigger: true
         passed: [deploy-frontend-to-staging]
@@ -1753,6 +1770,8 @@ jobs:
 
   - name: record-adminusers-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: adminusers-ecr-registry-staging
         trigger: true
         passed: [deploy-adminusers-to-staging]
@@ -1959,6 +1978,8 @@ jobs:
 
   - name: record-products-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: products-ecr-registry-staging
         trigger: true
         passed: [deploy-products-to-staging]
@@ -2165,6 +2186,8 @@ jobs:
 
   - name: record-products-ui-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: products-ui-ecr-registry-staging
         trigger: true
         passed: [deploy-products-ui-to-staging]
@@ -2313,6 +2336,8 @@ jobs:
 
   - name: record-publicauth-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: publicauth-ecr-registry-staging
         trigger: true
         passed: [deploy-publicauth-to-staging]
@@ -2485,6 +2510,8 @@ jobs:
 
   - name: record-cardid-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: cardid-ecr-registry-staging
         trigger: true
         passed: [deploy-cardid-to-staging]
@@ -2646,6 +2673,8 @@ jobs:
 
   - name: record-publicapi-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: publicapi-ecr-registry-staging
         trigger: true
         passed: [deploy-publicapi-to-staging]
@@ -2808,6 +2837,8 @@ jobs:
 
   - name: record-ledger-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: ledger-ecr-registry-staging
         trigger: true
         passed: [deploy-ledger-to-staging]
@@ -3009,6 +3040,8 @@ jobs:
 
   - name: record-webhooks-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: webhooks-ecr-registry-staging
         trigger: true
         passed: [deploy-webhooks-to-staging]
@@ -3263,6 +3296,8 @@ jobs:
 
   - name: record-notifications-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: notifications-ecr-registry-staging
         trigger: true
         passed: [deploy-notifications-to-staging]

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -119,6 +119,11 @@ resources:
     source:
       uri: https://github.com/alphagov/pay-ci
       branch: master
+  - name: every-hour
+    icon: alarm
+    source:
+      interval: 1h
+    type: time
 
   # Github Releases
   - name: telegraf-git-release
@@ -1469,6 +1474,8 @@ jobs:
 
   - name: record-toolbox-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: toolbox-ecr-registry-test
         trigger: true
         passed: [deploy-toolbox]
@@ -1551,6 +1558,8 @@ jobs:
 
   - name: record-egress-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: egress-ecr-registry-test
         trigger: true
         passed: [deploy-egress]
@@ -1851,6 +1860,8 @@ jobs:
 
   - name: record-frontend-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: frontend-ecr-registry-test
         trigger: true
         passed: [deploy-frontend]
@@ -2187,6 +2198,8 @@ jobs:
 
   - name: record-adminusers-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: adminusers-ecr-registry-test
         trigger: true
         passed: [deploy-adminusers]
@@ -2607,6 +2620,8 @@ jobs:
 
   - name: record-connector-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: connector-ecr-registry-test
         trigger: true
         passed: [deploy-connector]
@@ -2937,6 +2952,8 @@ jobs:
 
   - name: record-ledger-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: ledger-ecr-registry-test
         trigger: true
         passed: [deploy-ledger]
@@ -3312,6 +3329,8 @@ jobs:
 
   - name: record-products-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: products-ecr-registry-test
         trigger: true
         passed: [deploy-products]
@@ -3666,6 +3685,8 @@ jobs:
 
   - name: record-products-ui-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: products-ui-ecr-registry-test
         trigger: true
         passed: [deploy-products-ui]
@@ -4014,6 +4035,8 @@ jobs:
 
   - name: record-publicapi-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: publicapi-ecr-registry-test
         trigger: true
         passed: [deploy-publicapi]
@@ -4339,6 +4362,8 @@ jobs:
 
   - name: record-publicauth-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: publicauth-ecr-registry-test
         trigger: true
         passed: [deploy-publicauth]
@@ -4668,6 +4693,8 @@ jobs:
 
   - name: record-selfservice-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: selfservice-ecr-registry-test
         trigger: true
         passed: [deploy-selfservice]
@@ -5045,6 +5072,8 @@ jobs:
 
   - name: record-cardid-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: cardid-ecr-registry-test
         trigger: true
         passed: [deploy-cardid]
@@ -5286,6 +5315,8 @@ jobs:
 
   - name: record-webhooks-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: webhooks-ecr-registry-test
         trigger: true
         passed: [deploy-webhooks]
@@ -5595,6 +5626,8 @@ jobs:
 
   - name: record-webhooks-egress-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: webhooks-egress-ecr-registry-test
         trigger: true
         passed: [deploy-webhooks-egress]
@@ -5964,6 +5997,8 @@ jobs:
 
   - name: record-notifications-release-number
     plan:
+      - get: every-hour
+        trigger: true
       - get: notifications-ecr-registry-test
         trigger: true
         passed: [deploy-notifications]


### PR DESCRIPTION
Hosted Graphite is not the best at keeping long-lived metrics hanging around. 

This PR adds an hourly 'time' resource that will trigger a refresh of the release metrics, and keep the dashboard populated. A normal release will also trigger the metric sending, as before. 