### PR TITLE
PP-11028: Add date to tag file

### DIFF
--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -9,7 +9,7 @@ inputs:
 outputs:
   - name: tags
 run:
-  path: sh
+  path: ash
   args:
     - -ec
     - |

--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -19,6 +19,9 @@ run:
       echo "${RELEASE_NUMBER}-release" | tee tags/tags
       echo "${RELEASE_NUMBER}-candidate" | tee tags/candidate-tag
       echo "${RELEASE_NUMBER}" > tags/release-number
-
+      date +%Y-%m-%d_%H-%M-%S | tee tags/date
+      echo -n "${RELEASE_NUMBER}-candidate " >> tags/allcandidatetags
+      cat tags/date >> tags/allcandidatetag
+      
       cd git-release
       git rev-parse HEAD | tee ../tags/release-sha

--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: alpine
-    tag: 3.16
+    tag: 3.18
 inputs:
   - name: git-release
 outputs:


### PR DESCRIPTION
We added a date to a new tag file so the date an image is built  can later be passed through Concourse pipeline.

The alpine image tag was out of date so this was bumped.