### PR TITLE
PP-11704: add timestamp tags to notifications and webhooks

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4924,6 +4924,8 @@ jobs:
           file: tags/release-sha
         - load_var: release-tag
           file: tags/tags
+        - load_var: date
+          file: tags/date
       - task: build-jar
         config:
           container_limits: {}
@@ -5499,8 +5501,17 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: notifications-git-release
-      - load_var: release-tag
-        file: tags/tags
+      - in_parallel:
+        - load_var: release-name
+          file: notifications-git-release/.git/ref
+        - load_var: release-tag
+          file: tags/tags
+        - load_var: release-number
+          file: tags/release-number
+        - load_var: release-sha
+          file: tags/release-sha
+        - load_var: date
+          file: tags/date
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
@@ -5512,6 +5523,10 @@ jobs:
         params:
           DOCKER_CONFIG: docker_creds
           CONTEXT: notifications-git-release
+          LABEL_release_number: ((.:release-number))
+          LABEL_release_name: ((.:release-name))
+          LABEL_release_sha: ((.:release-sha))
+          LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:
@@ -5527,7 +5542,7 @@ jobs:
       - put: notifications-ecr-registry-test
         params:
           image: image/image.tar
-          additional_tags: tags/tags
+          additional_tags: tags/all-release-tags
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4958,6 +4958,7 @@ jobs:
           LABEL_release_number: ((.:release-number))
           LABEL_release_name: ((.:release-name))
           LABEL_release_sha: ((.:release-sha))
+          LABEL_build_date: ((.:date))
         config:
           platform: linux
           image_resource:
@@ -4975,7 +4976,7 @@ jobs:
         - put: webhooks-ecr-registry-test
           params:
             image: image/image.tar
-            additional_tags: tags/tags
+            additional_tags: tags/all-release-tags
           get_params:
             skip_download: true
         - put: webhooks-dockerhub


### PR DESCRIPTION
Adding build date labels and tags to webhooks and notifications images before they are pushed to ECR in test.
Some extra docker labels were added to follow the other images.

Pipeline changes can be checked by:
`fly --target pay-dev set-pipeline --config ci/pipelines/deploy-to-test.yml --pipeline deploy-to-test`