### PR TITLE
PP-8143: fully continuously deploy all apps and sidecars

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -688,6 +688,7 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: egress-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -814,7 +815,9 @@ jobs:
       - get: selfservice-ecr-registry-prod
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -982,8 +985,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: connector-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1434,9 +1440,13 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: frontend-ecr-registry-prod
+        trigger: true
       - get: nginx-forward-proxy-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1631,7 +1641,9 @@ jobs:
       - get: adminusers-ecr-registry-prod
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1861,8 +1873,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: products-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2092,8 +2107,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: products-ui-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2261,8 +2279,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: publicauth-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2445,8 +2466,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: cardid-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2614,8 +2638,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: publicapi-ecr-registry-prod
+        trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2785,7 +2812,9 @@ jobs:
       - get: ledger-ecr-registry-prod
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -3015,7 +3044,7 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: notifications-ecr-registry-prod
-        trigger: false
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -3254,7 +3283,9 @@ jobs:
       - get: webhooks-ecr-registry-prod
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -850,7 +850,9 @@ jobs:
       - get: selfservice-ecr-registry-staging
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1055,8 +1057,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: connector-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1382,6 +1387,7 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: egress-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1621,9 +1627,13 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: frontend-ecr-registry-staging
+        trigger: true
       - get: nginx-forward-proxy-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1796,7 +1806,9 @@ jobs:
       - get: adminusers-ecr-registry-staging
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - task: parse-staging-release-tag
@@ -2059,8 +2071,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: products-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2268,8 +2283,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: products-ui-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2432,8 +2450,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: publicauth-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2594,8 +2615,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: cardid-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2758,8 +2782,11 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: publicapi-ecr-registry-staging
+        trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -2924,7 +2951,9 @@ jobs:
       - get: ledger-ecr-registry-staging
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - task: parse-staging-release-tag
@@ -3189,7 +3218,9 @@ jobs:
       - get: webhooks-ecr-registry-staging
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -3426,7 +3457,7 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: notifications-ecr-registry-staging
-        trigger: false
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag


### PR DESCRIPTION
Enable full continuous deployment for all application images and sidecars out to production.

This was agreed in [this ADR](https://github.com/alphagov/pay-architecture/blob/main/adr/021-continuously-deploy-all-applications.md) 