### PR TITLE
BAU: Pin Docker dependabot updates to 20.10.16

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
   labels:
     - dependencies
     - govuk-pay
+  ignore:
+    - dependency-name: docker
+      versions:
+        - "> 20.10.16"
 - package-ecosystem: docker
   directory: "/ci/docker/concourse-runner-with-java-17"
   schedule:
@@ -28,3 +32,7 @@ updates:
   labels:
     - dependencies
     - govuk-pay
+  ignore:
+    - dependency-name: docker
+      versions:
+        - "> 20.10.16"


### PR DESCRIPTION
In v20.10.17 the dockerd command was removed. [We reverted it once already](https://github.com/alphagov/pay-ci/pull/786) but forgot to tell dependabot to create new PRs for it, so ended up [merging and reverting a second time](https://github.com/alphagov/pay-ci/pull/797) 😿 