### PR TITLE
PP-11138: Dependabot security updates only for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
     - dependencies
     - govuk-pay


### PR DESCRIPTION
We'll keep receiving all docker updates, as Dependabot does not tend to flag security updates for these.