### PR TITLE
BAU: The stubs ecr registry image needs the variant filter

### DIFF
--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -47,6 +47,7 @@ resources:
     icon: docker
     source:
       repository: govukpay/stubs
+      variant: release
       aws_access_key_id: ((readonly_access_key_id))
       aws_secret_access_key: ((readonly_secret_access_key))
       aws_session_token: ((readonly_session_token))


### PR DESCRIPTION
Add the variant release filter to the stubs ecr registry image.

Without this we get an empty list of resources and it makes the deploy stubs pipeline impossible to pin the ecr image.