### PR TITLE
PP-10051 Remove old environment variable

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -230,7 +230,7 @@
         "filename": "ci/tasks/endtoend/docker-config/endtoend.env",
         "hashed_secret": "778c0204b40447fe46db8608ae4718dcd497099f",
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 37,
         "is_secret": false
       }
     ],
@@ -367,5 +367,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-17T11:51:36Z"
+  "generated_at": "2022-10-18T10:54:42Z"
 }

--- a/ci/tasks/endtoend/docker-config/endtoend.env
+++ b/ci/tasks/endtoend/docker-config/endtoend.env
@@ -26,7 +26,6 @@ ADMINUSERS_URL=http://adminusers.pymnt.localdomain:9700
 SELFSERVICE_URL=https://selfservice.pymnt.localdomain
 SELFSERVICE_USERNAME=alice.111@mail.fake
 SELFSERVICE_PASSWORD=arandompassword
-SELFSERVICE_OTP_KEY=55w7bwl169
 SELFSERVICE_OTP_KEY_BASE32=RG5RNFK3IBUK4RWGHUOU7SSGC6FRRCZR
 STUBS_URL=https://stubs.pymnt.localdomain/
 DB_SETUP_FOR_SMOKE=true


### PR DESCRIPTION
Remove the SELFSERVICE_OTP_KEY environment variable for end-to-end builds as its usages have been replaced by SELFSERVICE_OTP_KEY_BASE32.