### PR TITLE
PP-11227-add-adot-sidecar-to-cd

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1527,7 +1527,7 @@ jobs:
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: adot-candidate
-        passed: [deploy-toolbox]
+        passed: [build-and-push-adot-candidate]
         trigger: true
       - get: pay-infra
       - get: pay-ci

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1572,31 +1572,6 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
-      - task: run-toolbox-metric-tests
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: governmentdigitalservice/pay-node-runner
-              tag: node16
-          inputs:
-            - name: pay-ci
-          params:
-            TEST_METRIC_IMAGE_TAG: candidate
-            TEST_METRIC_ECS_SERVICE: toolbox
-            # TODO: find out how to get endpoint and creds
-            # AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-            # AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-            # AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-            # AWS_REGION: "eu-west-1"
-            # CLUSTER_NAME: "test-12-fargate"
-            # APP_NAME: "adminusers"
-            # APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-          run:
-            path: node
-            args:
-              - pay-ci/ci/scripts/test-metrics.js
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 
@@ -6620,6 +6595,24 @@ jobs:
               image: adot-candidate/image.tar
           get_params:
             skip_download: true
+      - task: run-toolbox-metric-tests
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: governmentdigitalservice/pay-node-runner
+              tag: node16
+          inputs:
+            - name: pay-ci
+          params:
+            TEST_METRIC_IMAGE_TAG: candidate
+            TEST_METRIC_ECS_SERVICE: toolbox
+            <<: *aws_test_config
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/test-metrics.js
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -6576,25 +6576,6 @@ jobs:
             ecr-repo: adot-candidate
         - load_var: candidate_image_tag
           file: adot-candidate/tag
-      # We'll add an actual integration test later!
-      - in_parallel:
-        - do:
-          - put: adot-ecr-registry-test
-            params:
-              image: adot-candidate/image.tar
-              additional_tags: parse-candidate-tag/release-tag
-            get_params:
-              skip_download: true
-          - put: adot-latest
-            params:
-              image: adot-candidate/image.tar
-            get_params:
-              skip_download: true
-        - put: adot-dockerhub
-          params:
-              image: adot-candidate/image.tar
-          get_params:
-            skip_download: true
       - task: run-toolbox-metric-tests
         config:
           platform: linux
@@ -6613,6 +6594,24 @@ jobs:
             path: node
             args:
               - pay-ci/ci/scripts/test-metrics.js
+      - in_parallel:
+        - do:
+          - put: adot-ecr-registry-test
+            params:
+              image: adot-candidate/image.tar
+              additional_tags: parse-candidate-tag/release-tag
+            get_params:
+              skip_download: true
+          - put: adot-latest
+            params:
+              image: adot-candidate/image.tar
+            get_params:
+              skip_download: true
+        - put: adot-dockerhub
+          params:
+              image: adot-candidate/image.tar
+          get_params:
+            skip_download: true
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1526,7 +1526,7 @@ jobs:
         passed: [build-and-push-telegraf-to-test-ecr]
       - get: nginx-proxy-ecr-registry-test
         trigger: true
-      - get: adot-ecr-registry-test
+      - get: adot-candidate
         trigger: true
       - get: pay-infra
       - get: pay-ci
@@ -1535,7 +1535,7 @@ jobs:
       - load_var: telegraf_image_tag
         file: telegraf-ecr-registry-test/tag
       - load_var: adot_image_tag
-        file: adot-ecr-registry-test/tag
+        file: adot-candidate/tag
       - load_var: nginx_image_tag
         file: nginx-proxy-ecr-registry-test/tag
       - task: create-notification-snippets

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -6588,9 +6588,11 @@ jobs:
           inputs:
             - name: pay-ci
           params:
-            TEST_METRIC_IMAGE_TAG: candidate
-            TEST_METRIC_ECS_SERVICE: toolbox
             <<: *aws_test_config
+            AWS_ACCESS_KEY_ID: ((readonly_access_key_id))
+            AWS_SECRET_ACCESS_KEY: ((readonly_secret_access_key))
+            AWS_SESSION_TOKEN: ((readonly_session_token))
+            TEST_METRIC_ECS_SERVICE: toolbox
           run:
             path: node
             args:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1527,6 +1527,7 @@ jobs:
       - get: nginx-proxy-ecr-registry-test
         trigger: true
       - get: adot-candidate
+        passed: [deploy-toolbox]
         trigger: true
       - get: pay-infra
       - get: pay-ci
@@ -1571,6 +1572,31 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
+      - task: run-toolbox-metric-tests
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: governmentdigitalservice/pay-node-runner
+              tag: node16
+          inputs:
+            - name: pay-ci
+          params:
+            TEST_METRIC_IMAGE_TAG: candidate
+            TEST_METRIC_ECS_SERVICE: toolbox
+            # TODO: find out how to get endpoint and creds
+            # AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            # AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            # AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            # AWS_REGION: "eu-west-1"
+            # CLUSTER_NAME: "test-12-fargate"
+            # APP_NAME: "adminusers"
+            # APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          run:
+            path: node
+            args:
+              - pay-ci/ci/scripts/test-metrics.js
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
 

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1007,6 +1007,7 @@ groups:
       - build-and-push-adot-candidate
       - run-adot-integration-test
       - push-adot-to-staging-ecr
+      - deploy-toolbox
   - name: alpine
     jobs:
       - build-and-push-alpine-to-ecr
@@ -6567,7 +6568,7 @@ jobs:
           params:
             format: oci
           trigger: true
-          passed: [build-and-push-adot-candidate]
+          passed: [deploy-toolbox]
         - get: pay-ci
       - in_parallel:
         - task: parse-candidate-tag

--- a/ci/scripts/test-metrics.js
+++ b/ci/scripts/test-metrics.js
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
 
 // Query Prometheus for a specific metric, exiting 0 if we find it, and 1
-// if we don't. Retries a few times, to account for scrape intervals.
+// if we don't. Retries a few times, to account for scrape intervals. 
+// Assumes the metric is sent by the ADOT sidecar, from, the test env.
 
 const assert = require('assert');
 const http = require('http');
-const tag = process.env.TOOLBOX_IMAGE_TAG;
+const imageTag = process.env.TEST_METRIC_IMAGE_TAG;
+const ecsService = process.env.TEST_METRIC_ECS_SERVICE;
 const metric = `nodejs_version_info{
   awsAccountName="test", 
-  containerImageTag="${tag}", 
-  ecsServiceName="toolbox", 
+  containerImageTag="${imageTag}", 
+  ecsServiceName="${ecsService}",
   job="adot-sidecar-scrape-application"}`;
 
 const endpoint = {
-  host: '192.168.1.9', // FIXME what id endpoint, how do we auth?
-  port: 9090,
-  protocol: 'http:',
+  host: 'aps-workspaces.eu-west-1.amazonaws.com/workspaces/ws-ef55ad23-3e0c-44f6-997e-1b2d51f20102',
+  protocol: 'https:',
   path: encodeURI(`/api/v1/query?query=${metric}`),
 }
 

--- a/ci/scripts/test-metrics.js
+++ b/ci/scripts/test-metrics.js
@@ -3,8 +3,15 @@
 // Query Prometheus for a specific metric, exiting 0 if we find it, and 1
 // if we don't. Retries a few times, to account for scrape intervals. 
 // Assumes the metric is sent by the ADOT sidecar, from, the test env.
-// We have to manually sign the HTTP request: there's no AWS SDK helper 
-// for hitting the AMP query endpoint.
+//
+// Written to interact with the Amazon Managed Prometheus service, which 
+// means it requires the AmazonPrometheusQueryAccess managed policy,
+// and that all requests are signed. 
+//
+// We use an "instant query", which provides us with a view of the world
+// as it is right now. If the required metric is not *currently* being sent,
+// the script will not see it. This is, at the time of writing, the desired
+// behaviour.
 
 const assert = require('assert');
 const https = require('https');

--- a/ci/scripts/test-metrics.js
+++ b/ci/scripts/test-metrics.js
@@ -10,7 +10,6 @@ const assert = require('assert');
 const https = require('https');
 const aws4 = require('aws4');
 
-const imageTag = process.env.TEST_METRIC_IMAGE_TAG;
 const ecsService = process.env.TEST_METRIC_ECS_SERVICE;
 var retries = 5;
 const retryIntervalMs = 5000;
@@ -19,7 +18,6 @@ const ampEndpointHost = 'aps-workspaces.eu-west-1.amazonaws.com';
 const ampEndpointPath = '/workspaces/ws-ef55ad23-3e0c-44f6-997e-1b2d51f20102';
 const metric = `nodejs_version_info{
   awsAccountName="test", 
-  containerImageTag="${imageTag}", 
   ecsServiceName="${ecsService}",
   job="adot-sidecar-scrape-application"}`;
 

--- a/ci/scripts/test-metrics.js
+++ b/ci/scripts/test-metrics.js
@@ -6,11 +6,15 @@
 // We have to manually sign the HTTP request: there's no AWS SDK helper 
 // for hitting the AMP query endpoint.
 
+// We issue an instant query, looking for metrics from toolbox in the test 
+// environment. Using an instant query means metrics are being sent right now. 
+// (Or at least within the last scrape interval.) If we find metrics, we exit 
+// 0, if not, we exit 1.
+
 const assert = require('assert');
 const https = require('https');
 const aws4 = require('aws4');
 
-const imageTag = process.env.TEST_METRIC_IMAGE_TAG;
 const ecsService = process.env.TEST_METRIC_ECS_SERVICE;
 var retries = 5;
 const retryIntervalMs = 5000;
@@ -19,7 +23,6 @@ const ampEndpointHost = 'aps-workspaces.eu-west-1.amazonaws.com';
 const ampEndpointPath = '/workspaces/ws-ef55ad23-3e0c-44f6-997e-1b2d51f20102';
 const metric = `nodejs_version_info{
   awsAccountName="test", 
-  containerImageTag="${imageTag}", 
   ecsServiceName="${ecsService}",
   job="adot-sidecar-scrape-application"}`;
 

--- a/ci/scripts/test-metrics.js
+++ b/ci/scripts/test-metrics.js
@@ -6,15 +6,11 @@
 // We have to manually sign the HTTP request: there's no AWS SDK helper 
 // for hitting the AMP query endpoint.
 
-// We issue an instant query, looking for metrics from toolbox in the test 
-// environment. Using an instant query means metrics are being sent right now. 
-// (Or at least within the last scrape interval.) If we find metrics, we exit 
-// 0, if not, we exit 1.
-
 const assert = require('assert');
 const https = require('https');
 const aws4 = require('aws4');
 
+const imageTag = process.env.TEST_METRIC_IMAGE_TAG;
 const ecsService = process.env.TEST_METRIC_ECS_SERVICE;
 var retries = 5;
 const retryIntervalMs = 5000;
@@ -23,6 +19,7 @@ const ampEndpointHost = 'aps-workspaces.eu-west-1.amazonaws.com';
 const ampEndpointPath = '/workspaces/ws-ef55ad23-3e0c-44f6-997e-1b2d51f20102';
 const metric = `nodejs_version_info{
   awsAccountName="test", 
+  containerImageTag="${imageTag}", 
   ecsServiceName="${ecsService}",
   job="adot-sidecar-scrape-application"}`;
 

--- a/ci/scripts/test-toolbox-metrics.js
+++ b/ci/scripts/test-toolbox-metrics.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+// Query Prometheus for a specific metric, exiting 0 if we find it, and 1
+// if we don't. Retries a few times, to account for scrape intervals.
+
+const assert = require('assert');
+const http = require('http');
+const tag = process.env.TOOLBOX_IMAGE_TAG;
+const metric = `nodejs_version_info{
+  awsAccountName="test", 
+  containerImageTag="${tag}", 
+  ecsServiceName="toolbox", 
+  job="adot-sidecar-scrape-application"}`;
+
+const endpoint = {
+  host: '192.168.1.9', // FIXME what id endpoint, how do we auth?
+  port: 9090,
+  protocol: 'http:',
+  path: encodeURI(`/api/v1/query?query=${metric}`),
+}
+
+var retries = 5;
+const retryIntervalMs = 5000;
+
+// Because we issue a very specific query, we don't need to check much other
+// than that we got a successful response containing metrics. A failed assertion
+// raises an exception which is caught in fetchMetrics().
+const testData = function(resp) {
+  assert.equal(resp.status, 'success');
+  assert.equal(resp.data.resultType, 'vector');
+  assert(resp.data.result.length > 0);
+  return true;
+}
+
+// Watch out for the immediate exit 
+const fetchMetrics = function() {
+  http.get(endpoint, (res) => {
+    const { statusCode } = res;
+    const contentType = res.headers['content-type'];
+
+    if (statusCode !== 200) {
+      console.log(`Unexpected status code: ${statusCode}`);
+    }
+
+    if (!/^application\/json/.test(contentType)) {
+      console.log(`Unexpected content-type: ${contentType}`);
+    }
+
+    let rawData = '';
+    res.setEncoding('utf8');
+    res.on('data', (chunk) => { rawData += chunk; });
+    res.on('end', () => {
+      try {
+        parsedData = JSON.parse(rawData);
+      } catch (e) {
+        console.log(`Error parsing response: ${e}`)
+      }
+      try {
+        testData(parsedData)
+        console.log("Found metrics");
+        process.exit(0); // TERMINATE IMMEDIATELY ON SUCCESS!
+      } catch (e) {
+        console.log(`Failed test assertion: ${e.message}`);
+      }
+    });
+  }).on('error', (e) => {
+    console.log(`Error making request: ${e.errors}`);
+  });
+}
+
+fetchMetrics();
+
+setInterval(function() {
+  fetchMetrics();
+  if (retries-- == 0) {
+    process.exit(1); // TERMINATE AFTER ALL RETRIES
+  }
+}, retryIntervalMs);


### PR DESCRIPTION
## What?
We don't currently test the full metrics path when we make a deployment. This PR exercises the ADOT sidecar and asserts that metrics from a test Toolbox deployment make it through, correctly tagged, to our hosted Prometheus.

## How?
Adds a `run-adot-integration-test` job to the `deploy-to-test` pipeline. This depends on a successful build of the ADOT sidecar, which it attaches to a `toolbox` in the test account. A script is run via `node-runner`, which connects to Amazon Managed Prometheus and performs and instant query, asserting that as of "right now" Toolbox in the test environment is sending metrics. Note: **this does not currently assert a particular version of Toolbox**, which may be incorrect. If the test finds metrics, it passes and the pipeline continues. If not, the test fails and halts the pipeline.

This change has required other changes [to grant Concourse privilege to access Prometheus](https://github.com/alphagov/pay-concourse-deployment/pull/100), and to [build the AWS4 module into `node-runner`](https://github.com/alphagov/pay-ci/pull/936).

Example of successful test job: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/run-adot-integration-test/builds/26