### PR TITLE
PP-10714: Update concourse runner docker helpers sanitize cgroups

### DIFF
--- a/ci/docker/concourse-runner-with-java-17/docker-helpers.sh
+++ b/ci/docker/concourse-runner-with-java-17/docker-helpers.sh
@@ -7,6 +7,10 @@ SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
 STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
 
 sanitize_cgroups() {
+  if [ -e /sys/fs/cgroup/cgroup.controllers ]; then
+    return
+  fi
+
   mkdir -p /sys/fs/cgroup
   mountpoint -q /sys/fs/cgroup || \
     mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
@@ -45,7 +49,7 @@ sanitize_cgroups() {
     fi
   done
 
-  if ! test -e /sys/fs/cgroup/systemd ; then
+  if [ ! -e /sys/fs/cgroup/systemd ] && [ $(cat /proc/self/cgroup | grep '^1:name=openrc:' | wc -l) -eq 0 ]; then
     mkdir /sys/fs/cgroup/systemd
     mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
   fi

--- a/ci/docker/concourse-runner/docker-helpers.sh
+++ b/ci/docker/concourse-runner/docker-helpers.sh
@@ -7,6 +7,10 @@ SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
 STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
 
 sanitize_cgroups() {
+  if [ -e /sys/fs/cgroup/cgroup.controllers ]; then
+    return
+  fi
+
   mkdir -p /sys/fs/cgroup
   mountpoint -q /sys/fs/cgroup || \
     mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
@@ -45,7 +49,7 @@ sanitize_cgroups() {
     fi
   done
 
-  if ! test -e /sys/fs/cgroup/systemd ; then
+  if [ ! -e /sys/fs/cgroup/systemd ] && [ $(cat /proc/self/cgroup | grep '^1:name=openrc:' | wc -l) -eq 0 ]; then
     mkdir /sys/fs/cgroup/systemd
     mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
   fi


### PR DESCRIPTION
Updated the sanitize crgroups method to match the latest version https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh which provides cgroups v2 support