### PR TITLE
PP-10386-build-cardid-in-codebuild

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4450,7 +4450,7 @@ jobs:
               - -ec
               - |
                 apk add --quiet --no-progress git
-                sed -i "s/git@github.com:/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+                sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
                 git submodule init -q data
                 git submodule update data
                 sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
@@ -4493,11 +4493,19 @@ jobs:
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
       - in_parallel:    
-        - task: run-codebuild-cardid
+        - task: run-codebuild-cardid-amd64
           attempts: 3
           file: pay-ci/ci/tasks/run-codebuild.yml
           params:
-            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/cardid.json"
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/cardid-amd64.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        - task: run-codebuild-cardid-armv8
+          attempts: 3
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/cardid-armv8.json"
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -118,7 +118,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: PP-10386-build-cardid-in-codebuild
   - name: adot-git-release
     type: git
     icon: github
@@ -4445,10 +4445,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-          RELEASE_NUMBER: ((.release-number)
-          RELEASE_NAME: ((.release-name))
-          RELEASE_SHA: ((.release-sha)
-          BUILD_DATE: ((.date)
+          RELEASE_NUMBER: ((.:release-number)
+          RELEASE_NAME: ((.:release-name))
+          RELEASE_SHA: ((.:release-sha)
+          BUILD_DATE: ((.:date)
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4428,39 +4428,11 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: cardid-git-release
-      - task: update-submodule
-        config:
-          container_limits: {}
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: alpine
-              tag: 3.16
-          inputs:
-            - name: cardid-git-release
-          params:
-            GH_ACCESS_TOKEN: ((github-access-token))
-          outputs:
-            - name: cardid-git-release-with-submodules
-          run:
-            path: ash
-            dir: cardid-git-release
-            args:
-              - -ec
-              - |
-                apk add --quiet --no-progress git
-                sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
-                git submodule init -q data
-                git submodule update data
-                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
-                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
-                cp -r . ../cardid-git-release-with-submodules
       - in_parallel:
         - load_var: release-number
           file: tags/release-number
         - load_var: release-name
-          file: cardid-git-release-with-submodules/.git/ref
+          file: cardid-git-release/.git/ref
         - load_var: release-sha
           file: tags/release-sha
         - load_var: candidate-image-tag

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -118,7 +118,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: PP-10386-build-cardid-in-codebuild
   - name: adot-git-release
     type: git
     icon: github
@@ -828,7 +828,6 @@ groups:
       - smoke-test-cardid
       - cardid-pact-tag
       - push-cardid-to-staging-ecr
-      - codebuild-cardid
   - name: connector
     jobs:
       - build-and-push-connector-candidate
@@ -4416,7 +4415,8 @@ jobs:
           image: selfservice-ecr-registry-test/image.tar
           additional_tags: selfservice-ecr-registry-test/tag
 
-  - name: codebuild-cardid
+  - name: build-and-push-cardid-candidate
+  # - name: codebuild-cardid
     plan:
       - in_parallel:
         - get: pay-ci
@@ -4490,113 +4490,113 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
-  - name: build-and-push-cardid-candidate
-    plan:
-      - in_parallel:
-        - get: pay-ci
-        - get: cardid-git-release
-          trigger: true
-          params:
-            submodules: none
-      - task: update-submodule
-        config:
-          container_limits: {}
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: alpine
-              tag: 3.16
-          inputs:
-            - name: cardid-git-release
-          params:
-            GH_ACCESS_TOKEN: ((github-access-token))
-          outputs:
-            - name: cardid-git-release-with-submodules
-          run:
-            path: ash
-            dir: cardid-git-release
-            args:
-              - -ec
-              - |
-                apk add --quiet --no-progress git
-                # rewrite the submodule url for https to add the token.
-                # The risk of setting the token in the url is mitigated since these files are not committed,
-                # the container is ephemeral and anyone with access to read the files could read the token from
-                # environment variable. Furthermore we redact the token from the files after the update.
-                sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
-                git submodule init -q data
-                git submodule update data
-                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
-                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
+  # - name: build-and-push-cardid-candidate
+  #   plan:
+  #     - in_parallel:
+  #       - get: pay-ci
+  #       - get: cardid-git-release
+  #         trigger: true
+  #         params:
+  #           submodules: none
+  #     - task: update-submodule
+  #       config:
+  #         container_limits: {}
+  #         platform: linux
+  #         image_resource:
+  #           type: registry-image
+  #           source:
+  #             repository: alpine
+  #             tag: 3.16
+  #         inputs:
+  #           - name: cardid-git-release
+  #         params:
+  #           GH_ACCESS_TOKEN: ((github-access-token))
+  #         outputs:
+  #           - name: cardid-git-release-with-submodules
+  #         run:
+  #           path: ash
+  #           dir: cardid-git-release
+  #           args:
+  #             - -ec
+  #             - |
+  #               apk add --quiet --no-progress git
+  #               # rewrite the submodule url for https to add the token.
+  #               # The risk of setting the token in the url is mitigated since these files are not committed,
+  #               # the container is ephemeral and anyone with access to read the files could read the token from
+  #               # environment variable. Furthermore we redact the token from the files after the update.
+  #               sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+  #               git submodule init -q data
+  #               git submodule update data
+  #               sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
+  #               sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
 
-                cp -r . ../cardid-git-release-with-submodules
-      - task: parse-release-tag
-        file: pay-ci/ci/tasks/parse-release-tag.yml
-        input_mapping:
-          git-release: cardid-git-release
-      - in_parallel:
-        - load_var: release-number
-          file: tags/release-number
-        - load_var: release-name
-          file: cardid-git-release-with-submodules/.git/ref
-        - load_var: release-sha
-          file: tags/release-sha
-        - load_var: candidate-image-tag
-          file: tags/candidate-tag
-        - load_var: date
-          file: tags/date
-      - task: generate-docker-creds-config
-        file: pay-ci/ci/tasks/generate-docker-config-file.yml
-        params:
-          USERNAME: ((docker-username))
-          PASSWORD: ((docker-access-token))
-          EMAIL: ((docker-email))
-      - task: build-image
-        privileged: true
-        params:
-          DOCKER_CONFIG: docker_creds
-          LABEL_release_number: ((.:release-number))
-          LABEL_release_name: ((.:release-name))
-          LABEL_release_sha: ((.:release-sha))
-          LABEL_build_date: ((.:date))
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: concourse/oci-build-task
-          inputs:
-            - name: cardid-git-release-with-submodules
-              path: .
-          outputs:
-            - name: image
-          run:
-            path: build
-      - put: cardid-candidate
-        params:
-          image: image/image.tar
-          additional_tags: tags/all-candidate-tags
-        get_params:
-          skip_download: true
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: cardid candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':hammer: cardid candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+  #               cp -r . ../cardid-git-release-with-submodules
+  #     - task: parse-release-tag
+  #       file: pay-ci/ci/tasks/parse-release-tag.yml
+  #       input_mapping:
+  #         git-release: cardid-git-release
+  #     - in_parallel:
+  #       - load_var: release-number
+  #         file: tags/release-number
+  #       - load_var: release-name
+  #         file: cardid-git-release-with-submodules/.git/ref
+  #       - load_var: release-sha
+  #         file: tags/release-sha
+  #       - load_var: candidate-image-tag
+  #         file: tags/candidate-tag
+  #       - load_var: date
+  #         file: tags/date
+  #     - task: generate-docker-creds-config
+  #       file: pay-ci/ci/tasks/generate-docker-config-file.yml
+  #       params:
+  #         USERNAME: ((docker-username))
+  #         PASSWORD: ((docker-access-token))
+  #         EMAIL: ((docker-email))
+  #     - task: build-image
+  #       privileged: true
+  #       params:
+  #         DOCKER_CONFIG: docker_creds
+  #         LABEL_release_number: ((.:release-number))
+  #         LABEL_release_name: ((.:release-name))
+  #         LABEL_release_sha: ((.:release-sha))
+  #         LABEL_build_date: ((.:date))
+  #       config:
+  #         platform: linux
+  #         image_resource:
+  #           type: registry-image
+  #           source:
+  #             repository: concourse/oci-build-task
+  #         inputs:
+  #           - name: cardid-git-release-with-submodules
+  #             path: .
+  #         outputs:
+  #           - name: image
+  #         run:
+  #           path: build
+  #     - put: cardid-candidate
+  #       params:
+  #         image: image/image.tar
+  #         additional_tags: tags/all-candidate-tags
+  #       get_params:
+  #         skip_download: true
+  #   on_failure:
+  #     put: slack-notification
+  #     attempts: 10
+  #     params:
+  #       channel: '#govuk-pay-announce'
+  #       silent: true
+  #       text: ':red-circle: cardid candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+  #       icon_emoji: ":concourse:"
+  #       username: pay-concourse
+  #   on_success:
+  #     put: slack-notification
+  #     attempts: 10
+  #     params:
+  #       channel: '#govuk-pay-activity'
+  #       silent: true
+  #       text: ':hammer: cardid candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+  #       icon_emoji: ":concourse:"
+  #       username: pay-concourse
 
   - name: run-cardid-e2e
     plan:
@@ -4604,8 +4604,8 @@ jobs:
         - get: cardid-candidate
           params:
             format: oci
-          trigger: true
-          passed: [build-and-push-cardid-candidate]
+          # trigger: true
+          # passed: [build-and-push-cardid-candidate]
         - get: pay-ci
       - in_parallel:
         - task: parse-candidate-tag

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4439,6 +4439,11 @@ jobs:
           file: tags/candidate-tag
         - load_var: date
           file: tags/date
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
+            AWS_ROLE_SESSION_NAME: e2e-test-assume-role
       - load_var: role
         file: assume-role/assume-role.json
         format: json

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4415,6 +4415,48 @@ jobs:
           image: selfservice-ecr-registry-test/image.tar
           additional_tags: selfservice-ecr-registry-test/tag
 
+  - name: codebuild-cardid-candidate
+    plan:
+      - in_parallel:
+        - get: pay-ci
+        - get: cardid-git-release
+          trigger: false # TODO change this when we're done
+          params:
+            submodules: none
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: cardid-git-release
+      - in_parallel:
+        - load_var: release-number
+          file: tags/release-number
+        - load_var: release-name
+          file: cardid-git-release-with-submodules/.git/ref
+        - load_var: release-sha
+          file: tags/release-sha
+        - load_var: candidate-image-tag
+          file: tags/candidate-tag
+        - load_var: date
+          file: tags/date
+      - task: prepare-codebuild
+        file: pay-ci/ci/tasks/prepare-codebuild-multiarch.yml
+        params:
+          PROJECT_TO_BUILD: cardid
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          RELEASE_NUMBER: ((.release-number)
+          RELEASE_NAME: ((.release-name))
+          RELEASE_SHA: ((.release-sha)
+          BUILD_DATE: ((.date)
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-access-token))
+          EMAIL: ((docker-email))
+      - task: build-image
+
   - name: build-and-push-cardid-candidate
     plan:
       - in_parallel:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4428,11 +4428,39 @@ jobs:
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: cardid-git-release
+      - task: update-submodule
+        config:
+          container_limits: {}
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: alpine
+              tag: 3.16
+          inputs:
+            - name: cardid-git-release
+          params:
+            GH_ACCESS_TOKEN: ((github-access-token))
+          outputs:
+            - name: cardid-git-release-with-submodules
+          run:
+            path: ash
+            dir: cardid-git-release
+            args:
+              - -ec
+              - |
+                apk add --quiet --no-progress git
+                sed -i "s/git@github.com:/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+                git submodule init -q data
+                git submodule update data
+                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
+                sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
+                cp -r . ../cardid-git-release-with-submodules
       - in_parallel:
         - load_var: release-number
           file: tags/release-number
-        # - load_var: release-name
-        #   file: cardid-git-release-with-submodules/.git/ref
+        - load_var: release-name
+          file: cardid-git-release-with-submodules/.git/ref
         - load_var: release-sha
           file: tags/release-sha
         - load_var: candidate-image-tag
@@ -4442,8 +4470,8 @@ jobs:
         - task: assume-role
           file: pay-ci/ci/tasks/assume-role.yml
           params:
-            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
-            AWS_ROLE_SESSION_NAME: e2e-test-assume-role
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
+            AWS_ROLE_SESSION_NAME: codebuild-assume-role
       - load_var: role
         file: assume-role/assume-role.json
         format: json
@@ -4454,17 +4482,25 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-          RELEASE_NUMBER: ((.:release-number)
-          # RELEASE_NAME: ((.:release-name))
-          RELEASE_NAME: dummy-name
-          RELEASE_SHA: ((.:release-sha)
-          BUILD_DATE: ((.:date)
+          RELEASE_NUMBER: ((.:release-number))
+          RELEASE_NAME: ((.:release-name))
+          RELEASE_SHA: ((.:release-sha))
+          BUILD_DATE: ((.:date))
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
         params:
           USERNAME: ((docker-username))
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
+      - in_parallel:    
+        - task: run-codebuild-cardid
+          attempts: 3
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/cardid.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: build-and-push-cardid-candidate
     plan:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -118,7 +118,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-10386-build-cardid-in-codebuild
+      branch: master
   - name: adot-git-release
     type: git
     icon: github

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4509,6 +4509,14 @@ jobs:
             AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: run-codebuild-cardid-manifest
+        attempts: 3
+        file: pay-ci/ci/tasks/run-codebuild.yml
+        params:
+          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/cardid-manifest.json"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   - name: build-and-push-cardid-candidate
     plan:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -828,6 +828,7 @@ groups:
       - smoke-test-cardid
       - cardid-pact-tag
       - push-cardid-to-staging-ecr
+      - codebuild-cardid
   - name: connector
     jobs:
       - build-and-push-connector-candidate
@@ -4415,7 +4416,7 @@ jobs:
           image: selfservice-ecr-registry-test/image.tar
           additional_tags: selfservice-ecr-registry-test/tag
 
-  - name: codebuild-cardid-candidate
+  - name: codebuild-cardid
     plan:
       - in_parallel:
         - get: pay-ci
@@ -4430,14 +4431,17 @@ jobs:
       - in_parallel:
         - load_var: release-number
           file: tags/release-number
-        - load_var: release-name
-          file: cardid-git-release-with-submodules/.git/ref
+        # - load_var: release-name
+        #   file: cardid-git-release-with-submodules/.git/ref
         - load_var: release-sha
           file: tags/release-sha
         - load_var: candidate-image-tag
           file: tags/candidate-tag
         - load_var: date
           file: tags/date
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-codebuild-multiarch.yml
         params:
@@ -4446,7 +4450,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
           RELEASE_NUMBER: ((.:release-number)
-          RELEASE_NAME: ((.:release-name))
+          # RELEASE_NAME: ((.:release-name))
+          RELEASE_NAME: dummy-name
           RELEASE_SHA: ((.:release-sha)
           BUILD_DATE: ((.:date)
       - task: generate-docker-creds-config
@@ -4455,7 +4460,6 @@ jobs:
           USERNAME: ((docker-username))
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
-      - task: build-image
 
   - name: build-and-push-cardid-candidate
     plan:

--- a/ci/tasks/prepare-codebuild-multiarch.yml
+++ b/ci/tasks/prepare-codebuild-multiarch.yml
@@ -27,10 +27,25 @@ run:
     - pipefail
     - -c
     - |
-      echo "Writing CodeBuild configuration"
-      cat <<EOF | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}.json
+      echo "Writing amd64 CodeBuild configuration"
+      cat <<EOAMD | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}-amd64.json
       {
         "projectName": "pay-${PROJECT_TO_BUILD}-amd64",
+        "sourceVersion": "${RELEASE_SHA}",
+        "secondarySourcesVersions": {},
+        "environmentVariables": {
+          "RELEASE_NUMBER": "${RELEASE_NUMBER}",
+          "RELEASE_NAME": "${RELEASE_NAME}",
+          "RELEASE_SHA": "${RELEASE_SHA}",
+          "BUILD_DATE": "${BUILD_DATE}"
+        }
+      }
+      EOAMD
+
+      echo "Writing armv8 CodeBuild configuration"
+      cat <<EOF | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}-armv8.json
+      {
+        "projectName": "pay-${PROJECT_TO_BUILD}-armv8",
         "sourceVersion": "${RELEASE_SHA}",
         "secondarySourcesVersions": {},
         "environmentVariables": {

--- a/ci/tasks/prepare-codebuild-multiarch.yml
+++ b/ci/tasks/prepare-codebuild-multiarch.yml
@@ -60,7 +60,7 @@ run:
       echo "Writing manifest CodeBuild configuration"
       cat <<EOF | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}-manifest.json
       {
-        "projectName": "pay-${PROJECT_TO_BUILD}-armv8",
+        "projectName": "pay-${PROJECT_TO_BUILD}-manifest",
         "secondarySourcesVersions": {},
         "environmentVariables": {
           "RELEASE_NUMBER": "${RELEASE_NUMBER}",

--- a/ci/tasks/prepare-codebuild-multiarch.yml
+++ b/ci/tasks/prepare-codebuild-multiarch.yml
@@ -56,3 +56,15 @@ run:
         }
       }
       EOF
+
+      echo "Writing manifest CodeBuild configuration"
+      cat <<EOF | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}-manifest.json
+      {
+        "projectName": "pay-${PROJECT_TO_BUILD}-armv8",
+        "secondarySourcesVersions": {},
+        "environmentVariables": {
+          "RELEASE_NUMBER": "${RELEASE_NUMBER}",
+          "BUILD_DATE": "${BUILD_DATE}"
+        }
+      }
+      EOF

--- a/ci/tasks/prepare-codebuild-multiarch.yml
+++ b/ci/tasks/prepare-codebuild-multiarch.yml
@@ -31,7 +31,7 @@ run:
       cat <<EOF | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}.json
       {
         "projectName": "${PROJECT_TO_BUILD}",
-        "sourceVersion": "${PAY_CI_VERSION_ID}",
+        "sourceVersion": "${RELEASE_SHA}",
         "secondarySourcesVersions": {},
         "environmentVariables": {
           "RELEASE_NUMBER": "${RELEASE_NUMBER}",

--- a/ci/tasks/prepare-codebuild-multiarch.yml
+++ b/ci/tasks/prepare-codebuild-multiarch.yml
@@ -1,0 +1,43 @@
+---
+# The JSON configuration is written into the run-codebuild-configuration 
+# output for a later task to use as an input
+
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentdigitalservice/pay-concourse-runner
+inputs:
+  - name: pay-ci
+outputs:
+  - name: run-codebuild-configuration
+params:
+  PROJECT_TO_BUILD:
+  RELEASE_NAME:
+  RELEASE_NUMBER:
+  RELEASE_SHA:
+  BUILD_DATE:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_SESSION_TOKEN:
+run:
+  path: /bin/bash
+  args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      echo "Writing CodeBuild configuration"
+      cat <<EOF | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}.json
+      {
+        "projectName": "${PROJECT_TO_BUILD}",
+        "sourceVersion": "${PAY_CI_VERSION_ID}",
+        "secondarySourcesVersions": {},
+        "environmentVariables": {
+          "RELEASE_NUMBER": "${RELEASE_NUMBER}",
+          "RELEASE_NAME": "${RELEASE_NAME}",
+          "RELEASE_SHA": "${RELEASE_SHA}",
+          "BUILD_DATE": "${BUILD_DATE}"
+        }
+      }
+      EOF

--- a/ci/tasks/prepare-codebuild-multiarch.yml
+++ b/ci/tasks/prepare-codebuild-multiarch.yml
@@ -30,7 +30,7 @@ run:
       echo "Writing CodeBuild configuration"
       cat <<EOF | tee ./run-codebuild-configuration/${PROJECT_TO_BUILD}.json
       {
-        "projectName": "${PROJECT_TO_BUILD}",
+        "projectName": "pay-${PROJECT_TO_BUILD}-amd64",
         "sourceVersion": "${RELEASE_SHA}",
         "secondarySourcesVersions": {},
         "environmentVariables": {


### PR DESCRIPTION
Build multi-arch cardid Docker images in CodeBuild, and publish them to ECR and Docker Hub.

This PR has [a companion in `pay-infra`](https://github.com/alphagov/pay-infra/pull/4679) which sets up the IAM role Concourse needs to run CodeBuild jobs.

The work here can easily be repurposed to other Pay applications. N

[Here is a completed Concourse job](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/codebuild-cardid/builds/38) and [here are the published images](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/223851549868/govukpay/cardid?region=eu-west-1). 