### PR TITLE
BAU: increase db startup & shutdown timeouts

### DIFF
--- a/ci/tasks/start-rds-instance.yml
+++ b/ci/tasks/start-rds-instance.yml
@@ -36,7 +36,12 @@ run:
         aws rds start-db-instance --db-instance-identifier "${RDS_INSTANCE_NAME}" >> /dev/null
       fi
 
+      # You can't change how long 'aws rds wait' waits, in total it waits for 30 minutes, but we want to
+      # wait for 60 minutes, so if it fails the first time we will run it again.
       echo "Waiting for RDS instance ${RDS_INSTANCE_NAME} to be available"
-      aws rds wait db-instance-available --db-instance-identifier "${RDS_INSTANCE_NAME}"
+      if ! aws rds wait db-instance-available --db-instance-identifier "${RDS_INSTANCE_NAME}"; then
+        echo "Still not available after 30 minutes, waiting another 30 minutes"
+        aws rds wait db-instance-available --db-instance-identifier "${RDS_INSTANCE_NAME}"
+      fi
 
       echo "RDS instance ${RDS_INSTANCE_NAME} is now available"

--- a/ci/tasks/stop-rds-instance.yml
+++ b/ci/tasks/stop-rds-instance.yml
@@ -7,7 +7,7 @@ image_resource:
 params:
   RDS_INSTANCE_NAME:
   AWS_DEFAULT_REGION: eu-west-1
-  MAX_ATTEMPTS: 140 # 40 minutes
+  MAX_ATTEMPTS: 240 # 60 minutes
 run:
   path: /bin/bash
   args:


### PR DESCRIPTION
The RDS instances sometimes take a long time to startup/shutdown, on some occasions AWS decides to do a backup at startup, or shutdown, and our waiting period isn't long enough for it to complete.

Increase waiting periods for both startup and shutdown to 1 hour.