### PR TITLE
PP-12015: Add reusable workflow to check docker image definitions are manifests, not images

### DIFF
--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -37,8 +37,7 @@ jobs:
 
           DOCKERFILE=${{ inputs.dockerfile }}
 
-          while read -r FROM_LINE; do
-            BASE_CONTAINER_DEFINITION=$(awk '{ print $2; }' <<<"$FROM_LINE")
+          while read -r BASE_CONTAINER_DEFINITION; do
             echo "Checking base container definition: $BASE_CONTAINER_DEFINITION"
 
             # Image definitions are going to be of one of the forms:
@@ -51,7 +50,7 @@ jobs:
             DIGEST=$(cut -f 2 -d "@" <<<"$BASE_CONTAINER_DEFINITION")
 
             if [ -z "$DIGEST" ]; then
-              echo "Error There was no image digest in the line '$FROM_LINE'"
+              echo "Error There was no image digest in '$BASE_CONTAINER_DEFINITION'"
               echo "The FROM lines must have a digest pin in order to use this workflow"
               exit 1
             fi
@@ -60,7 +59,7 @@ jobs:
             IMAGE_TAG=$(cut -f 2 -d ":" <<<"$IMAGE")
 
             if ! docker manifest inspect "$BASE_CONTAINER_DEFINITION" >> /dev/null 2>&1; then
-              echo "ERROR! The image specified in the line '$FROM_LINE' does not refer to a manifest"
+              echo "ERROR! The image specified by '$BASE_CONTAINER_DEFINITION' does not refer to a manifest"
               echo
               echo "All image sha pins must point to the image manifest, not to one of the architecture specific images"
               echo "This is required so our multi-architecture builds can succeed"
@@ -85,7 +84,7 @@ jobs:
 
             echo "Valid manifest for $BASE_CONTAINER_DEFINITION"
             echo
-          done < <(grep "^FROM " "$DOCKERFILE" | sort | uniq)
+          done < <(grep "^FROM " "$DOCKERFILE" | awk '{ print $2; }' | sort | uniq)
 
           echo "All FROM lines in $DOCKERFILE point to valid manifests"
           echo

--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -1,0 +1,91 @@
+# This workflow checks that all the base images in a specified docker file are manifests and not images
+#
+# Usage:
+# jobs:
+#   validate-docker-image-is-manifest:
+#     uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+#     with:
+#       dockerfile: "Dockerfile"
+#
+name: Validate Docker Image is Manifest
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        description: "Filepath within the repo under test to the Dockerfile to be checked"
+        required: false
+        type: string
+        default: "Dockerfile"
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    name: "Check dockerfile '${{ inputs.dockerfile }}'"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          fetch-depth: 1
+      - name: Validate sources
+        run: |
+          set -euo pipefail
+
+          DOCKERFILE=${{ inputs.dockerfile }}
+
+          while read -r FROM_LINE; do
+            BASE_CONTAINER_DEFINITION=$(awk '{ print $2; }' <<<"$FROM_LINE")
+            echo "Checking base container definition: $BASE_CONTAINER_DEFINITION"
+
+            # Image definitions are going to be of one of the forms:
+            #
+            #   image_name:tag
+            #   image_name:tag@sha256:<sha>
+            #   image_name@sha256
+            #
+            IMAGE=$(cut -f 1 -d "@" <<<"$BASE_CONTAINER_DEFINITION")
+            DIGEST=$(cut -f 2 -d "@" <<<"$BASE_CONTAINER_DEFINITION")
+
+            if [ -z "$DIGEST" ]; then
+              echo "Error There was no image digest in the line '$FROM_LINE'"
+              echo "The FROM lines must have a digest pin in order to use this workflow"
+              exit 1
+            fi
+
+            IMAGE_NAME=$(cut -f 1 -d ":" <<<"$IMAGE")
+            IMAGE_TAG=$(cut -f 2 -d ":" <<<"$IMAGE")
+
+            if ! docker manifest inspect "$BASE_CONTAINER_DEFINITION" >> /dev/null 2>&1; then
+              echo "ERROR! The image specified in the line '$FROM_LINE' does not refer to a manifest"
+              echo
+              echo "All image sha pins must point to the image manifest, not to one of the architecture specific images"
+              echo "This is required so our multi-architecture builds can succeed"
+              echo
+              if [ -z "$IMAGE_TAG" ]; then
+                echo "No image tag is specified in the FROM definition, so I can't lookup a potentially correct manifest sha for you"
+                echo
+                echo "To get this yourself run 'docker pull ${IMAGE_TAG}:<tag> | grep Digest'"
+                echo
+                echo "To validate that is a manifest you can run 'docker manifest inspect ${IMAGE_NAME}@<digest>', if you get a JSON blob from"
+                echo "  this, then the sha is a manifest, however if it says 'manifest verification failed for digest <digest>' then it is not a manifest"
+              else
+                LIKELY_DIGEST=$(docker pull "${IMAGE_NAME}:${IMAGE_TAG}" 2>&1 | grep Digest | cut -f 2 -d " ")
+
+                echo "It's likely the digest you need is '$LIKELY_DIGEST' based on a lookup of ${IMAGE_NAME}:${IMAGE_TAG}"
+              fi
+              echo
+              echo "See the guide to updating base images in the pay team manual: https://manual.payments.service.gov.uk/manual/reference/docker.html#updating-docker-base-images"
+              echo
+              exit 1
+            fi
+
+            echo "Valid manifest for $BASE_CONTAINER_DEFINITION"
+            echo
+          done < <(grep "^FROM " "$DOCKERFILE" | sort | uniq)
+
+          echo "All FROM lines in $DOCKERFILE point to valid manifests"
+          echo

--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           fetch-depth: 1
-      - name: Validate sources
+      - name: Validate base images are manifests
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Given we are moving to multi-arch builds we want to be able to check from all repos with docker images SHA pinned that the pins point to a manifest, and not directly to an image.

This reusable workflow will check every FROM line in the dockerfile specified as an input (defaulting to Dockerfile in the root of the repo using this workflow) and validate they are a manifest, and provide helpful information if they are not a manifest, including a likely manifest sha where that is possible to establish.

I opened a PR in pay-frontend which uses this workflow. This test https://github.com/alphagov/pay-frontend/actions/runs/7387040621/job/20095008936 shows a passing check (where all the FROM lines are valid).

For this test I altered one of the FROM lines to use a SHA which points directly to an image instead of a manifest:
https://github.com/alphagov/pay-frontend/actions/runs/7387100332/job/20095056520?pr=3776