### PR TITLE
PP 10733 add concourse metrics on the deploy to staging pipeline adminusers

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1891,7 +1891,7 @@ jobs:
         passed: [smoke-test-adminusers-on-staging]
         trigger: true
       - load_var: application_image_tag
-        file: adminusers-ecr-registry-staging/tag 
+        file: adminusers-ecr-registry-staging/tag
       - get: pay-ci
       - task: send-job-release-info-to-hosted-graphite
         file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
@@ -1933,6 +1933,16 @@ jobs:
           format: oci
         trigger: true
         passed: [adminusers-pact-tag]
+      - load_var: application_image_tag
+        file: adminusers-ecr-registry-staging/tag 
+      - get: pay-ci
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: push-adminusers-to-production-ecr
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY
       - put: adminusers-ecr-registry-prod
         params:
           image: adminusers-ecr-registry-staging/image.tar

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1933,16 +1933,6 @@ jobs:
           format: oci
         trigger: true
         passed: [adminusers-pact-tag]
-      - load_var: application_image_tag
-        file: adminusers-ecr-registry-staging/tag 
-      - get: pay-ci
-      - task: send-job-release-info-to-hosted-graphite
-        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
-        params:
-          BUILD_PIPELINE_NAME: deploy-to-staging
-          BUILD_JOB_NAME: push-adminusers-to-production-ecr
-          RELEASE_NUMBER: ((.:application_image_tag))
-          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - put: adminusers-ecr-registry-prod
         params:
           image: adminusers-ecr-registry-staging/image.tar

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1855,7 +1855,7 @@ jobs:
       - task: parse-staging-release-tag
         file: pay-ci/ci/tasks/parse-staging-release-tag.yml
         input_mapping:
-          git-release: endtoend-git-release
+          ecr-repo: adminusers-ecr-registry-staging
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
       - task: send-job-release-info-to-hosted-graphite
@@ -1863,7 +1863,7 @@ jobs:
         params:
           BUILD_PIPELINE_NAME: deploy-to-staging
           BUILD_JOB_NAME: smoke-test-adminusers-on-staging
-          RELEASE_NUMBER: ((.:application_image_tag))
+          RELEASE_NUMBER: ((.:parse-staging-release-tag))
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY)) 
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -205,7 +205,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: PP-10733-Add-concourse-metrics-on-the-deploy-to-staging-pipeline 
   - name: every-hour
     icon: alarm
     source:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1716,14 +1716,20 @@ jobs:
       - get: telegraf-ecr-registry-staging
       - get: pay-infra
       - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: adminusers-ecr-registry-staging
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
       - task: send-job-release-info-to-hosted-graphite
         file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
         params:
           BUILD_PIPELINE_NAME: deploy-to-staging
           BUILD_JOB_NAME: deploy-adminusers-to-staging
-          RELEASE_NUMBER: ((.:application_image_tag))
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))  
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
@@ -1858,12 +1864,14 @@ jobs:
           ecr-repo: adminusers-ecr-registry-staging
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
       - task: send-job-release-info-to-hosted-graphite
         file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
         params:
           BUILD_PIPELINE_NAME: deploy-to-staging
           BUILD_JOB_NAME: smoke-test-adminusers-on-staging
-          RELEASE_NUMBER: ((.:parse-staging-release-tag))
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY)) 
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
@@ -1896,12 +1904,18 @@ jobs:
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
       - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: adminusers-ecr-registry-staging
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
       - task: send-job-release-info-to-hosted-graphite
         file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
         params:
           BUILD_PIPELINE_NAME: deploy-to-staging
           BUILD_JOB_NAME: adminusers-pact-tag
-          RELEASE_NUMBER: ((.:application_image_tag))
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
@@ -1939,12 +1953,18 @@ jobs:
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag 
       - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: adminusers-ecr-registry-staging
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
       - task: send-job-release-info-to-hosted-graphite
         file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
         params:
           BUILD_PIPELINE_NAME: deploy-to-staging
           BUILD_JOB_NAME: push-adminusers-to-production-ecr
-          RELEASE_NUMBER: ((.:application_image_tag))
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY
       - put: adminusers-ecr-registry-prod
         params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -205,7 +205,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-10733-Add-concourse-metrics-on-the-deploy-to-staging-pipeline 
+      branch: PP-10733-Add-concourse-metrics-on-the-deploy-to-staging-pipeline
   - name: every-hour
     icon: alarm
     source:
@@ -1220,6 +1220,7 @@ jobs:
       - get: pay-ci
       - load_var: application_image_tag
         file: toolbox-ecr-registry-staging/tag
+      
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - load_var: nginx_image_tag
@@ -1712,19 +1713,19 @@ jobs:
     plan:
       - get: adminusers-ecr-registry-staging
         trigger: true
-      - task: send-release-info-to-hosted-graphite
-        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
-        params:
-          ENVIRONMENT: "test-12"
-          APP_NAME: "adminusers"
-          RELEASE_NUMBER: ((.:application_image_tag))
-          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - get: nginx-proxy-ecr-registry-staging
       - get: telegraf-ecr-registry-staging
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: deploy-adminusers-to-staging
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))  
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
@@ -1854,6 +1855,13 @@ jobs:
       - get: pay-ci
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: smoke-test-adminusers-on-staging
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY)) 
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -1883,8 +1891,15 @@ jobs:
         passed: [smoke-test-adminusers-on-staging]
         trigger: true
       - load_var: application_image_tag
-        file: adminusers-ecr-registry-staging/tag
+        file: adminusers-ecr-registry-staging/tag 
       - get: pay-ci
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: adminusers-pact-tag
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -1918,6 +1933,16 @@ jobs:
           format: oci
         trigger: true
         passed: [adminusers-pact-tag]
+      - load_var: application_image_tag
+        file: adminusers-ecr-registry-staging/tag 
+      - get: pay-ci
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: push-adminusers-to-production-ecr
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - put: adminusers-ecr-registry-prod
         params:
           image: adminusers-ecr-registry-staging/image.tar

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -205,7 +205,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-10733-Add-concourse-metrics-on-the-deploy-to-staging-pipeline
+      branch: master
   - name: every-hour
     icon: alarm
     source:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -205,7 +205,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: PP-10733-Add-concourse-metrics-on-the-deploy-to-staging-pipeline
   - name: every-hour
     icon: alarm
     source:
@@ -1852,6 +1852,10 @@ jobs:
         trigger: true
         passed: [deploy-adminusers-to-staging]
       - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          git-release: endtoend-git-release
       - load_var: application_image_tag
         file: adminusers-ecr-registry-staging/tag
       - task: send-job-release-info-to-hosted-graphite

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1220,7 +1220,6 @@ jobs:
       - get: pay-ci
       - load_var: application_image_tag
         file: toolbox-ecr-registry-staging/tag
-      
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - load_var: nginx_image_tag

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1712,6 +1712,13 @@ jobs:
     plan:
       - get: adminusers-ecr-registry-staging
         trigger: true
+      - task: send-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-release-info-to-hosted-graphite.yml
+        params:
+          ENVIRONMENT: "test-12"
+          APP_NAME: "adminusers"
+          RELEASE_NUMBER: ((.:application_image_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - get: nginx-proxy-ecr-registry-staging
       - get: telegraf-ecr-registry-staging
       - get: pay-infra

--- a/ci/scripts/parse-staging-release-tag.js
+++ b/ci/scripts/parse-staging-release-tag.js
@@ -10,7 +10,7 @@ async function run () {
     }
 
     const tag = fs.readFileSync('ecr-repo/tag', 'utf8')
-    fs.writeFileSync(`${dir}/tag`, tag.replace(-release,''))
+    fs.writeFileSync(`${dir}/tag`, tag.replace('-release',''))
     
     console.log('Resulting tag: ' + fs.readFileSync(`${dir}/tag`, 'utf8'))
   } catch (err) {

--- a/ci/scripts/parse-staging-release-tag.js
+++ b/ci/scripts/parse-staging-release-tag.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+
+async function run () {
+  try {
+    const dir = 'parse-staging-release-tag'
+    if (!fs.existsSync(dir)){
+      fs.mkdirSync(dir);
+    }
+
+    const tag = fs.readFileSync('ecr-repo/tag', 'utf8')
+    fs.writeFileSync(`${dir}/tag`, tag.replace(‘-release', ''))
+
+    console.log('Resulting tag: ' + fs.readFileSync(`${dir}/tag`, 'utf8'))
+  } catch (err) {
+    console.log(`An error occurred: ${err}`)
+    process.exitCode = 1
+  }
+}
+
+run()

--- a/ci/scripts/parse-staging-release-tag.js
+++ b/ci/scripts/parse-staging-release-tag.js
@@ -10,8 +10,8 @@ async function run () {
     }
 
     const tag = fs.readFileSync('ecr-repo/tag', 'utf8')
-    fs.writeFileSync(`${dir}/tag`, tag.replace(‘-release', ''))
-
+    fs.writeFileSync(`${dir}/tag`, tag.replace(-release,''))
+    
     console.log('Resulting tag: ' + fs.readFileSync(`${dir}/tag`, 'utf8'))
   } catch (err) {
     console.log(`An error occurred: ${err}`)

--- a/ci/tasks/parse-staging-release-tag.yml
+++ b/ci/tasks/parse-staging-release-tag.yml
@@ -1,7 +1,7 @@
 # This task parses the staging release candidate tag from an ecr resource and turns it into a *-staging release tag
 #
 # File written:
-#   parse-staging-release-tag/tag : The staging release tag (e.g. 123-release)
+#   parse-staging-release-tag/tag : The staging release tag (e.g. 123)
 #
 platform: linux
 image_resource:
@@ -17,4 +17,3 @@ outputs:
 run:
   path: node
   args: ['pay-ci/ci/scripts/parse-staging-release-tag.js']
-

--- a/ci/tasks/parse-staging-release-tag.yml
+++ b/ci/tasks/parse-staging-release-tag.yml
@@ -1,4 +1,4 @@
-# This task parses the staging release tag from an ecr resource and turns it into a *-staging release tag
+# This task parses the staging release candidate tag from an ecr resource and turns it into a *-staging release tag
 #
 # File written:
 #   parse-staging-release-tag/tag : The staging release tag (e.g. 123-release)
@@ -17,3 +17,4 @@ outputs:
 run:
   path: node
   args: ['pay-ci/ci/scripts/parse-staging-release-tag.js']
+

--- a/ci/tasks/parse-staging-release-tag.yml
+++ b/ci/tasks/parse-staging-release-tag.yml
@@ -1,0 +1,19 @@
+# This task parses the candidate tag from an ecr resource and turns it into a *-staging release tag
+#
+# File written:
+#   parse-staging-release-tag/tag : The staging release tag (e.g. 123-release)
+#
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentdigitalservice/pay-node-runner
+    tag: node16
+inputs:
+  - name: pay-ci
+  - name: ecr-repo
+outputs:
+  - name: parse-staging-release-tag
+run:
+  path: node
+  args: ['pay-ci/ci/scripts/parse-staging-release-tag.js']

--- a/ci/tasks/parse-staging-release-tag.yml
+++ b/ci/tasks/parse-staging-release-tag.yml
@@ -1,19 +1,25 @@
-# This task parses the candidate tag from an ecr resource and turns it into a *-staging release tag
+# This task parses the candidate tag from an ecr resource and turns it into the final release tag
 #
-# File written:
-#   parse-staging-release-tag/tag : The staging release tag (e.g. 123-release)
+# Files written:
+#   parse-staging-release-tag/release-tag : The actual release tag (e.g. 123-release)
+#   parse-staging-release-tag/release-number : The number of the candidate release (e.g. in the case of 123-candidate, this is 123)
 #
 platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: governmentdigitalservice/pay-node-runner
-    tag: node16
+    repository: alpine
+    tag: 3.16
 inputs:
-  - name: pay-ci
   - name: ecr-repo
 outputs:
   - name: parse-staging-release-tag
 run:
-  path: node
-  args: ['pay-ci/ci/scripts/parse-staging-release-tag.js']
+  path: sh
+  args:
+    - -ec
+    - |
+      RELEASE_NUMBER=$(cut -f 1 -d "-" < ecr-repo/tag)
+      echo "${RELEASE_NUMBER}-release" | tee parse-staging-release-tag/release-tag
+      echo "$RELEASE_NUMBER" > parse-staging-release/release-number
+      

--- a/ci/tasks/parse-staging-release-tag.yml
+++ b/ci/tasks/parse-staging-release-tag.yml
@@ -1,25 +1,19 @@
-# This task parses the candidate tag from an ecr resource and turns it into the final release tag
+# This task parses the staging release tag from an ecr resource and turns it into a *-staging release tag
 #
-# Files written:
-#   parse-staging-release-tag/release-tag : The actual release tag (e.g. 123-release)
-#   parse-staging-release-tag/release-number : The number of the candidate release (e.g. in the case of 123-candidate, this is 123)
+# File written:
+#   parse-staging-release-tag/tag : The staging release tag (e.g. 123-release)
 #
 platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: alpine
-    tag: 3.16
+    repository: governmentdigitalservice/pay-node-runner
+    tag: node16
 inputs:
+  - name: pay-ci
   - name: ecr-repo
 outputs:
   - name: parse-staging-release-tag
 run:
-  path: sh
-  args:
-    - -ec
-    - |
-      RELEASE_NUMBER=$(cut -f 1 -d "-" < ecr-repo/tag)
-      echo "${RELEASE_NUMBER}-release" | tee parse-staging-release-tag/release-tag
-      echo "$RELEASE_NUMBER" > parse-staging-release/release-number
-      
+  path: node
+  args: ['pay-ci/ci/scripts/parse-staging-release-tag.js']


### PR DESCRIPTION
Added tasks to get metrics in the deploy-to-staging Adminusers in the following jobs:

- deploy-adminusers-to-staging
- smoke-test-adminusers-on-staging
- adminusers-pact-tag
- push-adminusers-to-production-ecr