### PR TITLE
PP-11459-create-stubs-ecs-pipeline

### DIFF
--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -1,0 +1,200 @@
+---
+resource_types:
+  # - name: cf-cli
+  #   type: docker-image
+  #   source:
+  #     repository: nulldriver/cf-cli-resource
+
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+resources:
+  - name: stubs-pipeline
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: PP-11459-create-stubs-ecs-pipeline
+      paths:
+        - ci/pipelines/stubs.yml
+
+  - name: stubs-src
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-stubs
+      branch: master
+      paths:
+        - ./*
+
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: PP-11459-create-stubs-ecs-pipeline
+
+  - name: pay-infra
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-infra
+      branch: master
+      username: alphagov-pay-ci-concourse
+      password: ((github-access-token))
+
+  - name: stubs-ecr-registry-deploy
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/stubs
+      aws_access_key_id: ((readonly_access_key_id))
+      aws_secret_access_key: ((readonly_secret_access_key))
+      aws_session_token: ((readonly_session_token))
+      aws_role_arn: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse
+      aws_ecr_registry_id: "((pay_aws_deploy_account_id))"
+      aws_region: eu-west-1
+
+  - name: slack-notification
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-notification-secret))
+
+jobs:
+  - name: set-pipeline
+    plan:
+      - get: stubs-pipeline
+        trigger: true
+      - set_pipeline: stubs
+        file: stubs-pipeline/ci/pipelines/stubs.yml
+
+  - name: deploy-stubs
+    plan:
+      - get: pay-ci
+      - get: pay-infra
+      - get: stubs-ecr-registry-deploy
+        passed: [build-and-push-stubs]
+        trigger: true
+      - task: assume-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/pay-concourse-stubs-deploy-tooling
+          AWS_ROLE_SESSION_NAME: terraform-deploy-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - load_var: stubs_image_tag
+        file: stubs-ecr-registry-deploy/tag
+      - task: deploy-stubs
+        file: pay-ci/ci/tasks/deploy-stubs.yml
+        params:
+          ACCOUNT: deploy
+          ENVIRONMENT: deploy-tooling
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          STUBS_IMAGE_TAG: ((.:stubs_image_tag))
+      - task: wait-for-deploy
+        file: pay-ci/ci/tasks/wait-for-deploy.yml
+        params:
+          ACCOUNT: deploy
+          APP_NAME: stubs
+          ENVIRONMENT: deploy-tooling
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-starling"
+        silent: true
+        text: ":red-circle: Failed to deploy stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-activity"
+        silent: true
+        text: ":green-circle: Deployed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
+  - name: build-and-deploy-stubs
+    plan:
+      - in_parallel:
+        - get: stubs-src
+          trigger: true
+        - get: pay-ci
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-access-token))
+          EMAIL: ((docker-email))
+      - task: get-stubs-image-tag
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: alpine
+              tag: latest
+          inputs:
+          - name: stubs-src
+          outputs:
+           - name: tags
+          run:
+            path: ash
+            args:
+              - -ec
+              - |
+                cat stubs-src/ci/docker/stubs/Dockerfile | grep -i FROM | head -n 1 | awk '{print $2;}' | cut -f 2 -d ":" | tee tags/tag
+      - task: build-stubs-image
+        privileged: true
+        params:
+          CONTEXT: stubs-src/ci/docker/stubs
+          DOCKER_CONFIG: docker_creds
+          UNPACK_ROOTFS: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: stubs-src
+            - name: docker_creds
+          outputs:
+            - name: image
+          run:
+            path: build
+      - put: stubs-ecr-registry-deploy
+        params:
+          image: image/image.tar
+          additional_tags: tags/tag
+        get_params:
+          skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-starling"
+        silent: true
+        text: ":red-circle: Failed to build and push stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-activity"
+        silent: true
+        text: ":green-circle: Built and pushed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -106,24 +106,24 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: "#govuk-pay-starling"
-        silent: true
-        text: ":red-circle: Failed to deploy stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: "#govuk-pay-activity"
-        silent: true
-        text: ":green-circle: Deployed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+    # on_failure:
+    #   put: slack-notification
+    #   attempts: 10
+    #   params:
+    #     channel: "#govuk-pay-starling"
+    #     silent: true
+    #     text: ":red-circle: Failed to deploy stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    #     icon_emoji: ":concourse:"
+    #     username: pay-concourse
+    # on_success:
+    #   put: slack-notification
+    #   attempts: 10
+    #   params:
+    #     channel: "#govuk-pay-activity"
+    #     silent: true
+    #     text: ":green-circle: Deployed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    #     icon_emoji: ":concourse:"
+    #     username: pay-concourse
 
   - name: build-and-deploy-stubs
     plan:
@@ -180,21 +180,21 @@ jobs:
           additional_tags: tags/tag
         get_params:
           skip_download: true
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: "#govuk-pay-starling"
-        silent: true
-        text: ":red-circle: Failed to build and push stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: "#govuk-pay-activity"
-        silent: true
-        text: ":green-circle: Built and pushed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+    # on_failure:
+    #   put: slack-notification
+    #   attempts: 10
+    #   params:
+    #     channel: "#govuk-pay-starling"
+    #     silent: true
+    #     text: ":red-circle: Failed to build and push stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    #     icon_emoji: ":concourse:"
+    #     username: pay-concourse
+    # on_success:
+    #   put: slack-notification
+    #   attempts: 10
+    #   params:
+    #     channel: "#govuk-pay-activity"
+    #     silent: true
+    #     text: ":green-circle: Built and pushed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    #     icon_emoji: ":concourse:"
+    #     username: pay-concourse

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -1,10 +1,5 @@
 ---
 resource_types:
-  # - name: cf-cli
-  #   type: docker-image
-  #   source:
-  #     repository: nulldriver/cf-cli-resource
-
   # - name: slack-notification
   #   type: docker-image
   #   source:
@@ -30,7 +25,7 @@ resources:
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
       paths:
-        - ./*
+        - "alpha-release-(.*)"
 
   - name: pay-ci
     type: git
@@ -146,24 +141,6 @@ jobs:
           USERNAME: ((docker-username))
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
-      # The Stubs image in Docker Hub is always tagged 'latest-master'
-      - task: get-stubs-image-tag
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: alpine
-              tag: latest
-          inputs:
-          - name: stubs-src
-          outputs:
-           - name: tags
-          run:
-            path: ash
-            args:
-              - -ec
-              - echo latest-master | tee tags/tag
       - task: build-stubs-image
         privileged: true
         params:

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -12,7 +12,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-11459-create-stubs-ecs-pipeline
+      branch: master
       paths:
         - ci/pipelines/stubs.yml
 
@@ -24,15 +24,14 @@ resources:
       branch: master
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
-      paths:
-        - "alpha-release-(.*)"
+      tag_regex: "alpha_release-(.*)"
 
   - name: pay-ci
     type: git
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-11459-create-stubs-ecs-pipeline
+      branch: master
 
   - name: pay-infra
     type: git
@@ -135,6 +134,8 @@ jobs:
         file: tags/release-sha
       - load_var: date
         file: tags/date
+      - load_var: release-tag
+        file: tags/tags
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -165,7 +166,7 @@ jobs:
       - put: stubs-ecr-registry-deploy
         params:
           image: image/image.tar
-          additional_tags: tags/tag
+          additional_tags: tags/tags
         get_params:
           skip_download: true
     # on_failure:

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -129,16 +129,24 @@ jobs:
 
   - name: build-and-push-stubs
     plan:
-      - in_parallel:
-        - get: stubs-src
-          trigger: true
-        - get: pay-ci
+      - get: stubs-src
+        trigger: true
+      - get: pay-ci
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: stubs-src
+      - load_var: release-sha
+        file: tags/release-sha
+      - load_var: date
+        file: tags/date
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
           USERNAME: ((docker-username))
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
+      # The Stubs image in Docker Hub is always tagged 'latest-master'
       - task: get-stubs-image-tag
         config:
           platform: linux
@@ -155,13 +163,15 @@ jobs:
             path: ash
             args:
               - -ec
-              - sed -n '/^FROM/s/^[^:]*:\(.*\)@.*/\1/p' stubs-src/ci/docker/stubs/Dockerfile | tee tags/tag
+              - echo latest-master | tee tags/tag
       - task: build-stubs-image
         privileged: true
         params:
-          CONTEXT: stubs-src
           DOCKER_CONFIG: docker_creds
+          CONTEXT: stubs-src
           UNPACK_ROOTFS: true
+          LABEL_release_sha: ((.:release-sha))
+          LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -153,8 +153,7 @@ jobs:
             path: ash
             args:
               - -ec
-              - |
-                cat stubs-src/ci/docker/stubs/Dockerfile | grep -i FROM | head -n 1 | awk '{print $2;}' | cut -f 2 -d ":" | tee tags/tag
+              - sed -n '/^FROM/s/^[^:]*:\(.*\)@.*/\1/p' stubs-src/ci/docker/stubs/Dockerfile | tee tags/tag
       - task: build-stubs-image
         privileged: true
         params:

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -27,6 +27,8 @@ resources:
     source:
       uri: https://github.com/alphagov/pay-stubs
       branch: master
+      username: alphagov-pay-ci-concourse
+      password: ((github-access-token))
       paths:
         - ./*
 
@@ -125,7 +127,7 @@ jobs:
     #     icon_emoji: ":concourse:"
     #     username: pay-concourse
 
-  - name: build-and-deploy-stubs
+  - name: build-and-push-stubs
     plan:
       - in_parallel:
         - get: stubs-src
@@ -157,7 +159,7 @@ jobs:
       - task: build-stubs-image
         privileged: true
         params:
-          CONTEXT: stubs-src/ci/docker/stubs
+          CONTEXT: stubs-src
           DOCKER_CONFIG: docker_creds
           UNPACK_ROOTFS: true
         config:

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -5,11 +5,11 @@ resource_types:
   #   source:
   #     repository: nulldriver/cf-cli-resource
 
-  - name: slack-notification
-    type: docker-image
-    source:
-      repository: cfcommunity/slack-notification-resource
-      tag: latest
+  # - name: slack-notification
+  #   type: docker-image
+  #   source:
+  #     repository: cfcommunity/slack-notification-resource
+  #     tag: latest
 
 resources:
   - name: stubs-pipeline
@@ -58,10 +58,10 @@ resources:
       aws_ecr_registry_id: "((pay_aws_deploy_account_id))"
       aws_region: eu-west-1
 
-  - name: slack-notification
-    type: slack-notification
-    source:
-      url: https://hooks.slack.com/services/((slack-notification-secret))
+  # - name: slack-notification
+  #   type: slack-notification
+  #   source:
+  #     url: https://hooks.slack.com/services/((slack-notification-secret))
 
 jobs:
   - name: set-pipeline

--- a/ci/tasks/deploy-stubs.yml
+++ b/ci/tasks/deploy-stubs.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+inputs:
+  - name: pay-infra
+image_resource:
+  type: registry-image
+  source:
+    repository: hashicorp/terraform
+    tag: 1.3.7
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:
+  AWS_REGION: eu-west-1
+  ACCOUNT:
+  ENVIRONMENT:
+  STUBS_IMAGE_TAG:
+run:
+  path: /bin/sh
+  args:
+    - -ec
+    - |
+      cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/environment/stubs
+      terraform init
+      terraform apply \
+        -var stubs_image_tag=${STUBS_IMAGE_TAG} \
+        -auto-approve
+       


### PR DESCRIPTION
## What

Add a pipeline to build and deploy the Stubs application in ECS.

A couple of things about this pipeline are "old". First, though we have other tickets to move tests into Github Actions, building from the Stubs `Dockerfile` runs tests in-place so, in this case, in Concourse. Second, the tag of the image is always `latest-master`. These don't seem ideal, but I chose to leave them as-is. I have, however, added code to put in build-date and Git SHA labels, in line with other repos.

[The pipeline currently in Concourse](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/stubs) has been deployed from my laptop. The deploy phase is not expected to work, as it currently has nothing to deploy to. The ECS service is defined in https://github.com/alphagov/pay-infra/pull/4547, which is not yet applied.

The Slack notifications are commented out, so as not to add noise whilst things are being debugged. I will uncomment them in a separate PR once we're up and running.
