### PR TITLE
PP-10501 Add Worldpay recurring payment smoke test tasks

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -165,6 +165,12 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_prod"
+      - task: run_recurring_card_payment_worldpay-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "reccard_worldpay_prod"
       - task: run_cancel_card_payment_sandbox-production
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -166,6 +166,12 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_stag"
+      - task: run_recurring_card_payment_worldpay-staging
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "reccard_worldpay_stag"
       - task: run_cancel_card_payment_sandbox-staging
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1047,6 +1047,12 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_test"
+      - task: run_recurring_card_payment_worldpay-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "reccard_worldpay_test"
       - task: run_cancel_card_payment_sandbox-test
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -17,10 +17,10 @@ run:
     - -ec
     - |
       POST_DEPLOY_CANARIES="notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
-      card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox rec_card_sandbox rec_card_stripe"
+      card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox rec_card_sandbox rec_card_stripe reccard_worldpay"
 
       SCHEDULED_CANARIES_STAGING="s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
-      s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications s_reccard_sandbx s_reccard_stripe"
+      s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications s_reccard_sandbx s_reccard_stripe s_reccrd_worldpy_stag"
 
       SCHEDULED_CANARIES_PROD="s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_reccard_sandbx s_notifications"
 


### PR DESCRIPTION
## WHAT
- Added Worldpay recurring card payment smoke test tasks to test/staging/prod pipelines