### PR TITLE
BAU: Update golang version for pipecleaner

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -2344,7 +2344,7 @@ jobs:
             - -ec
             - |
               apk add git shellcheck
-              go get github.com/alphagov/paas-cf/tools/pipecleaner
+              go install github.com/alphagov/paas-cf/tools/pipecleaner@latest
 
               cd /tmp/
 

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -2334,7 +2334,7 @@ jobs:
           type: registry-image
           source:
             repository: golang
-            tag: 1.14-alpine
+            tag: 1.20-alpine
         inputs:
           - name: src
         run:


### PR DESCRIPTION
Pipecleaner has been updated to need golang 1.18+