### PR TITLE
PP-11028: Add timestamp tags to release images

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -5781,6 +5781,8 @@ jobs:
           git-release: nginx-proxy-git-release
       - load_var: release-tag
         file: tags/tags
+      - load_var: date
+        file: tags/date
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -5792,6 +5794,7 @@ jobs:
         params:
           DOCKER_CONFIG: docker_creds
           CONTEXT: nginx-proxy-git-release
+          LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:
@@ -5808,7 +5811,7 @@ jobs:
         - put: nginx-proxy-ecr-registry-test
           params:
             image: image/image.tar
-            additional_tags: tags/tags
+            additional_tags: tags/all-release-tags
         - put: docker-nginx-proxy-dockerhub
           params:
             image: image/image.tar

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1239,6 +1239,8 @@ jobs:
           git-release: stream-s3-sqs-git-release
       - load_var: release-tag
         file: tags/tags
+      - load_var: date
+        file: tags/date
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -1250,6 +1252,7 @@ jobs:
         params:
             CONTEXT: stream-s3-sqs-git-release
             DOCKER_CONFIG: docker_creds
+            LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:
@@ -1265,7 +1268,7 @@ jobs:
       - put: stream-s3-sqs-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: tags/tags
+          additional_tags: tags/all-release-tags
         get_params:
           skip_download: true
     on_failure:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1108,6 +1108,8 @@ jobs:
           file: tags/release-number
         - load_var: release-sha
           file: tags/release-sha
+        - load_var: date
+          file: tags/date
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -1122,6 +1124,7 @@ jobs:
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
+          LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:
@@ -1137,7 +1140,7 @@ jobs:
       - put: alpine-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: tags/tags
+          additional_tags: tags/all-release-tags
         get_params:
           skip_download: true
     on_failure:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1330,6 +1330,8 @@ jobs:
           file: tags/release-sha
         - load_var: release-tag
           file: tags/tags
+        - load_var: date
+          file: tags/date
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -1343,6 +1345,7 @@ jobs:
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
+          LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:
@@ -1359,7 +1362,7 @@ jobs:
       - put: toolbox-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: tags/tags
+          additional_tags: tags/all-release-tags
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -5844,6 +5844,8 @@ jobs:
           git-release: webhooks-egress-git-release
       - load_var: release-tag
         file: tags/tags
+      - load_var: date
+        file: tags/date
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -5855,6 +5857,7 @@ jobs:
         params:
           DOCKER_CONFIG: docker_creds
           CONTEXT: webhooks-egress-git-release/production/webhooks-egress/
+          LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:
@@ -5870,7 +5873,7 @@ jobs:
       - put: webhooks-egress-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: tags/tags
+          additional_tags: tags/all-release-tags
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -20,6 +20,8 @@ run:
       echo "${RELEASE_NUMBER}-candidate" | tee tags/candidate-tag
       echo "${RELEASE_NUMBER}" > tags/release-number
       date +%Y-%m-%d_%H-%M-%S | tee tags/date
+      echo -n "${RELEASE_NUMBER}-release " >> tags/all-release-tags
+      cat tags/date >> tags/all-release-tags
       echo -n "${RELEASE_NUMBER}-candidate " >> tags/all-candidate-tags
       cat tags/date >> tags/all-candidate-tags
       


### PR DESCRIPTION
Image build date labels and Concourse tags were previously added to candidate images in https://github.com/alphagov/pay-ci/pull/885 . This PR adds labels and tags to release images in the same way.