### PR TITLE
BAU: Move daily perf tests to a more carbon-friendly time

### DIFF
--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -68,11 +68,11 @@ resources:
     source:
       url: https://hooks.slack.com/services/((slack-notification-secret))
 
-  - name: every-night-at-11pm
+  - name: every-morning-at-4am
     icon: alarm
     source:
-      start: "23:00"
-      stop: "23:30"
+      start: "04:00"
+      stop: "04:30"
       location: Europe/London
     type: time
 
@@ -80,7 +80,7 @@ resources:
     type: time
     icon: alarm
     source:
-      location: UTC
+      location: Europe/London
       start: "03:15"
       stop: "03:25"
       days: [Sunday]
@@ -89,7 +89,7 @@ resources:
     type: time
     icon: alarm
     source:
-      location: UTC
+      location: Europe/London
       start: "04:50"
       stop: "05:00"
       days: [Sunday]
@@ -599,7 +599,7 @@ jobs:
         - get: perf-tests-ecr-release
         - get: perf-tests-git-release
         - get: pay-ci
-        - get: every-night-at-11pm
+        - get: every-morning-at-4am
           trigger: true
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml


### PR DESCRIPTION
1. Move the nightly perf tests to 4am since it's a more carbon emissions friendly time than 11pm.

Change the other schedules in the perf-tests pipeline to run using Europe/London timezone instead of UTC to ensure the trigger times don't overlap and make more sense when we view them in the UI.