### PR TITLE
PP-11314 pipeline for versioning node packages

### DIFF
--- a/ci/pipelines/pay-js.yml
+++ b/ci/pipelines/pay-js.yml
@@ -1,0 +1,79 @@
+resources:
+  # GitHub Repos
+  - name: pay-js-pipeline-definition
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+      paths:
+        - ci/pipelines/pay-js.yml
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: pp-11314/metrics_release_process
+  - name: js-commons-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-js-commons
+      branch: master
+      commit_filter:
+        exclude: [ "\\[automated release\\]" ]
+  - name: js-metrics-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-js-metrics
+      branch: main
+      commit_filter:
+        exclude: [ "\\[automated release\\]" ]
+
+groups:
+  - name: js-commons
+    jobs:
+      - version-and-push-commons
+  - name: js-metrics
+    jobs:
+      - version-and-push-metrics
+  - name: update-pay-js-pipeline
+    jobs:
+      - update-pay-js-pipeline
+
+jobs:
+  - name: version-and-push-metrics
+    plan:
+      - in_parallel:
+        - get: js-metrics-git-release
+          trigger: false
+        - get: pay-ci
+      - task: npm-version-and-create-pr
+        file: pay-ci/ci/tasks/npm-version-and-create-pr.yml
+        input_mapping:
+          src: js-metrics-git-release
+        params:
+          BASE: main
+          REPO: alphagov/pay-js-metrics
+          GITHUB_TOKEN: ((github-access-token))
+  - name: version-and-push-commons
+    plan:
+      - in_parallel:
+        - get: js-commons-git-release
+          trigger: false
+        - get: pay-ci
+      - task: npm-version-and-create-pr
+        file: pay-ci/ci/tasks/npm-version-and-create-pr.yml
+        input_mapping:
+          src: js-commons-git-release
+        params:
+          BASE: master
+          REPO: alphagov/pay-js-commons
+          GITHUB_TOKEN: ((github-access-token))
+  - name: update-pay-js-pipeline
+    plan:
+      - get: pay-js-pipeline-definition
+        trigger: true
+      - set_pipeline: pay-js
+        file: pay-js-pipeline-definition

--- a/ci/pipelines/pay-js.yml
+++ b/ci/pipelines/pay-js.yml
@@ -13,7 +13,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: pp-11314/metrics_release_process
+      branch: master
   - name: js-commons-git-release
     type: git
     icon: github
@@ -47,7 +47,7 @@ jobs:
     plan:
       - in_parallel:
         - get: js-metrics-git-release
-          trigger: false
+          trigger: true
         - get: pay-ci
       - task: npm-version-and-create-pr
         file: pay-ci/ci/tasks/npm-version-and-create-pr.yml
@@ -76,4 +76,4 @@ jobs:
       - get: pay-js-pipeline-definition
         trigger: true
       - set_pipeline: pay-js
-        file: pay-js-pipeline-definition
+        file: pay-js-pipeline-definition/ci/pipelines/pay-js.yml

--- a/ci/tasks/npm-version-and-create-pr.yml
+++ b/ci/tasks/npm-version-and-create-pr.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: alpine3.16
+    tag: current-alpine
 params:
   BASE:
   REPO:

--- a/ci/tasks/npm-version-and-create-pr.yml
+++ b/ci/tasks/npm-version-and-create-pr.yml
@@ -1,0 +1,32 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: node
+    tag: alpine3.16
+params:
+  BASE:
+  REPO:
+  GITHUB_TOKEN:
+inputs:
+  - name: src
+run:
+  path: sh
+  dir: src
+  args:
+    - -c
+    - |
+      apk add --no-cache git github-cli
+      
+      git remote remove origin
+      git remote add origin "https://$GITHUB_TOKEN@github.com/$REPO"
+      git config --local user.email "github-pay-ci+concourse@digital.cabinet-office.gov.uk"
+      git config --local user.name "alphagov-pay-ci-concourse"
+      
+      npm ci
+      RELEASE_VERSION="$(npm version patch -m "[automated release] %s")"
+      
+      git checkout -b "release-$RELEASE_VERSION"
+      git push --follow-tags --set-upstream origin "release-$RELEASE_VERSION"
+      
+      gh pr create --base "$BASE" --title "[automated release] $RELEASE_VERSION" --body "🤖 automated PR, merge to trigger release"


### PR DESCRIPTION
### WHAT

Limitations in the GitHub permissions model mean that if we want to automatically version and release our Node packages we'll need to do the versioning part from Concourse.

This pipeline monitors commits to the main branches of our `pay-js` packages. When a new commit (that is not a release commit created by this pipeline) is detected. Concourse will build and version the package appropriately, creating a release tag and opening a PR to merge in files affected by the `npm version patch` command.