### PR TITLE
PP-10264 Switch to GDS Dockerhub account

### DIFF
--- a/ci/docker/concourse-runner-with-java-17/README.md
+++ b/ci/docker/concourse-runner-with-java-17/README.md
@@ -1,3 +1,3 @@
 # Pay Concourse Runner with java 17
 
-This Docker image identical to the original [govukpay/concourse-runner](https://github.com/alphagov/pay-ci/tree/master/ci/docker/concourse-runner) but with Java 17. The requirement for Java 17 comes from the fact that [webhooks](https://github.com/alphagov/pay-webhooks) uses it.
+This Docker image identical to the original [governmentdigitalservice/pay-concourse-runner](https://github.com/alphagov/pay-ci/tree/master/ci/docker/concourse-runner) but with Java 17. The requirement for Java 17 comes from the fact that [webhooks](https://github.com/alphagov/pay-webhooks) uses it.

--- a/ci/docker/node-runner/README.md
+++ b/ci/docker/node-runner/README.md
@@ -9,5 +9,5 @@ has been kept in this folder (defaulting to Dockerfile.node16), to prepare for f
 You can build the node16 version by providing the `--file` flag to docker build:
 
 ```
-docker build -f Dockerfile.node16 -t govukpay/node-runner:node16-local .
+docker build -f Dockerfile.node16 -t governmentdigitalservice/pay-node-runner:node16-local .
 ```

--- a/ci/pipelines/carbon-relay-ng.yml
+++ b/ci/pipelines/carbon-relay-ng.yml
@@ -47,7 +47,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/carbon-relay-ng
+      repository: governmentdigitalservice/pay-carbon-relay-ng
       password: ((docker-access-token))
       username: ((docker-username))
 

--- a/ci/pipelines/carbon-relay-ng.yml
+++ b/ci/pipelines/carbon-relay-ng.yml
@@ -196,7 +196,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/concourse-runner
+              repository: governmentdigitalservice/pay-concourse-runner
           inputs:
             - name: image
             - name: carbon-relay-ng-src

--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -31,7 +31,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/concourse-runner
+      repository: governmentdigitalservice/pay-concourse-runner
       username: ((docker-username))
       password: ((docker-access-token))
       tag: latest
@@ -40,7 +40,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/concourse-runner-with-java-17
+      repository: governmentdigitalservice/pay-concourse-runner-with-java-17
       username: ((docker-username))
       password: ((docker-access-token))
       tag: latest

--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -64,7 +64,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/concourse-runner
+              repository: governmentdigitalservice/pay-concourse-runner
           inputs:
             - name: smoke-tests-git-release
           outputs:

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -301,7 +301,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/stubs
+      repository: governmentdigitalservice/pay-stubs
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -497,7 +497,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -615,7 +615,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -789,7 +789,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -1025,7 +1025,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -1199,7 +1199,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -1373,7 +1373,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -1707,7 +1707,7 @@ jobs:
           manifest: pay-stubs-manifest/ci/pay_stubs/pay-stubs_manifest.yml
           docker_username: ((docker-username))
           docker_password: ((docker-access-token))
-          docker_image: govukpay/stubs:latest-master
+          docker_image: governmentdigitalservice/pay-stubs:latest-master
           vars:
             smartpay-expected-password: ((smartpay-expected-password))
             smartpay-expected-user: ((smartpay-expected-user))

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1159,7 +1159,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -1722,7 +1722,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -2036,7 +2036,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -2340,7 +2340,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -2959,7 +2959,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -3422,7 +3422,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1174,7 +1174,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -1818,7 +1818,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -2105,7 +2105,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -2419,7 +2419,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -2957,7 +2957,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -3173,7 +3173,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
 
           inputs:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -2297,7 +2297,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -2678,7 +2678,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -3175,7 +3175,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -3497,7 +3497,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -4599,7 +4599,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -5665,7 +5665,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/node-runner
+              repository: governmentdigitalservice/pay-node-runner
               tag: node16
           inputs:
             - name: pay-ci
@@ -6024,7 +6024,7 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: govukpay/concourse-runner
+              repository: governmentdigitalservice/pay-concourse-runner
           inputs:
             - name: telegraf-git-release
           run:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -326,7 +326,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/frontend
+      repository: governmentdigitalservice/pay-frontend
       tag: latest-master
       username: ((docker-username))
       password: ((docker-access-token))
@@ -355,7 +355,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/adminusers
+      repository: governmentdigitalservice/pay-adminusers
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -384,7 +384,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/cardid
+      repository: governmentdigitalservice/pay-cardid
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -413,7 +413,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/connector
+      repository: governmentdigitalservice/pay-connector
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -442,7 +442,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/ledger
+      repository: governmentdigitalservice/pay-ledger
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -478,7 +478,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/products
+      repository: governmentdigitalservice/pay-products
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -507,7 +507,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/products-ui
+      repository: governmentdigitalservice/pay-products-ui
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -536,7 +536,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/publicapi
+      repository: governmentdigitalservice/pay-publicapi
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -565,7 +565,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/publicauth
+      repository: governmentdigitalservice/pay-publicauth
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -594,7 +594,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/selfservice
+      repository: governmentdigitalservice/pay-selfservice
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -412,7 +412,7 @@ jobs:
               image_resource:
                 type: registry-image
                 source:
-                  repository: govukpay/concourse-runner
+                  repository: governmentdigitalservice/pay-concourse-runner
               inputs:
                 - name: pay-infra-src
                 - name: reverse-proxy-git-release

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -74,7 +74,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/endtoend
+      repository: governmentdigitalservice/pay-endtoend
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -109,7 +109,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/reverse-proxy
+      repository: governmentdigitalservice/pay-reverse-proxy
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))
@@ -157,7 +157,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/stubs
+      repository: governmentdigitalservice/pay-stubs
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -22,7 +22,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/node-runner
+      repository: governmentdigitalservice/pay-node-runner
       username: ((docker-username))
       password: ((docker-access-token))
       tag: node16

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -58,7 +58,7 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: govukpay/perftests
+      repository: governmentdigitalservice/pay-perftests
       tag: latest-master
       password: ((docker-access-token))
       username: ((docker-username))

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -112,7 +112,7 @@ definitions:
       image_resource:
         type: registry-image
         source:
-          repository: govukpay/pay-pr-flow-stats
+          repository: governmentdigitalservice/pay-pr-flow-stats
       inputs:
         - name: src
       run:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1277,7 +1277,7 @@ jobs:
             image_resource:
               type: registry-image
               source:
-                repository: govukpay/concourse-runner
+                repository: governmentdigitalservice/pay-concourse-runner
             inputs:
               - name: src
             params:

--- a/ci/tasks/assume-role.yml
+++ b/ci/tasks/assume-role.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 inputs:
   - name: pay-ci

--- a/ci/tasks/build-docker-image.yml
+++ b/ci/tasks/build-docker-image.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
     tag: latest
 inputs:
   - name: build

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/check-release-versions.yml
+++ b/ci/tasks/check-release-versions.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 inputs:
   - name: pay-ci

--- a/ci/tasks/endtoend/task.yml
+++ b/ci/tasks/endtoend/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
     tag: 0-release_2022-01-21
 inputs:
   - name: src

--- a/ci/tasks/get-git-sha-for-release-tag.yml
+++ b/ci/tasks/get-git-sha-for-release-tag.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 params:
   APP_NAME:

--- a/ci/tasks/get-pr-build-docker-image-info.yml
+++ b/ci/tasks/get-pr-build-docker-image-info.yml
@@ -17,7 +17,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
 inputs:
   - name: src
 outputs:

--- a/ci/tasks/java-17-integration-tests.yml
+++ b/ci/tasks/java-17-integration-tests.yml
@@ -2,7 +2,7 @@ container_limits: {}
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner-with-java-17
+    repository: governmentdigitalservice/pay-concourse-runner-with-java-17
     tag: latest
 caches:
   - path: src/.m2

--- a/ci/tasks/java-integration-tests.yml
+++ b/ci/tasks/java-integration-tests.yml
@@ -2,7 +2,7 @@ container_limits: {}
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
     tag: latest
 caches:
   - path: src/.m2

--- a/ci/tasks/pact-provider-verification.yml
+++ b/ci/tasks/pact-provider-verification.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
 params:
   provider:
   consumer:

--- a/ci/tasks/parse-perf-db-release-tag.yml
+++ b/ci/tasks/parse-perf-db-release-tag.yml
@@ -7,7 +7,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 inputs:
   - name: pay-ci

--- a/ci/tasks/parse-perf-release-tag.yml
+++ b/ci/tasks/parse-perf-release-tag.yml
@@ -7,7 +7,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 inputs:
   - name: pay-ci

--- a/ci/tasks/pause-unpause-pipeline.yml
+++ b/ci/tasks/pause-unpause-pipeline.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
     tag: latest
   version:
     digest: sha256:5a7c14795856965615ae9af4564731bf1d13df1c7c2dbda1b8f2a6554e154760

--- a/ci/tasks/prepare-e2e-codebuild.yml
+++ b/ci/tasks/prepare-e2e-codebuild.yml
@@ -12,7 +12,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
 inputs:
   - name: pay-ci
 outputs:

--- a/ci/tasks/run-codebuild.yml
+++ b/ci/tasks/run-codebuild.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 inputs:
   - name: pay-ci

--- a/ci/tasks/run-smoke-test.yml
+++ b/ci/tasks/run-smoke-test.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 inputs:
   - name: pay-ci

--- a/ci/tasks/scale-fargate-service.yml
+++ b/ci/tasks/scale-fargate-service.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
 params:
   SERVICE_NAME:
   SCALE_DIRECTION:

--- a/ci/tasks/start-rds-instance.yml
+++ b/ci/tasks/start-rds-instance.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
 params:
   RDS_INSTANCE_NAME:
   AWS_DEFAULT_REGION: eu-west-1

--- a/ci/tasks/stop-rds-instance.yml
+++ b/ci/tasks/stop-rds-instance.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/concourse-runner
+    repository: governmentdigitalservice/pay-concourse-runner
 params:
   RDS_INSTANCE_NAME:
   AWS_DEFAULT_REGION: eu-west-1

--- a/ci/tasks/wait-for-deploy.yml
+++ b/ci/tasks/wait-for-deploy.yml
@@ -5,7 +5,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: govukpay/node-runner
+    repository: governmentdigitalservice/pay-node-runner
     tag: node16
 params:
   AWS_ACCESS_KEY_ID:


### PR DESCRIPTION
We're switching over to the GDS Dockerhub account, for managing images used in local development and some of our tests. No artefacts destined for production are sent to Dockerhub in either account.

Out of scope of this PR:
- Removing the old `govukpay/postgres:11.1` image in the shared pact testing GHA workflow (we're now using a generic up-to-date image)

This PR will be followed by a pay-infra PR to change the `pay local` setup to fetch images from the new account. I've manually pushed a 'latest-master'/'latest' tagged image for each app in the new account, so anyone already switching over should find a relatively up to date image.