### PR TITLE
PP-11411-upgrade-concourse-script-containers-to-node-18

### DIFF
--- a/.github/workflows/test-run-codebuild.yml
+++ b/.github/workflows/test-run-codebuild.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16.14.0
+          node-version: 18.17.1
       - name: Install dependencies
         run: npm ci
         working-directory: 'ci/scripts/run-codebuild'

--- a/.github/workflows/test-run-codebuild.yml
+++ b/.github/workflows/test-run-codebuild.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 18.17.1
+          node-version: 18.18.0
       - name: Install dependencies
         run: npm ci
         working-directory: 'ci/scripts/run-codebuild'

--- a/ci/docker/node-runner/Dockerfile.node18
+++ b/ci/docker/node-runner/Dockerfile.node18
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine3.18@sha256:3482a20c97e401b56ac50ba8920cc7b5b2022bfc6aa7d4e4c231755770cf892f
+FROM node:18.18.0-alpine3.18@sha256:619ce27eb37c7c0476bd518085bf1ba892e2148fc1ab5dbaff2f20c56e50444d
 
 # As of node 15 the docker container fails to npm install without either a WORKDIR or -g
 WORKDIR /node-runner

--- a/ci/docker/node-runner/Dockerfile.node18
+++ b/ci/docker/node-runner/Dockerfile.node18
@@ -1,4 +1,4 @@
-FROM node:18.18.0-alpine3.18@sha256:619ce27eb37c7c0476bd518085bf1ba892e2148fc1ab5dbaff2f20c56e50444d
+FROM node:18.18.0-alpine3.18@sha256:28630a8b97ae8336d77b6dae5705bea816bdc1d6383901bb4495c521929a4091
 
 # As of node 15 the docker container fails to npm install without either a WORKDIR or -g
 WORKDIR /node-runner

--- a/ci/docker/node-runner/Dockerfile.node18
+++ b/ci/docker/node-runner/Dockerfile.node18
@@ -1,0 +1,10 @@
+FROM node:18.17.1-alpine3.18@sha256:3482a20c97e401b56ac50ba8920cc7b5b2022bfc6aa7d4e4c231755770cf892f
+
+# As of node 15 the docker container fails to npm install without either a WORKDIR or -g
+WORKDIR /node-runner
+
+RUN npm install -g aws-sdk@^2.x.x
+RUN npm install -g aws4@^1.x.x
+RUN npm install -g @octokit/rest@^18.x.x
+
+ENV NODE_PATH=/usr/local/lib/node_modules

--- a/ci/pipelines/node-runner.yml
+++ b/ci/pipelines/node-runner.yml
@@ -18,14 +18,14 @@ resources:
       paths:
         - ci/docker/node-runner/*
 
-  - name: node-runner-node16
+  - name: node-runner-node18
     type: registry-image
     icon: docker
     source:
       repository: governmentdigitalservice/pay-node-runner
       username: ((docker-username))
       password: ((docker-access-token))
-      tag: node16
+      tag: node18
 
   - name: pay-ci
     type: git
@@ -49,13 +49,13 @@ jobs:
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
       - in_parallel:
-        - task: build-node-16
+        - task: build-node-18
           privileged: true
           output_mapping:
-            image: node16-image
+            image: node18-image
           params:
             CONTEXT: node-runner-src/ci/docker/node-runner
-            DOCKERFILE: node-runner-src/ci/docker/node-runner/Dockerfile.node16
+            DOCKERFILE: node-runner-src/ci/docker/node-runner/Dockerfile.node18
             DOCKER_CONFIG: docker_creds
           config:
             platform: linux
@@ -71,9 +71,9 @@ jobs:
               path: build
       - in_parallel:
         - do:
-        - put: node-runner-node16
+        - put: node-runner-node18
           params:
-            image: node16-image/image.tar
+            image: node18-image/image.tar
           get_params:
             skip_download: true
 

--- a/ci/tasks/node-build-pr.yml
+++ b/ci/tasks/node-build-pr.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 16-bullseye-slim
+    tag: 18-bullseye-slim
 inputs:
   - name: src
 outputs:


### PR DESCRIPTION
## What
Node 16 is out of support. Move internal tooling to Node 18.

## How
Move Github actions from 16 to 18; build new Node 18 version of node-runner and have Concourse use it; use Node 18 for Concourse PR jobs.

Use Node18 runtime for logging Lambdas. They all pass their unit tests on Node 18.

I have run what scripts I could locally with Node 16 and 18 containers, and observed no difference.

I'VE LOOKED HARD BUT I MAY HAVE MISSED SOMETHING!