### PR TITLE
BAU: Add docker labels to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
   labels:
     - dependencies
     - govuk-pay
+    - docker
 - package-ecosystem: docker
   directory: "/ci/docker/concourse-runner"
   schedule:
@@ -19,6 +20,7 @@ updates:
   labels:
     - dependencies
     - govuk-pay
+    - docker
 - package-ecosystem: docker
   directory: "/ci/docker/concourse-runner-with-java-17"
   schedule:
@@ -28,3 +30,4 @@ updates:
   labels:
     - dependencies
     - govuk-pay
+    - docker


### PR DESCRIPTION
This will help us categorise our Dependabot PRs across all Pay's repositories more easily.