### PR TITLE
PP-10733: added tasks to send job release info to HG

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1218,8 +1218,21 @@ jobs:
         trigger: true
       - get: pay-infra
       - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: toolbox-ecr-registry-staging
       - load_var: application_image_tag
         file: toolbox-ecr-registry-staging/tag
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: deploy-toolbox-to-staging
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY)) 
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - load_var: nginx_image_tag
@@ -1289,6 +1302,22 @@ jobs:
           format: oci
         trigger: true
         passed: [deploy-toolbox-to-staging]
+      - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: toolbox-ecr-registry-staging
+      - load_var: application_image_tag
+        file: toolbox-ecr-registry-staging/tag
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: push-toolbox-to-production-ecr
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - put: toolbox-ecr-registry-prod
         params:
           image: toolbox-ecr-registry-staging/image.tar


### PR DESCRIPTION
Added tasks to send metrics to HG in the deploy-to-staging toolbox pipeline in the following jobs:
- deploy to staging toolbox 
- push-toolbox-to-production-ecr
