### PR TITLE
Pp 12034/push multiarch stubs to deploy

### DIFF
--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -680,6 +680,13 @@ jobs:
               params:
                 AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
                 AWS_ROLE_SESSION_NAME: retag-ecr-image-as-release
+            - task: assume-write-to-deploy-role
+              file: pay-ci/ci/tasks/assume-role.yml
+              output_mapping:
+                assume-role: assume-write-to-deploy-role
+              params:
+                AWS_ROLE_ARN: arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_dev_worker_ecr_access
+                AWS_ROLE_SESSION_NAME: write-ecr-to-deploy
       - in_parallel:
           steps:
           - load_var: candidate_image_tag
@@ -690,8 +697,13 @@ jobs:
           - load_var: retag-role
             file: assume-retag-role/assume-role.json
             format: json
+          - load_var: write-to-deploy-role
+            file: assume-write-to-deploy-role/assume-role.json
+            format: json
           - load_var: release_image_tag
             file: parse-candidate-tag/release-tag
+          - load_var: release_number
+            file: parse-candidate-tag/release-number
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
@@ -744,6 +756,20 @@ jobs:
             params:
               SOURCE_MANIFEST: "governmentdigitalservice/pay-stubs:((.:candidate_image_tag))"
               NEW_MANIFEST: "governmentdigitalservice/pay-stubs:latest-master"
+          - task: copy-images-to-stubs-ecr-registry-deploy
+            file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+            privileged: true
+            params:
+              SOURCE_ECR_REGISTRY: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+              DESTINATION_ECR_REGISTRY: "((pay_aws_deploy_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+              ECR_REPO_NAME: "govukpay/stubs"
+              RELEASE_NUMBER:  ((.:release_number))
+              SOURCE_AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+              SOURCE_AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+              SOURCE_AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+              DESTINATION_AWS_ACCESS_KEY_ID: ((.:write-to-deploy-role.AWS_ACCESS_KEY_ID))
+              DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:write-to-deploy-role.AWS_SECRET_ACCESS_KEY))
+              DESTINATION_AWS_SESSION_TOKEN: ((.:write-to-deploy-role.AWS_SESSION_TOKEN))
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -1,0 +1,58 @@
+container_limits: {}
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentdigitalservice/pay-concourse-runner
+params:
+  SOURCE_ECR_REGISTRY:
+  DESTINATION_ECR_REGISTRY:
+  ECR_REPO_NAME:
+  RELEASE_NUMBER:
+run:
+  path: bash
+  args:
+    - -ec
+    - |
+
+      function cleanup {
+        echo "CLEANUP TRIGGERED"
+        clean_docker
+        stop_docker
+        echo "CLEANUP COMPLETE"
+      }
+
+      trap cleanup EXIT
+      source /docker-helpers.sh
+
+      start_docker
+
+      echo "Logging in to source ECR"
+      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
+
+      echo "Logging in to destination ECR"
+      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
+
+      echo "Pulling images"
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
+
+      echo "Waiting for pulls to complete"
+      wait
+
+      echo "Retagging images locally"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
+
+      echo "Pushing images"
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
+
+      echo "Waiting for pushes to complete"
+      wait
+
+      echo "Creating release manifest in destination registry"
+      docker buildx imagetools create \
+        -t "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-release" \
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" \
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -9,6 +9,12 @@ params:
   DESTINATION_ECR_REGISTRY:
   ECR_REPO_NAME:
   RELEASE_NUMBER:
+  SOURCE_AWS_ACCESS_KEY_ID:
+  SOURCE_AWS_SECRET_ACCESS_KEY:
+  SOURCE_AWS_SESSION_TOKEN:
+  DESTINATION_AWS_ACCESS_KEY_ID:
+  DESTINATION_AWS_SECRET_ACCESS_KEY:
+  DESTINATION_AWS_SESSION_TOKEN:
 
 run:
   path: bash
@@ -36,14 +42,6 @@ run:
       echo "Logging in to source ECR"
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
 
-      set +x # This is a safety measure to prevent us accidentally leaking AWS secrets in the future
-      AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
-      AWS_SECRET_ACCESS_KEY="$DESTINATION_AWS_SECRET_ACCESS_KEY"
-      AWS_SESSION_TOKEN="$DESTINATION_AWS_SESSION_TOKEN"
-
-      echo "Logging in to destination ECR"
-      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
-
       echo "Pulling images"
       docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
       docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
@@ -54,6 +52,14 @@ run:
       echo "Retagging images locally"
       docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8"
       docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
+
+      set +x # This is a safety measure to prevent us accidentally leaking AWS secrets in the future
+      AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
+      AWS_SECRET_ACCESS_KEY="$DESTINATION_AWS_SECRET_ACCESS_KEY"
+      AWS_SESSION_TOKEN="$DESTINATION_AWS_SESSION_TOKEN"
+
+      echo "Logging in to destination ECR"
+      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
 
       echo "Pushing images"
       docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -34,18 +34,18 @@ run:
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
 
       echo "Pulling images"
-      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
       docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
 
       echo "Waiting for pulls to complete"
       wait
 
       echo "Retagging images locally"
-      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8"
       docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
 
       echo "Pushing images"
-      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
       docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
 
       echo "Waiting for pushes to complete"
@@ -54,5 +54,5 @@ run:
       echo "Creating release manifest in destination registry"
       docker buildx imagetools create \
         -t "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-release" \
-        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-arm64" \
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" \
         "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -9,11 +9,14 @@ params:
   DESTINATION_ECR_REGISTRY:
   ECR_REPO_NAME:
   RELEASE_NUMBER:
+
 run:
   path: bash
   args:
     - -ec
     - |
+
+      set -euo pipefail
 
       function cleanup {
         echo "CLEANUP TRIGGERED"
@@ -27,8 +30,16 @@ run:
 
       start_docker
 
+      AWS_ACCESS_KEY_ID="$SOURCE_AWS_ACCESS_KEY_ID"
+      AWS_SECRET_ACCESS_KEY="$SOURCE_AWS_SECRET_ACCESS_KEY"
+      AWS_SESSION_TOKEN="$SOURCE_AWS_SESSION_TOKEN"
+
       echo "Logging in to source ECR"
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
+
+      AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
+      AWS_SECRET_ACCESS_KEY="$DESTINATION_AWS_SECRET_ACCESS_KEY"
+      AWS_SESSION_TOKEN="$DESTINATION_AWS_SESSION_TOKEN"
 
       echo "Logging in to destination ECR"
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -16,8 +16,6 @@ run:
     - -ec
     - |
 
-      set -euo pipefail
-
       function cleanup {
         echo "CLEANUP TRIGGERED"
         clean_docker
@@ -30,6 +28,7 @@ run:
 
       start_docker
 
+      set +x # This is a safety measure to prevent us accidentally leaking AWS secrets in the future
       AWS_ACCESS_KEY_ID="$SOURCE_AWS_ACCESS_KEY_ID"
       AWS_SECRET_ACCESS_KEY="$SOURCE_AWS_SECRET_ACCESS_KEY"
       AWS_SESSION_TOKEN="$SOURCE_AWS_SESSION_TOKEN"
@@ -37,6 +36,7 @@ run:
       echo "Logging in to source ECR"
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
 
+      set +x # This is a safety measure to prevent us accidentally leaking AWS secrets in the future
       AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
       AWS_SECRET_ACCESS_KEY="$DESTINATION_AWS_SECRET_ACCESS_KEY"
       AWS_SESSION_TOKEN="$DESTINATION_AWS_SESSION_TOKEN"

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -38,6 +38,9 @@ run:
       AWS_ACCESS_KEY_ID="$SOURCE_AWS_ACCESS_KEY_ID"
       AWS_SECRET_ACCESS_KEY="$SOURCE_AWS_SECRET_ACCESS_KEY"
       AWS_SESSION_TOKEN="$SOURCE_AWS_SESSION_TOKEN"
+      export AWS_ACCESS_KEY_ID
+      export AWS_SECRET_ACCESS_KEY
+      export AWS_SESSION_TOKEN
 
       echo "Logging in to source ECR"
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
@@ -57,6 +60,9 @@ run:
       AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
       AWS_SECRET_ACCESS_KEY="$DESTINATION_AWS_SECRET_ACCESS_KEY"
       AWS_SESSION_TOKEN="$DESTINATION_AWS_SESSION_TOKEN"
+      export AWS_ACCESS_KEY_ID
+      export AWS_SECRET_ACCESS_KEY
+      export AWS_SESSION_TOKEN
 
       echo "Logging in to destination ECR"
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"


### PR DESCRIPTION
We need to copy multi-arch images from one account to another. This adds a task (and uses it in e2e-helpers for stubs) which:

1. uses 1 role in a source account, logs in to ECR
2. pulls the images XX-candidate-<ARCH> (both amd64 and armv8)
3. uses a second role in a destination account and logs into ECR again with that
4. Pushes the images to the destination account
5. Creates a manifest in the destination account of XX-release