### PR TITLE
PP-11895 Pull postgres 15.2 for provider contract tests

### DIFF
--- a/.github/workflows/_run-provider-contract-tests.yml
+++ b/.github/workflows/_run-provider-contract-tests.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           docker pull govukpay/postgres:11.1
           docker pull postgres:11.16
+          docker pull postgres:15.2
       - name: Set Pact Provider Version
         id: set-pact-provider-version
         run: |


### PR DESCRIPTION
## WHAT
- Pull postgres 15.2 along with 11.16 when running provider contract tests. We can remove 11.16 once all apps have been updated to use postgres 15.2