### PR TITLE
PP-10675: replaced usage of set-output in run-provider-contract-tests.yml

### DIFF
--- a/.github/workflows/_run-provider-contract-tests.yml
+++ b/.github/workflows/_run-provider-contract-tests.yml
@@ -51,7 +51,7 @@ jobs:
             exit 1
           fi
           echo "Setting Provider version to ${PROVIDER_VERSION}"
-          echo "::set-output name=pact-provider-version::${PROVIDER_VERSION}"
+          echo "pact-provider-version=${PROVIDER_VERSION}" >> $GITHUB_OUTPUT
       - name: Run provider contract tests
         run: |
           mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master \


### PR DESCRIPTION
Located and replaced all usages of set-output commands in our workflows.