### PR TITLE
PP-10264: Unpin concourse-runner image version

### DIFF
--- a/ci/tasks/pause-unpause-pipeline.yml
+++ b/ci/tasks/pause-unpause-pipeline.yml
@@ -4,8 +4,6 @@ image_resource:
   source:
     repository: governmentdigitalservice/pay-concourse-runner
     tag: latest
-  version:
-    digest: sha256:5a7c14795856965615ae9af4564731bf1d13df1c7c2dbda1b8f2a6554e154760
 params:
   ACTION:
   PIPELINE:


### PR DESCRIPTION
The digest changed when we moved the image to the new governmentdigitalservice Docker Hub account.

We don't pin to an image digest elsewhere in the Concourse tasks - I think we can remove this, to streamline the process when we update the image in future.