### PR TITLE
BAU: Auto-deploy carbon-relay and stunnel to production

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1201,7 +1201,9 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: carbon-relay-ecr-registry-prod
+        trigger: true
       - get: stunnel-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: carbon_relay_image_tag


### PR DESCRIPTION
We've agreed to continuous deployment in principle for all apps. Carbon relay and stunnel are updated infrequently enough that the risk of being affected by the current Concourse flakiness is outweighed by the practicality of the 'merge-and-forget' option.

Note that we already deploy Carbon relay and Stunnel directly to staging, due to a historical quirk where we hadn't enabled metrics on the test-12 environment, and so needed to see changes on staging-2 to manually verify that metrics were still working. 