### PR TITLE
BAU: Add dependabot config for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,13 @@ updates:
     - dependencies
     - govuk-pay
     - docker
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 10
+  labels:
+    - dependencies
+    - govuk-pay
+    - github_actions


### PR DESCRIPTION
We haven't been getting updates for Actions dependencies in this repo, which is causing deprecation warnings both here and in repos that use the shared workflows.

Merging this PR should spawn a few Dependabot PRs to update the Actions themselves.