### PR TITLE
PP-11703: Start perf DBs for weekly maintenance window

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -95,7 +95,6 @@ resources:
       start: "03:15"
       stop: "03:25"
       days: [Sunday]
-      initial_version: true
 
   - name: every-sunday-at-0450
     type: time
@@ -105,7 +104,6 @@ resources:
       start: "04:50"
       stop: "05:00"
       days: [Sunday]
-      initial_version: true
 
 resource_types:
   - name: slack-notification

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -87,6 +87,26 @@ resources:
       location: Europe/London
     type: time
 
+  - name: every-sunday-at-0315
+    type: time
+    icon: alarm
+    source:
+      location: UTC
+      start: "03:15"
+      stop: "03:25"
+      days: [Sunday]
+      initial_version: true
+
+  - name: every-sunday-at-0450
+    type: time
+    icon: alarm
+    source:
+      location: UTC
+      start: "04:50"
+      stop: "05:00"
+      days: [Sunday]
+      initial_version: true
+
 resource_types:
   - name: slack-notification
     type: docker-image
@@ -870,7 +890,10 @@ jobs:
     serial: true
     serial_groups: [perf-tests]
     plan:
-      - get: pay-ci
+      - in_parallel:
+        - get: pay-ci
+        - get: every-sunday-at-0315
+          trigger: true
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -929,7 +952,10 @@ jobs:
     serial: true
     serial_groups: [perf-tests]
     plan:
-      - get: pay-ci
+      - in_parallel:
+        - get: pay-ci
+        - get: every-sunday-at-0450
+          trigger: true
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:


### PR DESCRIPTION
Start perf databases during the weekly maintenance window to ensure AWS can apply minor updates and OS security patches etc.

You can see this applied https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests