### PR TITLE
PP-10051 Add base 32 OTP key for e2e tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -230,7 +230,7 @@
         "filename": "ci/tasks/endtoend/docker-config/endtoend.env",
         "hashed_secret": "778c0204b40447fe46db8608ae4718dcd497099f",
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 38,
         "is_secret": false
       }
     ],
@@ -367,5 +367,5 @@
       }
     ]
   },
-  "generated_at": "2021-12-01T14:53:00Z"
+  "generated_at": "2022-10-17T11:51:36Z"
 }

--- a/ci/tasks/endtoend/docker-config/endtoend.env
+++ b/ci/tasks/endtoend/docker-config/endtoend.env
@@ -27,6 +27,7 @@ SELFSERVICE_URL=https://selfservice.pymnt.localdomain
 SELFSERVICE_USERNAME=alice.111@mail.fake
 SELFSERVICE_PASSWORD=arandompassword
 SELFSERVICE_OTP_KEY=55w7bwl169
+SELFSERVICE_OTP_KEY_BASE32=RG5RNFK3IBUK4RWGHUOU7SSGC6FRRCZR
 STUBS_URL=https://stubs.pymnt.localdomain/
 DB_SETUP_FOR_SMOKE=true
 FRONTEND_URL=https://frontend.pymnt.localdomain


### PR DESCRIPTION
We are in the process of removing support for non-base 32 encoded OTP keys. Add a new environment variable for a base 32 encoded OTP key for use by the end-to-end tests. The old SELFSERVICE_OTP_KEY environment variable will be removed when end-to-end tests are using the new environment variable.