### PR TITLE
PP-10386 Treat submodules URL as https

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4445,15 +4445,11 @@ jobs:
               - -ec
               - |
                 apk add --quiet --no-progress git
-                # cardid-data submodule's url is defined as ssh yet concourse
-                # is using oauth. Furthermore we need to avoid the password
-                # prompt from the git cli. Therefore rewrite the url for https
-                # and add the token. The risk of setting the token in the url is
-                # mitigated since these files are not committed, the container is ephemeral
-                # and anyone with access to read the files could read the token from
-                # environment variable. Furthermore we redact the token from the
-                # files after the update.
-                sed -i "s/git@github.com:/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+                # rewrite the submodule url for https to add the token.
+                # The risk of setting the token in the url is mitigated since these files are not committed,
+                # the container is ephemeral and anyone with access to read the files could read the token from
+                # environment variable. Furthermore we redact the token from the files after the update.
+                sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
                 git submodule init -q data
                 git submodule update data
                 sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1274,15 +1274,11 @@ jobs:
               args:
                 - -ec
                 - |
-                  # cardid-data submodule's url is defined as ssh yet concourse
-                  # is using oauth. Furthermore we need to avoid the password
-                  # prompt from the git cli. Therefore rewrite the url for https
-                  # and add the token. The risk of setting the token in the url is
-                  # mitigated since these files are not committed, the container is ephemeral
-                  # and anyone with access to read the files could read the token from
-                  # environment variable. Furthermore we redact the token from the
-                  # files after the update.
-                  sed -i "s/git@github.com:/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+                  # rewrite the submodule url for https to add the token.
+                  # The risk of setting the token in the url is mitigated since these files are not committed,
+                  # the container is ephemeral and anyone with access to read the files could read the token from
+                  # environment variable. Furthermore we redact the token from the files after the update.
+                  sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
                   git submodule init -q data
                   git submodule update data
                   sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules


### PR DESCRIPTION
## WHAT
- CardID submodule URL is configured as SSH but concourse is re-writing as HTTPS URL. Codebuild also needs HTTPS URL for submodules. https://github.com/alphagov/pay-cardid/pull/1134 updates the submodule URL to HTTPS. so update pipeline for the change