### PR TITLE
PP-10733: Added tasks in selfservice pipeline to send concourse metrics

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1033,7 +1033,6 @@ jobs:
           BUILD_JOB_NAME: push-selfservice-to-production-ecr
           RELEASE_NUMBER: ((.:parse_staging_release_tag))
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
-
       - put: selfservice-ecr-registry-prod
         params:
           image: selfservice-ecr-registry-staging/image.tar

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -925,8 +925,21 @@ jobs:
         trigger: true
         passed: [deploy-selfservice-to-staging]
       - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: selfservice-ecr-registry-staging
       - load_var: application_image_tag
         file: selfservice-ecr-registry-staging/tag
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: smoke-test-selfservice-on-staging
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -955,9 +968,22 @@ jobs:
       - get: selfservice-ecr-registry-staging
         passed: [smoke-test-selfservice-on-staging]
         trigger: true
+      - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: selfservice-ecr-registry-staging
       - load_var: application_image_tag
         file: selfservice-ecr-registry-staging/tag
-      - get: pay-ci
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: selfservice-pact-tag
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
@@ -991,6 +1017,23 @@ jobs:
           format: oci
         trigger: true
         passed: [selfservice-pact-tag]
+      - get: pay-ci
+      - task: parse-staging-release-tag
+        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+        input_mapping:
+          ecr-repo: selfservice-ecr-registry-staging
+      - load_var: application_image_tag
+        file: selfservice-ecr-registry-staging/tag
+      - load_var: parse_staging_release_tag
+        file: parse-staging-release-tag/tag
+      - task: send-job-release-info-to-hosted-graphite
+        file: pay-ci/ci/tasks/send-job-release-info-to-hosted-graphite.yml
+        params:
+          BUILD_PIPELINE_NAME: deploy-to-staging
+          BUILD_JOB_NAME: push-selfservice-to-production-ecr
+          RELEASE_NUMBER: ((.:parse_staging_release_tag))
+          HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
+
       - put: selfservice-ecr-registry-prod
         params:
           image: selfservice-ecr-registry-staging/image.tar


### PR DESCRIPTION
Added tasks in the deploy to staging selfservice pipeline for the jobs;
- deploy-selfservice-to-staging
- smoke-test-selfservice-on-staging
- selfservice-pact-tag
- push-selfservice-to-production-ecr