### PR TITLE
BAU: Switch Concourse PR node tests to use alpine3.17

### DIFF
--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 16-alpine3.17
+    tag: 16-bullseye-slim
 inputs:
   - name: src
 outputs:

--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 16-stretch-slim
+    tag: 16-alpine3.17
 inputs:
   - name: src
 outputs:


### PR DESCRIPTION
16-stretch-slim is no longer available. ~We use Alpine base images for the actual Node app images, so one would hope their tests should run OK on `node:16-alpine3.17`...~ We're going to try `bullseye-slim` instead for now, as the Alpine change would require some extra wrangling.