### PR TITLE
BAU Update ubuntu version for GitHub Actions workflow

### DIFF
--- a/.github/workflows/_run-provider-contract-tests.yml
+++ b/.github/workflows/_run-provider-contract-tests.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   provider-contract-tests:
     name: Provider contract tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846


### PR DESCRIPTION
Update to ubuntu-20.04 which is used by other workflows.

Ubuntu-18.04 is deprecated, and GitHub actions is scheduling brownouts before removing it on April 1st 2023.