### PR TITLE
PP-11227-change-request-signing-module

### DIFF
--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -4,7 +4,7 @@ FROM node:16.20.2-alpine3.17@sha256:bbc110afcd56dea9d27969ce1c3585aac53192ad14b3
 WORKDIR /node-runner
 
 RUN npm install -g aws-sdk@^2.x.x
-RUN npm install -g aws-crt@^1.x.x
+RUN npm install -g aws4@^1.x.x
 RUN npm install -g @octokit/rest@^18.x.x
 
 ENV NODE_PATH=/usr/local/lib/node_modules

--- a/ci/docker/node-runner/Dockerfile.node16
+++ b/ci/docker/node-runner/Dockerfile.node16
@@ -4,7 +4,7 @@ FROM node:16.20.2-alpine3.17@sha256:bbc110afcd56dea9d27969ce1c3585aac53192ad14b3
 WORKDIR /node-runner
 
 RUN npm install -g aws-sdk@^2.x.x
-RUN npm install -g aws-crt@^1.x.x
+RUN npm install -g aws4@^1.x.x
 RUN npm install -g @octokit/rest@^18.x.x
 
 ENV NODE_PATH=/usr/local/lib/node_modules


### PR DESCRIPTION
## What

I can't make successful API calls to Prom with with the `aws-crt` module. The module pre-dates the service, and I wonder if they're compatible. I also wasn't able to successfully sign requests with the aws-sdk-v3, but that may be down to my lack of Node chops. However, using the third-party but still-supported `aws4` module, request signing works just fine, and is simple to implement. 

Reviewer, please push back if you have concerns about this module or its dependencies.

## How

Install `aws4` instead of `aws-crt`.