### PR TITLE
PP-10135: Use serial_groups for recording metrics

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -728,6 +728,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-egress-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -863,6 +864,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-selfservice-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1031,6 +1033,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-connector-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1343,6 +1346,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-toolbox-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1485,6 +1489,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-frontend-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1674,6 +1679,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-adminusers-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1904,6 +1910,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-products-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2134,6 +2141,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-products-ui-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2289,6 +2297,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-publicauth-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2485,6 +2494,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-cardid-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2653,6 +2663,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-publicapi-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2822,6 +2833,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-ledger-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3065,6 +3077,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-notifications-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3283,6 +3296,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-webhooks-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3503,6 +3517,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-webhooks-egress-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -900,6 +900,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-selfservice-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1063,6 +1064,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-connector-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1262,6 +1264,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-toolbox-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1348,6 +1351,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-egress-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1467,6 +1471,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-webhooks-egress-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1602,6 +1607,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-frontend-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1769,6 +1775,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-adminusers-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1977,6 +1984,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-products-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2185,6 +2193,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-products-ui-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2335,6 +2344,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-publicauth-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2509,6 +2519,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-cardid-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2672,6 +2683,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-publicapi-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2836,6 +2848,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-ledger-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3039,6 +3052,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-webhooks-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3295,6 +3309,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-notifications-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1483,6 +1483,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-toolbox-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1567,6 +1568,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-egress-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1699,6 +1701,7 @@ jobs:
         username: pay-concourse
 
   - name: record-frontend-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -1890,6 +1893,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-frontend-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2083,6 +2087,7 @@ jobs:
         username: pay-concourse
 
   - name: record-adminusers-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2249,6 +2254,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-adminusers-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2481,6 +2487,7 @@ jobs:
         username: pay-concourse            
 
   - name: record-connector-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2692,6 +2699,7 @@ jobs:
     <<: *put_db_migration_failure_slack_notification               
 
   - name: record-connector-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -2879,6 +2887,7 @@ jobs:
         username: pay-concourse
 
   - name: record-ledger-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3045,6 +3054,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-ledger-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3277,6 +3287,7 @@ jobs:
         username: pay-concourse
 
   - name: record-products-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3443,6 +3454,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-products-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3654,6 +3666,7 @@ jobs:
         username: pay-concourse
 
   - name: record-products-ui-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -3820,6 +3833,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-products-ui-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -4010,6 +4024,7 @@ jobs:
         username: pay-concourse
 
   - name: record-publicapi-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -4191,6 +4206,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-publicapi-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -4378,6 +4394,7 @@ jobs:
         username: pay-concourse
 
   - name: record-publicauth-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -4539,6 +4556,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-publicauth-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -4716,6 +4734,7 @@ jobs:
         username: pay-concourse
 
   - name: record-selfservice-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -4890,6 +4909,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-selfservice-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -5116,6 +5136,7 @@ jobs:
         username: pay-concourse
 
   - name: record-cardid-candidate-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -5290,6 +5311,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-cardid-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -5532,6 +5554,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-webhooks-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -5843,6 +5866,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-webhooks-egress-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true
@@ -6214,6 +6238,7 @@ jobs:
     <<: *put_failure_slack_notification
 
   - name: record-notifications-release-number
+    serial_groups: [record-metrics]
     plan:
       - get: every-hour
         trigger: true


### PR DESCRIPTION
Scheduling the metric jobs every hour meant the resource checks were failing, as there were too many concurrent jobs.

For the test pipeline I've put the `*-release` and the `*-candidate` jobs in the same serial group to try and keep things simple - the jobs themselves are very quick and don't block anything else, so it shouldn't matter if there's a long queue.