### PR TITLE
BAU: Pin node-runner image to Node 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+    - dependency-name: "node"
+      versions:
+        - ">= 19"
   open-pull-requests-limit: 10
   labels:
     - dependencies


### PR DESCRIPTION
We're using Node18 everywhere at the moment - the `node-runner` helper image should align with this.