### PR TITLE
PP-10501 Increase number of attempts for Worldpay recurring card payment smoke tests

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -166,6 +166,7 @@ definitions:
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_prod"
       - task: run_recurring_card_payment_worldpay-production
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -167,6 +167,7 @@ definitions:
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_stag"
       - task: run_recurring_card_payment_worldpay-staging
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1048,6 +1048,7 @@ definitions:
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_wpay_test"
       - task: run_recurring_card_payment_worldpay-test
+        attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:
           <<: *aws_assumed_role_creds


### PR DESCRIPTION
## WHAT

- Increased number of attempts to 10 for Worldpay recurring card payments smoke tests in line with other Worldpay smoke tests tasks to deal with flakiness