### PR TITLE
PP-10565: Remove dependabot restriction

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,6 @@ updates:
   labels:
     - dependencies
     - govuk-pay
-  ignore:
-    - dependency-name: docker
-      versions:
-        - "> 20.10.16"
 - package-ecosystem: docker
   directory: "/ci/docker/concourse-runner-with-java-17"
   schedule:
@@ -32,7 +28,3 @@ updates:
   labels:
     - dependencies
     - govuk-pay
-  ignore:
-    - dependency-name: docker
-      versions:
-        - "> 20.10.16"


### PR DESCRIPTION
Now we have successfully updated to docker 20.10.22 using the `20.10.22-dind` image variant we can remove the dependabot restrictions