### PR TITLE
BAU: Only trigger reverse_proxy build for NAXSI changes in pay-infra

### DIFF
--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -47,6 +47,8 @@ resources:
       branch: master
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
+      paths:
+        - provisioning/terraform/modules/pay_microservices_v2  # NAXSI config
 
   - name: pay-ci
     type: git


### PR DESCRIPTION
Limit the pay-infra trigger to changes in the `pay_microservices_v2` folder only (where the app NAXSI config lives).