### PR TITLE
PP-10254: Specify version of alpine to build cardid

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -5022,6 +5022,7 @@ jobs:
             type: registry-image
             source:
               repository: alpine
+              tag: 3.16
           inputs:
             - name: cardid-git-release
           params:


### PR DESCRIPTION
Rather than use the bleeding edge version of alpine, pin to version 3.16.

Tested the `update-submodule` step [in this Concourse build](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-cardid-candidate/builds/113)