### PR TITLE
PP-11389: Remove error state checks for worldpay 3ds1 tests

### DIFF
--- a/ci/tasks/check-canaries-in-error-state.yml
+++ b/ci/tasks/check-canaries-in-error-state.yml
@@ -17,9 +17,9 @@ run:
     - -ec
     - |
       POST_DEPLOY_CANARIES="notifcatns_sndbx pymntlnk_sandbox cancel_sandbox card_wpay_3ds2ex \
-      card_wpay_3ds2 card_wpay_3ds card_wpay card_stripe_3ds card_stripe card_sandbox rec_card_sandbox rec_card_stripe reccard_worldpay"
+      card_wpay_3ds2 card_wpay card_stripe_3ds card_stripe card_sandbox rec_card_sandbox rec_card_stripe reccard_worldpay"
 
-      SCHEDULED_CANARIES_STAGING="s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds s_card_wpay_3ds2 \
+      SCHEDULED_CANARIES_STAGING="s_card_stripe s_card_stripe_3d s_card_wpay s_card_wpay_3ds2 \
       s_wpay_3ds2ex s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_notifications s_reccard_sandbx s_reccard_stripe s_reccrd_worldpy_stag"
 
       SCHEDULED_CANARIES_PROD="s_card_sandbox s_cancel_sandbox s_paylnk_sandbox s_reccard_sandbx s_notifications"


### PR DESCRIPTION
Worldpay remove 3ds1, we already removed the smoke tests for them, but forgot about the error state checks