### PR TITLE
PP-11873-scale-stubs-when-perf-test-run

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -147,15 +147,24 @@ groups:
 definitions:
   - &scale-down-services
     in_parallel:
-      - task: scale-down-stubs
-        file: pay-ci/ci/tasks/scale-fargate-service.yml
-        params:
-          SERVICE_NAME: stubs
-          SCALE_DIRECTION: in
-          DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_down_to.stubs))
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - do: # Stubs is in the deploy account
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/pay-concourse-stubs-deploy-tooling
+            AWS_ROLE_SESSION_NAME: terraform-deploy-assume-role
+        - load_var: deploy-role
+          file: assume-role/assume-role.json
+        - task: scale-down-stubs
+          file: pay-ci/ci/tasks/scale-fargate-service.yml
+          params:
+            SERVICE_NAME: stubs
+            ECS_CLUSTER: deploy-tooling
+            SCALE_DIRECTION: in
+            DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_down_to.stubs))
+            AWS_ACCESS_KEY_ID: ((.:deploy-role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:deploy-role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:deploy-role.AWS_SESSION_TOKEN)
       - task: scale-down-adminusers
         file: pay-ci/ci/tasks/scale-fargate-service.yml
         params:
@@ -404,15 +413,24 @@ definitions:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - task: scale-up-stubs
-        file: pay-ci/ci/tasks/scale-fargate-service.yml
-        params:
-          SERVICE_NAME: stubs
-          SCALE_DIRECTION: out
-          DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_up_to.stubs))
-          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - do: # Stubs is in the deploy account
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/pay-concourse-stubs-deploy-tooling
+            AWS_ROLE_SESSION_NAME: terraform-deploy-assume-role
+        - load_var: deploy-role-stubs
+          file: assume-role/assume-role.json
+        - task: scale-up-stubs
+          file: pay-ci/ci/tasks/scale-fargate-service.yml
+          params:
+            SERVICE_NAME: stubs
+            ECS_CLUSTER: deploy-tooling
+            SCALE_DIRECTION: out
+            DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_up_to.stubs))
+            AWS_ACCESS_KEY_ID: ((.:deploy-role-stubs.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:deploy-role-stubs.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:deploy-role-stubs.AWS_SESSION_TOKEN)
       - do:
         - task: scale-up-webhooks-egress
           file: pay-ci/ci/tasks/scale-fargate-service.yml

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -158,12 +158,15 @@ groups:
 definitions:
   - &scale-down-services
     in_parallel:
-      - put: scale-down-stubs
-        resource: paas
+      - task: scale-down-stubs
+        file: pay-ci/ci/tasks/scale-fargate-service.yml
         params:
-          command: scale
-          app_name: pay-stubs
-          instances: ((.:service-volumes.scale_down_to.stubs))
+          SERVICE_NAME: stubs
+          SCALE_DIRECTION: in
+          DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_down_to.stubs))
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: scale-down-adminusers
         file: pay-ci/ci/tasks/scale-fargate-service.yml
         params:
@@ -413,11 +416,14 @@ definitions:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - put: scale-up-stubs
-        resource: paas
+        file: pay-ci/ci/tasks/scale-fargate-service.yml
         params:
-          command: scale
-          app_name: pay-stubs
-          instances: ((.:service-volumes.scale_up_to.stubs))
+          SERVICE_NAME: stubs
+          SCALE_DIRECTION: out
+          DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_up_to.stubs))
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - do:
         - task: scale-up-webhooks-egress
           file: pay-ci/ci/tasks/scale-fargate-service.yml

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -404,7 +404,7 @@ definitions:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-      - put: scale-up-stubs
+      - task: scale-up-stubs
         file: pay-ci/ci/tasks/scale-fargate-service.yml
         params:
           SERVICE_NAME: stubs

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -68,17 +68,6 @@ resources:
     source:
       url: https://hooks.slack.com/services/((slack-notification-secret))
 
-  - name: paas
-    type: cf-cli
-    icon: cloud-upload-outline
-    source:
-      api: https://api.cloud.service.gov.uk
-      org: govuk-pay
-      space: build
-      username: ((cf-username))
-      password: ((cf-password))
-      cf_cli_version: 7
-
   - name: every-night-at-11pm
     icon: alarm
     source:

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -159,12 +159,12 @@ definitions:
           file: pay-ci/ci/tasks/scale-fargate-service.yml
           params:
             SERVICE_NAME: stubs
-            ECS_CLUSTER: deploy-tooling
+            ECS_CLUSTER: deploy-tooling-fargate
             SCALE_DIRECTION: in
             DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_down_to.stubs))
             AWS_ACCESS_KEY_ID: ((.:deploy-role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:deploy-role.AWS_SECRET_ACCESS_KEY))
-            AWS_SESSION_TOKEN: ((.:deploy-role.AWS_SESSION_TOKEN)
+            AWS_SESSION_TOKEN: ((.:deploy-role.AWS_SESSION_TOKEN))
       - task: scale-down-adminusers
         file: pay-ci/ci/tasks/scale-fargate-service.yml
         params:
@@ -425,12 +425,12 @@ definitions:
           file: pay-ci/ci/tasks/scale-fargate-service.yml
           params:
             SERVICE_NAME: stubs
-            ECS_CLUSTER: deploy-tooling
+            ECS_CLUSTER: deploy-tooling-fargate
             SCALE_DIRECTION: out
             DESIRED_HEALTHY_INSTANCES: ((.:service-volumes.scale_up_to.stubs))
             AWS_ACCESS_KEY_ID: ((.:deploy-role-stubs.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:deploy-role-stubs.AWS_SECRET_ACCESS_KEY))
-            AWS_SESSION_TOKEN: ((.:deploy-role-stubs.AWS_SESSION_TOKEN)
+            AWS_SESSION_TOKEN: ((.:deploy-role-stubs.AWS_SESSION_TOKEN))
       - do:
         - task: scale-up-webhooks-egress
           file: pay-ci/ci/tasks/scale-fargate-service.yml


### PR DESCRIPTION
Scale Stubs in ECS rather than in PAAS when we run the perf-test pipeline.

You can see successful scale-up and scale-downs:
* https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-all/builds/61.15
* https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-all/builds/27.2

This change will not work without the IAM changes in https://github.com/alphagov/pay-infra/pull/4617