### PR TITLE
PP-11626: Replace alpine-curl-jq with concourse-runner

### DIFF
--- a/ci/tasks/publish-pacts.yml
+++ b/ci/tasks/publish-pacts.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: dwdraju/alpine-curl-jq
+    repository: governmentdigitalservice/pay-concourse-runner
 inputs:
   - name: src
   - name: pacts


### PR DESCRIPTION
We should be consistent with the tooling used for running the Concourse tasks. Also this base image hasn't been updated in some time.

The `governmentdigitalservice/pay-concourse-runner` image ([see Dockerfile here](https://github.com/alphagov/pay-ci/blob/master/ci/docker/concourse-runner/Dockerfile)) has `curl` and `jq` installed, and receives regular Dependabot updates.