### PR TITLE
PP-10671: Pass pactbroker image tag through to terraform

### DIFF
--- a/ci/pipelines/pact-broker.yml
+++ b/ci/pipelines/pact-broker.yml
@@ -77,6 +77,8 @@ jobs:
       - get: pay-ci
       - get: pay-infra
       - get: pact-broker-ecr-registry-deploy
+        passed: [build-and-push-pact-broker]
+        trigger: true
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -105,6 +107,24 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-starling"
+        silent: true
+        text: ":red-circle: Failed to deploy pay-pact-broker image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-activity"
+        silent: true
+        text: ":green-circle: Deployed pay-pact-broker image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
 
   - name: build-and-push-pact-broker
     plan:

--- a/ci/pipelines/pact-broker.yml
+++ b/ci/pipelines/pact-broker.yml
@@ -76,6 +76,7 @@ jobs:
     plan:
       - get: pay-ci
       - get: pay-infra
+      - get: pact-broker-ecr-registry-deploy
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -84,6 +85,8 @@ jobs:
       - load_var: role
         file: assume-role/assume-role.json
         format: json
+      - load_var: pactbroker_image_tag
+        file: pact-broker-ecr-registry-deploy/tag
       - task: deploy-pact-broker
         file: pay-ci/ci/tasks/deploy-pact-broker.yml
         params:
@@ -92,6 +95,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          PACTBROKER_IMAGE_TAG: ((.:pactbroker_image_tag))
       - task: wait-for-deploy
         file: pay-ci/ci/tasks/wait-for-deploy.yml
         params:

--- a/ci/tasks/deploy-pact-broker.yml
+++ b/ci/tasks/deploy-pact-broker.yml
@@ -14,6 +14,7 @@ params:
   AWS_REGION: eu-west-1
   ACCOUNT:
   ENVIRONMENT:
+  PACTBROKER_IMAGE_TAG:
 run:
   path: /bin/sh
   args:
@@ -22,5 +23,6 @@ run:
       cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/environment/pactbroker
       terraform init
       terraform apply \
+        -var pactbroker_image_tag=${PACTBROKER_IMAGE_TAG} \
         -auto-approve
        


### PR DESCRIPTION
Pass the pact-broker image tag through to terraform so that the Concourse pipeline can be triggered to deploy/redeploy the AWS ECS Fargate service (using a new task definition).