### PR TITLE
Check for zendesk unsubscribers

### DIFF
--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -200,3 +200,43 @@ jobs:
           text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
           icon_emoji: ':aws-dark:'
           username: pay-concourse-drift-detector
+  - name: production-check-for-zendesk-unsubscribers
+    plan:
+    - in_parallel:
+      - get: every-morning-at-six-thirty
+        trigger: true
+      - get: pay-ci
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: zendesk-unsubscriber-assume-role
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-if-unsubscribed
+      file: pay-ci/ci/tasks/check-sns-topic-unsubscribers.yml
+      params:
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        AWS_REGION: eu-west-1
+        AWS_DEFAULT_REGION: eu-west-1
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: SNS topic subscribers consistent - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ':aws-dark:'
+        username: pay-concourse-drift-detector
+    on_failure:
+        put: slack-notification
+        attempts: 10
+        params:
+          channel: '#govuk-pay-starling'
+          silent: true
+          text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+          icon_emoji: ':aws-dark:'
+          username: pay-concourse-drift-detector

--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -159,3 +159,44 @@ jobs:
         trigger: true
       - set_pipeline: infra-drift-detector
         file: infra-drift-detector-pipeline/ci/pipelines/infra-drift-detector-higher-envs.yml
+
+  - name: staging-check-for-zendesk-unsubscribers
+    plan:
+    - in_parallel:
+      - get: every-morning-at-six
+        trigger: true
+      - get: pay-ci
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: zendesk-unsubscriber-assume-role
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-if-unsubscribed
+      file: pay-ci/ci/tasks/check-sns-topic-unsubscribers.yml
+      params:
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        AWS_REGION: eu-west-1
+        AWS_DEFAULT_REGION: eu-west-1
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: SNS topic subscribers consistent - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ':aws-dark:'
+        username: pay-concourse-drift-detector
+    on_failure:
+        put: slack-notification
+        attempts: 10
+        params:
+          channel: '#govuk-pay-starling'
+          silent: true
+          text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+          icon_emoji: ':aws-dark:'
+          username: pay-concourse-drift-detector

--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -240,3 +240,43 @@ jobs:
           text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
           icon_emoji: ':aws-dark:'
           username: pay-concourse-drift-detector
+  - name: deploy-check-for-zendesk-unsubscribers
+    plan:
+    - in_parallel:
+      - get: every-morning-at-six
+        trigger: true
+      - get: pay-ci
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: zendesk-unsubscriber-assume-role
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-if-unsubscribed
+      file: pay-ci/ci/tasks/check-sns-topic-unsubscribers.yml
+      params:
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        AWS_REGION: eu-west-1
+        AWS_DEFAULT_REGION: eu-west-1
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: SNS topic subscribers consistent - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ':aws-dark:'
+        username: pay-concourse-drift-detector
+    on_failure:
+        put: slack-notification
+        attempts: 10
+        params:
+          channel: '#govuk-pay-starling'
+          silent: true
+          text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+          icon_emoji: ':aws-dark:'
+          username: pay-concourse-drift-detector

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -159,3 +159,12 @@ jobs:
         trigger: true
       - set_pipeline: infra-drift-detector
         file: infra-drift-detector-pipeline/ci/pipelines/infra-drift-detector-lower-envs.yml
+
+  - name: test-check-for-zendesk-unsubscribers
+    plan:
+    - in_parallel:
+      - get: every-morning-at-five
+        trigger: true
+      - get: pay-ci
+    - task: check-if-unsubscribed
+      file: pay-ci/ci/tasks/check-sns-topic-unsubscribers.yml

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -200,3 +200,43 @@ jobs:
           text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
           icon_emoji: ':aws-dark:'
           username: pay-concourse-drift-detector
+  - name: dev-check-for-zendesk-unsubscribers
+    plan:
+    - in_parallel:
+      - get: every-morning-at-five
+        trigger: true
+      - get: pay-ci
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_dev_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: zendesk-unsubscriber-assume-role
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-if-unsubscribed
+      file: pay-ci/ci/tasks/check-sns-topic-unsubscribers.yml
+      params:
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        AWS_REGION: eu-west-1
+        AWS_DEFAULT_REGION: eu-west-1
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: SNS topic subscribers consistent - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ':aws-dark:'
+        username: pay-concourse-drift-detector
+    on_failure:
+        put: slack-notification
+        attempts: 10
+        params:
+          channel: '#govuk-pay-starling'
+          silent: true
+          text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+          icon_emoji: ':aws-dark:'
+          username: pay-concourse-drift-detector

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -166,5 +166,19 @@ jobs:
       - get: every-morning-at-five
         trigger: true
       - get: pay-ci
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: zendesk-unsubscriber-assume-role
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
     - task: check-if-unsubscribed
       file: pay-ci/ci/tasks/check-sns-topic-unsubscribers.yml
+      params:
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        AWS_REGION: eu-west-1
+        AWS_DEFAULT_REGION: eu-west-1

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -240,3 +240,43 @@ jobs:
           text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
           icon_emoji: ':aws-dark:'
           username: pay-concourse-drift-detector
+  - name: ci-check-for-zendesk-unsubscribers
+    plan:
+    - in_parallel:
+      - get: every-morning-at-five
+        trigger: true
+      - get: pay-ci
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_ci_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: zendesk-unsubscriber-assume-role
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-if-unsubscribed
+      file: pay-ci/ci/tasks/check-sns-topic-unsubscribers.yml
+      params:
+        AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+        AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+        AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        AWS_REGION: eu-west-1
+        AWS_DEFAULT_REGION: eu-west-1
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: SNS topic subscribers consistent - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ':aws-dark:'
+        username: pay-concourse-drift-detector
+    on_failure:
+        put: slack-notification
+        attempts: 10
+        params:
+          channel: '#govuk-pay-starling'
+          silent: true
+          text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+          icon_emoji: ':aws-dark:'
+          username: pay-concourse-drift-detector

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -182,3 +182,21 @@ jobs:
         AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         AWS_REGION: eu-west-1
         AWS_DEFAULT_REGION: eu-west-1
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: SNS topic subscribers consistent - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ':aws-dark:'
+        username: pay-concourse-drift-detector
+    on_failure:
+        put: slack-notification
+        attempts: 10
+        params:
+          channel: '#govuk-pay-starling'
+          silent: true
+          text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+          icon_emoji: ':aws-dark:'
+          username: pay-concourse-drift-detector

--- a/ci/tasks/check-sns-topic-unsubscribers.yml
+++ b/ci/tasks/check-sns-topic-unsubscribers.yml
@@ -1,0 +1,28 @@
+platform: linux
+image_resource:
+   type: registry-image
+   source:
+    repository: governmentdigitalservice/pay-concourse-runner
+run:
+  path: /bin/bash
+  args:
+    - -c
+    - |
+      set -euo pipefail
+      any_failed=0
+      while read -r TOPIC_ARN; do
+        echo "Checking topic: $TOPIC_ARN"
+        if [ "$TOPIC_ARN" == "None" ]; then
+          echo "No SNS topics found"
+          exit 1
+        fi
+        subscription_arn=$(aws sns list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" --query 'Subscriptions[].SubscriptionArn' --output text)
+            if [ "$subscription_arn" == "Deleted" ] ||  [ "$subscription_arn" == "PendingConfirmation" ]; then
+              echo "Topic subscription: $subscription_arn is unsubscribed
+              If you can find the Zendesk email to resubscribe, do that
+              If you can’t find it or it doesn’t work, talk to Starling"
+            fi
+      done < <(aws sns list-topics --query "Topics[].[TopicArn]" --output text)
+      if [ "$any_failed" -eq 1 ]; then
+        exit 1
+      fi


### PR DESCRIPTION
This PR adds a Concourse `check-for-zendesk-unsubscribers` job that runs a script to the `infra-drift-detector-pipeline` to check if there are any SNS topic unsubscribers, then notify the starling team if an SNS topic subscription has been deleted.

We were unable to find a solution with Terraform/CloudTrail logging:
https://payments-platform.atlassian.net/jira/software/c/projects/PP/boards/83?modal=detail&selectedIssue=PP-10926

>Unsubscribing via an email link does not generate a CloudTrail notification.

>Being unsubscribed does not make terraform see the state as inconsistent

>There are no AWS Config rules which can check this, and even if there were we are notified about compliance violations via an SNS topic which emails Zendesk, meaning if that topic was unsubscribed we would never know

In the Bash script, the AWS CLI is used to list the subscriptions by SNS topic, and show the "SubscriptionArn". If it is not subscribed, the "SubscriptionArn" = “Deleted” or "PendingConfirmation". Then notifies Starling by Slack.