### PR TITLE
Pp 11226/deploy adot to staging, prod, and perf

### DIFF
--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -8,6 +8,7 @@ definitions:
     <<: *aws_assumed_role_creds
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     ENVIRONMENT: test-perf-1
 
@@ -15,6 +16,7 @@ definitions:
     <<: *aws_assumed_role_creds
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     ACCOUNT: test
     ENVIRONMENT: test-perf-1
@@ -189,6 +191,13 @@ resources:
     icon: docker
     source:
       repository: govukpay/toolbox
+      variant: perf
+      <<: *aws_test_config
+  - name: adot-ecr-registry-perf
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adot
       variant: perf
       <<: *aws_test_config
   - name: telegraf-ecr-registry-perf
@@ -416,6 +425,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -424,6 +435,8 @@ jobs:
         file: adminusers-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -441,7 +454,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: adminusers
           <<: *deploy_params
@@ -534,6 +547,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -542,6 +557,8 @@ jobs:
         file: webhooks-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -559,7 +576,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: webhooks
           <<: *deploy_params
@@ -650,6 +667,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -658,6 +677,8 @@ jobs:
         file: selfservice-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -675,7 +696,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: selfservice
           <<: *deploy_params
@@ -708,6 +729,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -716,6 +739,8 @@ jobs:
         file: connector-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -733,7 +758,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: connector
           <<: *deploy_params
@@ -822,6 +847,8 @@ jobs:
     plan:
       - get: toolbox-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
@@ -830,6 +857,8 @@ jobs:
       - get: pay-ci
       - load_var: application_image_tag
         file: toolbox-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - load_var: nginx_image_tag
@@ -849,7 +878,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: toolbox
           <<: *deploy_params
@@ -882,6 +911,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -892,6 +923,8 @@ jobs:
         file: nginx-proxy-ecr-registry-perf/tag
       - load_var: nginx_forward_proxy_image_tag
         file: nginx-forward-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -909,7 +942,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-frontend.yml
+        file: pay-ci/ci/tasks/deploy-frontend-with-adot.yml
         params:
           APP_NAME: frontend
           NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
@@ -944,6 +977,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -952,6 +987,8 @@ jobs:
         file: products-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -969,7 +1006,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: products
           <<: *deploy_params
@@ -1060,6 +1097,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -1068,6 +1107,8 @@ jobs:
         file: products-ui-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -1085,7 +1126,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: products-ui
           <<: *deploy_params
@@ -1118,6 +1159,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -1126,6 +1169,8 @@ jobs:
         file: publicauth-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -1143,7 +1188,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: publicauth
           <<: *deploy_params
@@ -1234,6 +1279,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -1242,6 +1289,8 @@ jobs:
         file: cardid-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -1259,7 +1308,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: cardid
           <<: *deploy_params
@@ -1292,6 +1341,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -1300,6 +1351,8 @@ jobs:
         file: ledger-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -1317,7 +1370,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: ledger
           <<: *deploy_params
@@ -1408,6 +1461,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-perf
         trigger: true
+      - get: adot-ecr-registry-perf
+        trigger: true
       - get: telegraf-ecr-registry-perf
         trigger: true
       - get: pay-infra
@@ -1416,6 +1471,8 @@ jobs:
         file: publicapi-ecr-registry-perf/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-perf/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-perf/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-perf/tag
       - put: slack-notification
@@ -1433,7 +1490,7 @@ jobs:
         file: assume-role/assume-role.json
         format: json
       - task: deploy-to-perf
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: publicapi
           <<: *deploy_params

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -8,6 +8,7 @@ definitions:
     <<: *aws_assumed_role_creds
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     ENVIRONMENT: production-2
 
@@ -15,6 +16,7 @@ definitions:
     <<: *aws_assumed_role_creds
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     ACCOUNT: production
     ENVIRONMENT: production-2
@@ -24,6 +26,7 @@ definitions:
     AWS_REGION: "eu-west-1"
     CLUSTER_NAME: "production-2-fargate"
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
 
@@ -114,6 +117,7 @@ definitions:
   snippet_params_all_versions: &snippet_params_all_versions
     ENV: production-2
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
 
@@ -839,6 +843,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -847,6 +853,8 @@ jobs:
         file: selfservice-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -889,7 +897,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: selfservice
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: selfservice
           <<: *deploy_params
@@ -1011,6 +1019,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -1019,6 +1029,8 @@ jobs:
         file: connector-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -1061,7 +1073,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: connector
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: connector
           <<: *deploy_params
@@ -1337,6 +1349,8 @@ jobs:
     plan:
       - get: toolbox-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
@@ -1345,6 +1359,8 @@ jobs:
       - get: pay-ci
       - load_var: application_image_tag
         file: toolbox-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - load_var: nginx_image_tag
@@ -1376,7 +1392,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: toolbox
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: toolbox
           <<: *deploy_params
@@ -1468,6 +1484,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -1478,6 +1496,8 @@ jobs:
         file: nginx-proxy-ecr-registry-prod/tag
       - load_var: nginx_forward_proxy_image_tag
         file: nginx-forward-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -1521,7 +1541,7 @@ jobs:
           APP_NAME: frontend
           NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-frontend.yml
+        file: pay-ci/ci/tasks/deploy-frontend-with-adot.yml
         params:
           APP_NAME: frontend
           NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
@@ -1665,6 +1685,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -1673,6 +1695,8 @@ jobs:
         file: adminusers-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -1715,7 +1739,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: adminusers
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: adminusers
           <<: *deploy_params
@@ -1899,6 +1923,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -1907,6 +1933,8 @@ jobs:
         file: products-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -1949,7 +1977,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: products
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: products
           <<: *deploy_params
@@ -2133,6 +2161,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -2141,6 +2171,8 @@ jobs:
         file: products-ui-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -2183,7 +2215,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: products-ui
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: products-ui
           <<: *deploy_params
@@ -2305,6 +2337,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -2313,6 +2347,8 @@ jobs:
         file: publicauth-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -2342,7 +2378,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: publicauth
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: publicauth
           <<: *deploy_params
@@ -2492,6 +2528,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -2500,6 +2538,8 @@ jobs:
         file: cardid-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -2542,7 +2582,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: cardid
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: cardid
           <<: *deploy_params
@@ -2664,6 +2704,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -2672,6 +2714,8 @@ jobs:
         file: publicapi-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -2714,7 +2758,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: publicapi
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: publicapi
           <<: *deploy_params
@@ -2836,6 +2880,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -2844,6 +2890,8 @@ jobs:
         file: ledger-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -2886,7 +2934,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: ledger
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: ledger
           <<: *deploy_params
@@ -3307,6 +3355,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-prod
         trigger: true
+      - get: adot-ecr-registry-prod
+        trigger: true
       - get: telegraf-ecr-registry-prod
         trigger: true
       - get: pay-infra
@@ -3315,6 +3365,8 @@ jobs:
         file: webhooks-ecr-registry-prod/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-prod/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-prod/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -3351,7 +3403,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: webhooks
       - task: deploy-to-prod
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: webhooks
           <<: *deploy_params

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -8,6 +8,7 @@ definitions:
     <<: *aws_assumed_role_creds
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     ENVIRONMENT: staging-2
 
@@ -15,6 +16,7 @@ definitions:
     <<: *aws_assumed_role_creds
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     ACCOUNT: staging
     ENVIRONMENT: staging-2
@@ -25,6 +27,7 @@ definitions:
     CLUSTER_NAME: "staging-2-fargate"
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
 
     
@@ -115,6 +118,7 @@ definitions:
   snippet_params_all_versions: &snippet_params_all_versions
     ENV: staging-2
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
     TELEGRAF_IMAGE_TAG: ((.:telegraf_image_tag))
     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
   
@@ -902,6 +906,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -910,6 +916,8 @@ jobs:
         file: selfservice-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -952,7 +960,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: selfservice
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: selfservice
           <<: *deploy_params
@@ -1111,6 +1119,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -1119,6 +1129,8 @@ jobs:
         file: connector-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -1161,7 +1173,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: connector
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: connector
           <<: *deploy_params
@@ -1322,6 +1334,8 @@ jobs:
     plan:
       - get: toolbox-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
@@ -1343,6 +1357,8 @@ jobs:
           BUILD_JOB_NAME: deploy-toolbox-to-staging
           RELEASE_NUMBER: ((.:parse_staging_release_tag))
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY)) 
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - load_var: nginx_image_tag
@@ -1374,7 +1390,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: toolbox
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: toolbox
           <<: *deploy_params
@@ -1683,6 +1699,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -1693,6 +1711,8 @@ jobs:
         file: nginx-proxy-ecr-registry-staging/tag
       - load_var: nginx_forward_proxy_image_tag
         file: nginx-forward-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -1736,7 +1756,7 @@ jobs:
           APP_NAME: frontend
           NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-frontend.yml
+        file: pay-ci/ci/tasks/deploy-frontend-with-adot.yml
         params:
           APP_NAME: frontend
           NGINX_FORWARD_PROXY_IMAGE_TAG: ((.:nginx_forward_proxy_image_tag))
@@ -1858,6 +1878,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -1879,6 +1901,8 @@ jobs:
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))  
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -1921,7 +1945,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: adminusers
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: adminusers
           <<: *deploy_params
@@ -2125,6 +2149,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -2133,6 +2159,8 @@ jobs:
         file: products-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -2175,7 +2203,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: products
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: products
           <<: *deploy_params
@@ -2337,6 +2365,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -2345,6 +2375,8 @@ jobs:
         file: products-ui-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -2387,7 +2419,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: products-ui
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: products-ui
           <<: *deploy_params
@@ -2504,6 +2536,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -2512,6 +2546,8 @@ jobs:
         file: publicauth-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -2541,7 +2577,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: publicauth
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: publicauth
           <<: *deploy_params
@@ -2669,6 +2705,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -2677,6 +2715,8 @@ jobs:
         file: cardid-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -2719,7 +2759,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: cardid
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: cardid
           <<: *deploy_params
@@ -2836,6 +2876,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -2844,6 +2886,8 @@ jobs:
         file: publicapi-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -2886,7 +2930,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: publicapi
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: publicapi
           <<: *deploy_params
@@ -2995,6 +3039,7 @@ jobs:
         params:
           image: publicapi-ecr-registry-staging/image.tar
           additional_tags: publicapi-ecr-registry-staging/tag
+
   - name: deploy-ledger-to-staging
     serial: true
     serial_groups: [deploy-application]
@@ -3002,6 +3047,8 @@ jobs:
       - get: ledger-ecr-registry-staging
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
+        trigger: true
+      - get: adot-ecr-registry-staging
         trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
@@ -3024,6 +3071,8 @@ jobs:
           HOSTED_GRAPHITE_API_TOKEN: ((HOSTED_GRAPHITE_API_KEY))
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -3066,7 +3115,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: ledger
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: ledger
           <<: *deploy_params
@@ -3270,6 +3319,8 @@ jobs:
         trigger: true
       - get: nginx-proxy-ecr-registry-staging
         trigger: true
+      - get: adot-ecr-registry-staging
+        trigger: true
       - get: telegraf-ecr-registry-staging
         trigger: true
       - get: pay-infra
@@ -3278,6 +3329,8 @@ jobs:
         file: webhooks-ecr-registry-staging/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-staging/tag
+      - load_var: adot_image_tag
+        file: adot-ecr-registry-staging/tag
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -3314,7 +3367,7 @@ jobs:
           <<: *check_release_versions_params
           APP_NAME: webhooks
       - task: deploy-to-staging
-        file: pay-ci/ci/tasks/deploy-app.yml
+        file: pay-ci/ci/tasks/deploy-app-with-adot.yml
         params:
           APP_NAME: webhooks
           <<: *deploy_params

--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -35,27 +35,27 @@ run:
       :red_circle: ${ACTION_NAME} of <https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}|${APP_NAME} v${APPLICATION_IMAGE_TAG}> on ${ENV} failed. Version details:
       EOT
 
-      # Disable the shellcheck rull telling us this isn't an if-then-else. We know, and it's the desirable
+      # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${NGINX_IMAGE_TAG}" ] && \
       NGINX_RELEASE_NUMBER=$(echo "${NGINX_IMAGE_TAG}" | sed 's/-release//') && \
       echo "- <https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}|nginx-proxy v${NGINX_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
 
-      # Disable the shellcheck rull telling us this isn't an if-then-else. We know, and it's the desirable
+      # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${ADOT_IMAGE_TAG}" ] && \
       ADOT_RELEASE_NUMBER=$(echo "${ADOT_IMAGE_TAG}" | sed 's/-release//') && \
       echo "- <https://github.com/alphagov/pay-adot/releases/tag/alpha_release-${ADOT_RELEASE_NUMBER}|adot v${ADOT_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
 
-      # Disable the shellcheck rull telling us this isn't an if-then-else. We know, and it's the desirable
+      # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${TELEGRAF_IMAGE_TAG}" ] && \
       echo "- <https://github.com/alphagov/pay-telegraf/releases/tag/${TELEGRAF_IMAGE_TAG}|telegraf v${TELEGRAF_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
 
-      # Disable the shellcheck rull telling us this isn't an if-then-else. We know, and it's the desirable
+      # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
       echo "- <https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}|nginx-forward-proxy v${NGINX_FORWARD_PROXY_IMAGE_TAG}>" | \


### PR DESCRIPTION
Have concourse deploy ADOT to staging, prod, and perf

ADOT is still disabled so this is a whole lot of "No changes" right now.

You can see working jobs with this config:

perf: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-perf/jobs/deploy-publicauth-to-perf/builds/29
staging: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-staging/jobs/deploy-adminusers-to-staging/builds/503
production:  https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-production/jobs/deploy-adminusers-to-prod/builds/460