### PR TITLE
PP-10565: Add basic test for concourse-runner

### DIFF
--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -155,6 +155,7 @@ jobs:
         params:
           path: concourse-runner-pr
           status: pending
+          context: concourse-runner-tests
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -245,13 +246,16 @@ jobs:
         params:
           path: concourse-runner-pr
           status: success
+          context: concourse-runner-tests
     on_failure:
       put: concourse-runner-pr
       params:
         path: concourse-runner-pr
         status: failure
+        context: concourse-runner-tests
     on_error:
       put: concourse-runner-pr
       params:
         path: concourse-runner-pr
         status: failure
+        context: concourse-runner-tests

--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -1,4 +1,11 @@
 ---
+resource_types:
+  - name: pull-request
+    type: registry-image
+    source:
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
+
 resources:
   - name: concourse-runner-pipeline
     type: git
@@ -8,6 +15,18 @@ resources:
       branch: master
       paths:
         - ci/pipelines/concourse-runner.yml
+
+  - name: concourse-runner-pr
+    type: pull-request
+    icon: github
+    source:
+      disable_forks: true
+      repository: alphagov/pay-ci
+      access_token: ((github-access-token))
+      paths:
+        - "ci/docker/concourse-runner/**"
+        - "ci/docker/concourse-runner-with-java-17/**"
+        - "ci/pipelines/concourse-runner.yml"
 
   - name: concourse-runner-src
     type: git
@@ -124,3 +143,115 @@ jobs:
         trigger: true
       - set_pipeline: concourse-runner
         file: concourse-runner-pipeline/ci/pipelines/concourse-runner.yml
+
+  - name: concourse-runner-pr
+    plan:
+      - in_parallel:
+        - get: concourse-runner-pr
+          trigger: true
+        - get: pay-ci
+          trigger: false
+      - put: concourse-runner-pr
+        params:
+          path: concourse-runner-pr
+          status: pending
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-access-token))
+          EMAIL: ((docker-email))
+      - in_parallel:
+        - task: build-concourse-runner
+          privileged: true
+          output_mapping:
+            image: concourse-runner-image
+          params:
+            CONTEXT: concourse-runner-pr/ci/docker/concourse-runner
+            UNPACK_ROOTFS: true
+            DOCKER_CONFIG: docker_creds
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source:
+                repository: concourse/oci-build-task
+            inputs:
+            - name: concourse-runner-pr
+            outputs:
+            - name: image
+            run:
+              path: build
+        - task: build-concourse-runner-with-java-17
+          privileged: true
+          output_mapping:
+            image: concourse-runner-with-java-17-image
+          params:
+            CONTEXT: concourse-runner-pr/ci/docker/concourse-runner-with-java-17
+            UNPACK_ROOTFS: true
+            DOCKER_CONFIG: docker_creds
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source:
+                repository: concourse/oci-build-task
+            inputs:
+            - name: concourse-runner-pr
+            outputs:
+            - name: image
+            run:
+              path: build
+      - in_parallel:
+        - task: test-concourse-runner
+          privileged: true
+          image: concourse-runner-image
+          config:
+            platform: linux
+            run:
+              path: /bin/bash
+              args:
+                - -eo
+                - pipefail
+                - -c
+                - |
+                  source /docker-helpers.sh
+
+                  start_docker
+
+                  docker ps -a
+
+                  stop_docker
+        - task: test-concourse-runner-with-java-17
+          privileged: true
+          image: concourse-runner-with-java-17-image
+          config:
+            platform: linux
+            run:
+              path: /bin/bash
+              args:
+                - -eo
+                - pipefail
+                - -c
+                - |
+                  source /docker-helpers.sh
+
+                  start_docker
+
+                  docker ps -a
+
+                  stop_docker
+      - put: concourse-runner-pr
+        params:
+          path: concourse-runner-pr
+          status: success
+    on_failure:
+      put: concourse-runner-pr
+      params:
+        path: concourse-runner-pr
+        status: failure
+    on_error:
+      put: concourse-runner-pr
+      params:
+        path: concourse-runner-pr
+        status: failure

--- a/ci/pipelines/concourse-runner.yml
+++ b/ci/pipelines/concourse-runner.yml
@@ -1,4 +1,26 @@
 ---
+definitions:
+  - &test-concourse-runner
+    task: test-concourse-runner
+    privileged: true
+    image: updateThisValue
+    config:
+      platform: linux
+      run:
+        path: /bin/bash
+        args:
+          - -eo
+          - pipefail
+          - -c
+          - |
+            source /docker-helpers.sh
+
+            start_docker
+
+            docker ps -a
+
+            stop_docker
+
 resource_types:
   - name: pull-request
     type: registry-image
@@ -90,6 +112,7 @@ jobs:
         params: 
           CONTEXT: concourse-runner-src/ci/docker/concourse-runner
           DOCKER_CONFIG: docker_creds
+          UNPACK_ROOTFS: true
         config:
           platform: linux
           image_resource:
@@ -102,6 +125,8 @@ jobs:
           - name: image
           run:
             path: build
+      - <<: *test-concourse-runner
+        image: image
       - put: concourse-runner
         params: {image: image/image.tar}
 
@@ -122,6 +147,7 @@ jobs:
         params: 
           CONTEXT: concourse-runner-with-java-17-src/ci/docker/concourse-runner-with-java-17
           DOCKER_CONFIG: docker_creds
+          UNPACK_ROOTFS: true
         config:
           platform: linux
           image_resource:
@@ -134,6 +160,8 @@ jobs:
           - name: image
           run:
             path: build
+      - <<: *test-concourse-runner
+        image: image
       - put: concourse-runner-with-java-17
         params: {image: image/image.tar}
 
@@ -204,44 +232,12 @@ jobs:
             run:
               path: build
       - in_parallel:
-        - task: test-concourse-runner
-          privileged: true
+        - <<: *test-concourse-runner
+          task: test-concourse-runner
           image: concourse-runner-image
-          config:
-            platform: linux
-            run:
-              path: /bin/bash
-              args:
-                - -eo
-                - pipefail
-                - -c
-                - |
-                  source /docker-helpers.sh
-
-                  start_docker
-
-                  docker ps -a
-
-                  stop_docker
-        - task: test-concourse-runner-with-java-17
-          privileged: true
+        - <<: *test-concourse-runner
+          task: test-concourse-runner-with-java-17
           image: concourse-runner-with-java-17-image
-          config:
-            platform: linux
-            run:
-              path: /bin/bash
-              args:
-                - -eo
-                - pipefail
-                - -c
-                - |
-                  source /docker-helpers.sh
-
-                  start_docker
-
-                  docker ps -a
-
-                  stop_docker
       - put: concourse-runner-pr
         params:
           path: concourse-runner-pr


### PR DESCRIPTION
This adds a concourse job to test PRs on the concourse runner images.

We cannot do this in github actions because the whole point of the container is to give us docker-in-docker on concourse, but of course concourse doesn't run docker, it runs the garden container orchestrator. I did initially try with a github workflow but even in priviledged mode the docker-helpers script can't mess with the cgroups in the way it needs to.

So instead this new job in the concourse-runner pipeline builds the image, and the uses is and executes docker startup, runs a docker command (which would fail if the docker daemon were not running), and then runs docker stop.

It's a very minimal test but a good one going forward since we have had multiple failures where we bump the docker source container for the concourse-runner image and only find out later that it's not working correctly when devs report other builds failing.

I've also added the test concourse runner task as a step in each of the build-and-push jobs to help ensure we don't push anything broken after merge.

You can see a [successful run of it within the existing build-and-push-concourse-runner job](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/concourse-runner/jobs/build-and-push-concourse-runner/builds/9) and a [successful run of it within the existing build-and-push-concourse-runner-with-java-17 job](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/concourse-runner/jobs/build-and-push-concourse-runner-with-java-17/builds/9)

Finally you can see the [PR build job run successfully](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/concourse-runner/jobs/concourse-runner-pr/builds/20)