### PR TITLE
PP-11272: Prometheus pushgateway pipeline

### DIFF
--- a/ci/pipelines/prometheus-pushgateway.yml
+++ b/ci/pipelines/prometheus-pushgateway.yml
@@ -1,0 +1,68 @@
+---
+resources:
+  - name: prometheus-pushgateway
+    type: registry-image
+    icon: docker
+    check_every: 1h
+    source:
+      repository: prom/pushgateway
+      tag: v1.6.0
+      username: ((docker-username))
+      password: ((docker-access-token))
+
+  - name: ecr-prometheus-pushgateway
+    type: registry-image
+    icon: docker
+    check_every: never
+    source:
+      repository: pushgateway
+      tag: v1.6.0
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      aws_role_arn: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse
+      aws_ecr_registry_id: "((pay_aws_deploy_account_id))"
+      aws_region: eu-west-1
+
+  - name: slack-notification
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-notification-secret))
+
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+jobs:
+  - name: copy-prometheus-pushgateway
+    plan:
+      - get: prometheus-pushgateway
+        trigger: true
+        params:
+          format: oci
+      - put: ecr-prometheus-pushgateway
+        params:
+          image: prometheus-pushgateway/image.tar
+        get_params:
+          skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-starling"
+        silent: true
+        text: ":red-circle: Failed copying pushgateway:v1.6.0 image from Docker Hub to ECR - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-activity"
+        silent: true
+        text: ":green-circle: Copied pushgateway:v1.6.0 image from Docker Hub to ECR - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse


### PR DESCRIPTION
At the moment the pipeline copies v1.6.0 of the [prometheus pushgatway on dockerhub](https://hub.docker.com/r/prom/pushgateway/tags) to our ECR for use by the up-and-coming pushgateway ECR task definition. In the future we will extend this pipeline with deployment for the pushgateway.

[Successful run](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/prometheus-pushgateway/jobs/copy-prometheus-pushgateway/builds/1).

Pushgateway image is now in [deploy ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/424875624006/pushgateway?region=eu-west-1).