### PR TITLE
PP-10043: Upgrade all pipelines to terraform 1.3.7

### DIFF
--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -102,7 +102,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.8
+              tag: 1.3.7
           params:
             ENVIRONMENT: test
             SMOKE_TEST_VERSION: ((.:release_version))
@@ -153,7 +153,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.8
+              tag: 1.3.7
           params:
             ENVIRONMENT: staging
             SMOKE_TEST_VERSION: ((.:release_version))
@@ -205,7 +205,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.8
+              tag: 1.3.7
           params:
             ENVIRONMENT: production
             SMOKE_TEST_VERSION: ((.:release_version))

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -1659,7 +1659,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.8
+              tag: 1.3.7
           run:
             path: /bin/sh
             args:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -3055,7 +3055,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.8
+              tag: 1.3.7
           run:
             path: /bin/sh
             args:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -3285,7 +3285,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.8
+              tag: 1.3.7
           run:
             path: /bin/sh
             args:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -6215,7 +6215,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.0.8
+              tag: 1.3.7
           run:
             path: /bin/sh
             args:

--- a/ci/tasks/check-for-tf-drift.yml
+++ b/ci/tasks/check-for-tf-drift.yml
@@ -10,7 +10,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.0.8
+    tag: 1.3.7
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-app.yml
+++ b/ci/tasks/deploy-app.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.0.8
+    tag: 1.3.7
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-carbon-relay.yml
+++ b/ci/tasks/deploy-carbon-relay.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.0.8
+    tag: 1.3.7
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-egress.yml
+++ b/ci/tasks/deploy-egress.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.0.8
+    tag: 1.3.7
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.0.8
+    tag: 1.3.7
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-scheduled-tasks.yml
+++ b/ci/tasks/deploy-scheduled-tasks.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.0.8
+    tag: 1.3.7
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-webhooks-egress.yml
+++ b/ci/tasks/deploy-webhooks-egress.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.0.8
+    tag: 1.3.7
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:


### PR DESCRIPTION
Upgrade all pipelines and tasks to terraform 1.3.7.

I've tried this on the infra-drift-detector pipeline and here is a successful run: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/infra-drift-detector/jobs/test-perf-1-bastion/builds/364

