### PR TITLE
Pp 11425/make sns unsubscribe check multi region

### DIFF
--- a/ci/pipelines/infra-drift-detector-higher-envs.yml
+++ b/ci/pipelines/infra-drift-detector-higher-envs.yml
@@ -23,20 +23,25 @@ resources:
       branch: master
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
+  - name: every-15-minutes
+    type: time
+    icon: alarm
+    source:
+      interval: 15m
   - name: every-morning-at-six
+    type: time
     icon: alarm
     source:
       start: "06:00"
       stop: "06:30"
       location: Europe/London
-    type: time
   - name: every-morning-at-six-thirty
+    type: time
     icon: alarm
     source:
       start: "06:30"
       stop: "07:00"
       location: Europe/London
-    type: time
   - name: every-morning-at-seven
     icon: alarm
     source:
@@ -219,7 +224,7 @@ jobs:
   - name: staging-check-for-zendesk-unsubscribers
     plan:
     - in_parallel:
-      - get: every-morning-at-six
+      - get: every-15-minutes
         trigger: true
       - get: pay-ci
     - task: assume-role
@@ -238,6 +243,7 @@ jobs:
         AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         AWS_REGION: eu-west-1
         AWS_DEFAULT_REGION: eu-west-1
+        REGIONS: eu-west-1 us-east-1
     on_success:
       put: slack-notification
       attempts: 10
@@ -256,10 +262,11 @@ jobs:
           text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
           icon_emoji: ':aws-dark:'
           username: pay-concourse-drift-detector
+
   - name: production-check-for-zendesk-unsubscribers
     plan:
     - in_parallel:
-      - get: every-morning-at-six-thirty
+      - get: every-15-minutes
         trigger: true
       - get: pay-ci
     - task: assume-role
@@ -278,6 +285,7 @@ jobs:
         AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         AWS_REGION: eu-west-1
         AWS_DEFAULT_REGION: eu-west-1
+        REGIONS: eu-west-1 us-east-1
     on_success:
       put: slack-notification
       attempts: 10
@@ -296,10 +304,11 @@ jobs:
           text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
           icon_emoji: ':aws-dark:'
           username: pay-concourse-drift-detector
+
   - name: deploy-check-for-zendesk-unsubscribers
     plan:
     - in_parallel:
-      - get: every-morning-at-six
+      - get: every-15-minutes
         trigger: true
       - get: pay-ci
     - task: assume-role
@@ -318,6 +327,7 @@ jobs:
         AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         AWS_REGION: eu-west-1
         AWS_DEFAULT_REGION: eu-west-1
+        REGIONS: eu-west-1 eu-central-1 us-east-1
     on_success:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -168,7 +168,7 @@ jobs:
   - name: test-check-for-zendesk-unsubscribers
     plan:
     - in_parallel:
-      - get: every-morning-at-five
+      - get: every-15-minutes
         trigger: true
       - get: pay-ci
     - task: assume-role
@@ -187,6 +187,7 @@ jobs:
         AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
         AWS_REGION: eu-west-1
         AWS_DEFAULT_REGION: eu-west-1
+        REGIONS: eu-west-1 us-east-1
     on_success:
       put: slack-notification
       attempts: 10
@@ -208,7 +209,7 @@ jobs:
   - name: dev-check-for-zendesk-unsubscribers
     plan:
     - in_parallel:
-      - get: every-morning-at-five
+      - get: every-15-minutes
         trigger: true
       - get: pay-ci
     - task: assume-role
@@ -245,6 +246,7 @@ jobs:
           text: ':red-circle: An SNS topic subscriber is unsubscribed - $BUILD_JOB_NAME <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
           icon_emoji: ':aws-dark:'
           username: pay-concourse-drift-detector
+
   - name: ci-check-for-zendesk-unsubscribers
     plan:
     - in_parallel:

--- a/ci/pipelines/infra-drift-detector-lower-envs.yml
+++ b/ci/pipelines/infra-drift-detector-lower-envs.yml
@@ -22,21 +22,26 @@ resources:
       uri: https://github.com/alphagov/pay-infra
       branch: master
       username: alphagov-pay-ci-concourse
-      password: ((github-access-token))        
+      password: ((github-access-token))
+  - name: every-15-minutes
+    type: time
+    icon: alarm
+    source:
+      interval: 15m
   - name: every-morning-at-five
+    type: time
     icon: alarm
     source:
       start: "05:00"
       stop: "05:30"
       location: Europe/London
-    type: time
   - name: every-morning-at-five-thirty
+    type: time
     icon: alarm
     source:
       start: "05:30"
       stop: "06:00"
       location: Europe/London
-    type: time
   - name: pay-ci
     type: git
     icon: github
@@ -243,7 +248,7 @@ jobs:
   - name: ci-check-for-zendesk-unsubscribers
     plan:
     - in_parallel:
-      - get: every-morning-at-five
+      - get: every-15-minutes
         trigger: true
       - get: pay-ci
     - task: assume-role

--- a/ci/tasks/check-sns-topic-unsubscribers.yml
+++ b/ci/tasks/check-sns-topic-unsubscribers.yml
@@ -3,6 +3,8 @@ image_resource:
    type: registry-image
    source:
     repository: governmentdigitalservice/pay-concourse-runner
+params:
+  REGIONS: eu-west-1 eu-central-1 us-east-1
 run:
   path: /bin/bash
   args:
@@ -11,8 +13,6 @@ run:
       set -euo pipefail
 
       any_failed=0
-
-      REGIONS="eu-west-1 us-east-1 eu-central-1"
 
       for REGION in $REGIONS; do
         TOPIC_ARNS=$(aws sns --region "$REGION" list-topics --query "Topics[].TopicArn" | jq -r '.[]')

--- a/ci/tasks/check-sns-topic-unsubscribers.yml
+++ b/ci/tasks/check-sns-topic-unsubscribers.yml
@@ -9,20 +9,30 @@ run:
     - -c
     - |
       set -euo pipefail
+
       any_failed=0
-      while read -r TOPIC_ARN; do
-        echo "Checking topic: $TOPIC_ARN"
-        if [ "$TOPIC_ARN" == "None" ]; then
-          echo "No SNS topics found"
-          exit 1
-        fi
-        subscription_arn=$(aws sns list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" --query 'Subscriptions[].SubscriptionArn' --output text)
-            if [ "$subscription_arn" == "Deleted" ] ||  [ "$subscription_arn" == "PendingConfirmation" ]; then
-              echo "Topic subscription: $subscription_arn is unsubscribed
-              If you can find the Zendesk email to resubscribe, do that
-              If you can’t find it or it doesn’t work, talk to Starling"
-            fi
-      done < <(aws sns list-topics --query "Topics[].[TopicArn]" --output text)
-      if [ "$any_failed" -eq 1 ]; then
+
+      for REGION in eu-west-1 us-east-1 eu-central-1; do
+        while read -r TOPIC_ARN; do
+          echo "Checking topic: $TOPIC_ARN in $REGION"
+          if [ "$TOPIC_ARN" == "None" ]; then
+            echo "No SNS topics found in $REGION"
+            exit 1
+          fi
+
+          subscription_arn=$(aws sns --region "$REGION" list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" --query 'Subscriptions[].SubscriptionArn' --output text)
+          if [ "$subscription_arn" == "Deleted" ] || [ "$subscription_arn" == "PendingConfirmation" ]; then
+            echo "Topic subscription: $subscription_arn in region $REGION is unsubscribed."
+            echo
+            echo "If you can find the Zendesk email to resubscribe, do that; or"
+            echo "If you can’t find it or it doesn’t work, talk to Starling"
+
+            any_failed=$((any_failed+=1))
+          fi
+        done < <(aws sns --region "$REGION" list-topics --query "Topics[].[TopicArn]" --output text)
+      done
+
+      if [ "$any_failed" -ne 0 ]; then
+        echo "Some topics are unsubscribed from their email destinations. See above output"
         exit 1
       fi

--- a/ci/tasks/check-sns-topic-unsubscribers.yml
+++ b/ci/tasks/check-sns-topic-unsubscribers.yml
@@ -4,7 +4,7 @@ image_resource:
    source:
     repository: governmentdigitalservice/pay-concourse-runner
 params:
-  REGIONS: eu-west-1 eu-central-1 us-east-1
+  REGIONS: eu-west-1
 run:
   path: /bin/bash
   args:

--- a/ci/tasks/check-sns-topic-unsubscribers.yml
+++ b/ci/tasks/check-sns-topic-unsubscribers.yml
@@ -32,7 +32,7 @@ run:
             echo "If you can find the Zendesk email to resubscribe, do that; or"
             echo "If you can’t find it or it doesn’t work, talk to Starling"
 
-            any_failed=$((any_failed+=1))
+            any_failed=$((any_failed+1))
           fi
         done
       done

--- a/ci/tasks/check-sns-topic-unsubscribers.yml
+++ b/ci/tasks/check-sns-topic-unsubscribers.yml
@@ -12,13 +12,18 @@ run:
 
       any_failed=0
 
-      for REGION in eu-west-1 us-east-1 eu-central-1; do
-        while read -r TOPIC_ARN; do
+      REGIONS="eu-west-1 us-east-1 eu-central-1"
+
+      for REGION in $REGIONS; do
+        TOPIC_ARNS=$(aws sns --region "$REGION" list-topics --query "Topics[].TopicArn" | jq -r '.[]')
+
+        if [[ -z "$TOPIC_ARNS" ]]; then
+          echo "No SNS topics found in $REGION"
+          exit 1
+        fi
+
+        for TOPIC_ARN in $TOPIC_ARNS; do
           echo "Checking topic: $TOPIC_ARN in $REGION"
-          if [ "$TOPIC_ARN" == "None" ]; then
-            echo "No SNS topics found in $REGION"
-            exit 1
-          fi
 
           subscription_arn=$(aws sns --region "$REGION" list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" --query 'Subscriptions[].SubscriptionArn' --output text)
           if [ "$subscription_arn" == "Deleted" ] || [ "$subscription_arn" == "PendingConfirmation" ]; then
@@ -29,10 +34,11 @@ run:
 
             any_failed=$((any_failed+=1))
           fi
-        done < <(aws sns --region "$REGION" list-topics --query "Topics[].[TopicArn]" --output text)
+        done
       done
 
       if [ "$any_failed" -ne 0 ]; then
         echo "Some topics are unsubscribed from their email destinations. See above output"
         exit 1
       fi
+

--- a/ci/tasks/check-sns-topic-unsubscribers.yml
+++ b/ci/tasks/check-sns-topic-unsubscribers.yml
@@ -15,6 +15,9 @@ run:
       any_failed=0
 
       for REGION in $REGIONS; do
+        echo "Checking topics in $REGION"
+        echo "-------------------------------"
+
         TOPIC_ARNS=$(aws sns --region "$REGION" list-topics --query "Topics[].TopicArn" | jq -r '.[]')
 
         if [[ -z "$TOPIC_ARNS" ]]; then
@@ -23,7 +26,7 @@ run:
         fi
 
         for TOPIC_ARN in $TOPIC_ARNS; do
-          echo "Checking topic: $TOPIC_ARN in $REGION"
+          echo "Checking topic: $TOPIC_ARN"
 
           subscription_arn=$(aws sns --region "$REGION" list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" --query 'Subscriptions[].SubscriptionArn' --output text)
           if [ "$subscription_arn" == "Deleted" ] || [ "$subscription_arn" == "PendingConfirmation" ]; then
@@ -35,6 +38,8 @@ run:
             any_failed=$((any_failed+1))
           fi
         done
+
+        echo
       done
 
       if [ "$any_failed" -ne 0 ]; then


### PR DESCRIPTION
# What

1. Rewrote the sns checker to be a little more resilient and to check multiple regions as specified by the REGIONS parameter.
2. Set the checker to run every 15 minutes now we are much more dependent on these sns topics.

You can see the jobs running and working in the infra-drift-detector pipelines in dev and deploy teams