### PR TITLE
PP-11071-add-aws-crt-to-node-runner

### DIFF
--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -4,6 +4,7 @@ FROM node:16.20.2-alpine3.17@sha256:bbc110afcd56dea9d27969ce1c3585aac53192ad14b3
 WORKDIR /node-runner
 
 RUN npm install -g aws-sdk@^2.x.x
+RUN npm install -g aws-crt@^1.x.x
 RUN npm install -g @octokit/rest@^18.x.x
 
 ENV NODE_PATH=/usr/local/lib/node_modules

--- a/ci/docker/node-runner/Dockerfile.node16
+++ b/ci/docker/node-runner/Dockerfile.node16
@@ -4,6 +4,7 @@ FROM node:16.20.2-alpine3.17@sha256:bbc110afcd56dea9d27969ce1c3585aac53192ad14b3
 WORKDIR /node-runner
 
 RUN npm install -g aws-sdk@^2.x.x
+RUN npm install -g aws-crt@^1.x.x
 RUN npm install -g @octokit/rest@^18.x.x
 
 ENV NODE_PATH=/usr/local/lib/node_modules


### PR DESCRIPTION
## What

We need to make API calls to our Amazon Managed Prometheus service, which [requires signed requests](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-query-APIs.html). Signing requests manually is non-trivial, but Amazon's own [aws-crt](https://www.npmjs.com/package/aws-crt) module provides helpers which make it relatively straightforward.

## How

Add the `aws-crt` module to the `NODE_PATH` directory.