### PR TITLE
PP-11224: Add deploy-to-test group and deployment for adot image

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -135,6 +135,13 @@ resources:
       tag_regex: "(.*)-release"
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
+  - name: adot-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-adot
+      branch: main
+      tag_regex: "alpha_release-(.*)"
   - name: nginx-forward-proxy-git-release
     type: git
     icon: github
@@ -677,6 +684,35 @@ resources:
       repository: govukpay/telegraf
       variant: release
       <<: *aws_test_config
+  - name: adot-dockerhub
+    type: registry-image
+    icon: docker
+    source:
+      repository: governmentdigitalservice/pay-adot
+      tag: latest-master
+      username: ((docker-username))
+      password: ((docker-access-token))
+  - name: adot-ecr-registry-test
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adot
+      variant: release
+      <<: *aws_test_config
+  - name: adot-candidate
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adot
+      variant: candidate
+      <<: *aws_test_config
+  - name: adot-latest
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adot
+      tag: latest
+      <<: *aws_test_config
   - name: notifications-ecr-registry-test
     type: registry-image
     icon: docker
@@ -799,6 +835,12 @@ resources:
     icon: docker
     source:
       repository: govukpay/telegraf
+      <<: *aws_staging_config
+  - name: adot-ecr-registry-staging
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adot
       <<: *aws_staging_config
   - name: notifications-ecr-registry-staging
     type: registry-image
@@ -956,6 +998,11 @@ groups:
       - record-webhooks-egress-release-number
       - smoke-test-webhooks-egress
       - push-webhooks-egress-to-staging-ecr
+  - name: adot
+    jobs:
+      - build-and-push-adot-candidate
+      - run-adot-integration-test
+      - push-adot-to-staging-ecr
   - name: alpine
     jobs:
       - build-and-push-alpine-to-ecr
@@ -6378,3 +6425,143 @@ jobs:
         params:
           image: notifications-ecr-registry-test/image.tar
           additional_tags: notifications-ecr-registry-test/tag
+
+  - name: build-and-push-adot-candidate
+    plan:
+      - in_parallel:
+        - get: pay-ci
+        - get: adot-git-release
+          trigger: true
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: adot-git-release
+      - in_parallel:
+        - load_var: release-number
+          file: tags/release-number
+        - load_var: release-name
+          file: adot-git-release/.git/ref
+        - load_var: release-sha
+          file: tags/release-sha
+        - load_var: candidate-image-tag
+          file: tags/candidate-tag
+        - load_var: date
+          file: tags/date
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-access-token))
+          EMAIL: ((docker-email))
+      - task: build
+        privileged: true
+        params:
+          DOCKER_CONFIG: docker_creds
+          LABEL_release_number: ((.:release-number))
+          LABEL_release_name: ((.:release-name))
+          LABEL_release_sha: ((.:release-sha))
+          LABEL_build_date: ((.:date))
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: adot-git-release
+              path: .
+          outputs:
+            - name: image
+          run:
+            path: build
+      - put: adot-candidate
+        params:
+          image: image/image.tar
+          additional_tags: tags/all-candidate-tags
+        get_params:
+          skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: adot candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':hammer: adot candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
+  - name: run-adot-integration-test
+    plan:
+      - in_parallel:
+        - get: adot-candidate
+          params:
+            format: oci
+          trigger: true
+          passed: [build-and-push-adot-candidate]
+        - get: pay-ci
+      - in_parallel:
+        - task: parse-candidate-tag
+          file: pay-ci/ci/tasks/parse-candidate-tag.yml
+          input_mapping:
+            ecr-repo: adot-candidate
+        - load_var: candidate_image_tag
+          file: adot-candidate/tag
+      # We'll add an actual integration test later!
+      - in_parallel:
+        - do:
+          - put: adot-ecr-registry-test
+            params:
+              image: adot-candidate/image.tar
+              additional_tags: parse-candidate-tag/release-tag
+            get_params:
+              skip_download: true
+          - put: adot-latest
+            params:
+              image: adot-candidate/image.tar
+            get_params:
+              skip_download: true
+        - put: adot-dockerhub
+          params:
+              image: adot-candidate/image.tar
+          get_params:
+            skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: adot candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':green-circle: adot candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
+  - name: push-adot-to-staging-ecr
+    plan:
+      - get: adot-ecr-registry-test
+        params:
+          format: oci
+        trigger: true
+        passed: [run-adot-integration-test]
+      - put: adot-ecr-registry-staging
+        params:
+          image: adot-ecr-registry-test/image.tar
+          additional_tags: adot-ecr-registry-test/tag
+


### PR DESCRIPTION
Adds deployment of adot images to test and then staging ecr.

There's a job to run integration tests, but since we don't have time this second to be pragmatic we'll leave the test out and add it in a couple of weeks when I'm back. Instead for now it retags the candidate image with a release tag, a latest tag, and pushes to github as latest-master

You can see this job succeeding:

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test?group=adot