### PR TITLE
PP-11389: Remove 3ds1 smoke tests

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -141,13 +141,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "rec_card_sandbox_prod"
-      - task: run_create_card_payment_worldpay_with_3ds-production
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds_prod"
       - task: run_create_card_payment_worldpay_with_3ds2-production
         attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -142,13 +142,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "rec_card_sandbox_stag"
-      - task: run_create_card_payment_worldpay_with_3ds-staging
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds_stag"
       - task: run_create_card_payment_worldpay_with_3ds2-staging
         attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1070,13 +1070,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "rec_card_sandbox_test"
-      - task: run_create_card_payment_worldpay_with_3ds-test
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds_test"
       - task: run_create_card_payment_worldpay_with_3ds2-test
         attempts: 10
         file: pay-ci/ci/tasks/run-smoke-test.yml


### PR DESCRIPTION
3DS1 is no longer supported by the card brands (and hasn’t been since 2022), some of our smoke tests test 3DS1 through Worldpay. Worldpay have now removed 3DS1 support completely and so our smoke tests are failing and blocking deploys.

This PR removes execution of the 3DS1 smoke test in all envs