### PR TITLE
PP-11279: Run connector-as-consumer pact test against adminusers-as-p…

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -608,6 +608,7 @@ jobs:
           path: src
           status: pending
           context: app-as-consumer pact verification
+      - get: adminusers-master
       - get: ledger-master
       - get: cardid-master
         params: { submodules: none }
@@ -615,6 +616,13 @@ jobs:
         params:
           consumer: connector
       - in_parallel:
+        - <<: *pact-provider-verification
+          task: adminusers-provider-pact-verification
+          input_mapping:
+            test_target: adminusers-master
+          params:
+            consumer: connector
+            provider: adminusers
         - <<: *pact-provider-verification
           task: ledger-provider-pact-verification
           input_mapping:


### PR DESCRIPTION
…rovider

This is because we now have a [messaging pact
test](https://github.com/alphagov/pay-connector/pull/4837) where connector is the consumer and adminusers is the provider.