### PR TITLE
PP-11018: Add bastion drift detector for deploy

### DIFF
--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -37,6 +37,13 @@ resources:
       stop: "07:00"
       location: Europe/London
     type: time
+  - name: every-morning-at-seven
+    icon: alarm
+    source:
+      start: "07:00"
+      stop: "07:30"
+      location: Europe/London
+    type: time
   - name: pay-ci
     type: git
     icon: github
@@ -153,11 +160,11 @@ jobs:
         icon_emoji: ":terraform:"
         username: pay-concourse-drift-detector
 
-  - name: deploy-2-bastion
+  - name: deploy-tooling-bastion
     serial: true
     plan:
     - in_parallel:
-      - get: every-morning-at-six
+      - get: every-morning-at-seven
         trigger: true
       - get: pay-ci
       - get: pay-infra

--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -153,6 +153,55 @@ jobs:
         icon_emoji: ":terraform:"
         username: pay-concourse-drift-detector
 
+  - name: deploy-2-bastion
+    serial: true
+    plan:
+    - in_parallel:
+      - get: every-morning-at-six
+        trigger: true
+      - get: pay-ci
+      - get: pay-infra
+    - task: assume-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/pay-concourse-bastion-read-only-deploy-tooling
+        AWS_ROLE_SESSION_NAME: pay-concourse-bastion-drift-detection
+    - load_var: role
+      file: assume-role/assume-role.json
+      format: json
+    - task: check-for-drift
+      file: pay-ci/ci/tasks/check-for-tf-drift.yml
+      params:
+        <<: *aws_assumed_role_creds
+        DEPLOYMENT_PATH: "deploy/deploy-tooling/environment/bastion"
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Drift detected for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_error:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-starling'
+        silent: true
+        text: ':red-circle: Pipeline to detect drift for $BUILD_JOB_NAME failed to run <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: Terraform state consistent for $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":terraform:"
+        username: pay-concourse-drift-detector
+
   - name: update-infra-drift-detector-pipeline
     plan:
       - get: infra-drift-detector-pipeline


### PR DESCRIPTION
Add drift detection for deploy-tooling environment bastion.

When there was drift (the AMI needing updating) this [run showed it had drifted](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/infra-drift-detector/jobs/deploy-2-bastion/builds/3) and we got this meesage in slack
![Screenshot 2023-06-05 at 12 31 12](https://github.com/alphagov/pay-ci/assets/2170030/a72945e2-3bbc-4d37-968a-baa7483efb62)

After the new AMI was applied, [a rerun of the job passed with no drift](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/infra-drift-detector/jobs/deploy-2-bastion/builds/4) and the activity channel got this message 
![Screenshot 2023-06-05 at 12 37 07](https://github.com/alphagov/pay-ci/assets/2170030/8b1d38d7-a23c-4917-ae4f-0be1f1637b89)


After I ran those jobs I changed it to run every day at 7am so the job now wont work until tomorrow (and also fixed the name of the job to deploy-tooling-bastion not deploy-2-bastion)

The overnight drift detection ran successfully https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/infra-drift-detector/jobs/deploy-tooling-bastion/builds/1 and correctly (with the right name this time) reported to #govuk-pay-activity in slack
![Screenshot 2023-06-06 at 08 25 41](https://github.com/alphagov/pay-ci/assets/2170030/89672afe-bc39-4823-8ca1-a4a5d7bb6e4f)
