### PR TITLE
BAU: Re-enable Worldpay 3DS smoke tests

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -131,20 +131,20 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_prod"
-#      - task: run_create_card_payment_worldpay_with_3ds-production
-#        attempts: 10
-#        file: pay-ci/ci/tasks/run-smoke-test.yml
-#        params:
-#          <<: *aws_assumed_role_creds
-#          AWS_REGION: "eu-west-1"
-#          SMOKE_TEST_NAME: "card_wpay_3ds_prod"
-#      - task: run_create_card_payment_worldpay_with_3ds2-production
-#        attempts: 10
-#        file: pay-ci/ci/tasks/run-smoke-test.yml
-#        params:
-#          <<: *aws_assumed_role_creds
-#          AWS_REGION: "eu-west-1"
-#          SMOKE_TEST_NAME: "card_wpay_3ds2_prod"
+      - task: run_create_card_payment_worldpay_with_3ds-production
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds_prod"
+      - task: run_create_card_payment_worldpay_with_3ds2-production
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2_prod"
       - task: run_create_card_payment_worldpay_with_3ds2_exemption-production
         attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -132,20 +132,20 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_stag"
-#      - task: run_create_card_payment_worldpay_with_3ds-staging
-#        attempts: 10
-#        file: pay-ci/ci/tasks/run-smoke-test.yml
-#        params:
-#          <<: *aws_assumed_role_creds
-#          AWS_REGION: "eu-west-1"
-#          SMOKE_TEST_NAME: "card_wpay_3ds_stag"
-#      - task: run_create_card_payment_worldpay_with_3ds2-staging
-#        attempts: 10
-#        file: pay-ci/ci/tasks/run-smoke-test.yml
-#        params:
-#          <<: *aws_assumed_role_creds
-#          AWS_REGION: "eu-west-1"
-#          SMOKE_TEST_NAME: "card_wpay_3ds2_stag"
+      - task: run_create_card_payment_worldpay_with_3ds-staging
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds_stag"
+      - task: run_create_card_payment_worldpay_with_3ds2-staging
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2_stag"
       - task: run_create_card_payment_worldpay_with_3ds2_exemption-staging
         attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1005,20 +1005,20 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_sandbox_test"
-#      - task: run_create_card_payment_worldpay_with_3ds-test
-#        attempts: 10
-#        file: pay-ci/ci/tasks/run-smoke-test.yml
-#        params:
-#          <<: *aws_assumed_role_creds
-#          AWS_REGION: "eu-west-1"
-#          SMOKE_TEST_NAME: "card_wpay_3ds_test"
-#      - task: run_create_card_payment_worldpay_with_3ds2-test
-#        attempts: 10
-#        file: pay-ci/ci/tasks/run-smoke-test.yml
-#        params:
-#          <<: *aws_assumed_role_creds
-#          AWS_REGION: "eu-west-1"
-#          SMOKE_TEST_NAME: "card_wpay_3ds2_test"
+      - task: run_create_card_payment_worldpay_with_3ds-test
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds_test"
+      - task: run_create_card_payment_worldpay_with_3ds2-test
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2_test"
       - task: run_create_card_payment_worldpay_with_3ds2_exemption-test
         attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml


### PR DESCRIPTION
The Worldpay test environment has been working for the last couple of days.