### PR TITLE
PP-12034: Stubs is built and pushed to deploy ECR from the e2e-helpers pipeline, don't rebuild it

### DIFF
--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -16,16 +16,6 @@ resources:
       paths:
         - ci/pipelines/stubs.yml
 
-  - name: stubs-src
-    type: git
-    icon: github
-    source:
-      uri: https://github.com/alphagov/pay-stubs
-      branch: master
-      username: alphagov-pay-ci-concourse
-      password: ((github-access-token))
-      tag_regex: "alpha_release-(.*)"
-
   - name: pay-ci
     type: git
     icon: github
@@ -73,7 +63,6 @@ jobs:
       - get: pay-ci
       - get: pay-infra
       - get: stubs-ecr-registry-deploy
-        passed: [build-and-push-stubs]
         trigger: true
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
@@ -119,72 +108,5 @@ jobs:
         channel: "#govuk-pay-activity"
         silent: true
         text: ":green-circle: Deployed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-
-  - name: build-and-push-stubs
-    plan:
-      - get: stubs-src
-        trigger: true
-      - get: pay-ci
-      - task: parse-release-tag
-        file: pay-ci/ci/tasks/parse-release-tag.yml
-        input_mapping:
-          git-release: stubs-src
-      - load_var: release-sha
-        file: tags/release-sha
-      - load_var: date
-        file: tags/date
-      - load_var: release-tag
-        file: tags/tags
-      - task: generate-docker-creds-config
-        file: pay-ci/ci/tasks/generate-docker-config-file.yml
-        params:
-          USERNAME: ((docker-username))
-          PASSWORD: ((docker-access-token))
-          EMAIL: ((docker-email))
-      - task: build-stubs-image
-        privileged: true
-        params:
-          DOCKER_CONFIG: docker_creds
-          CONTEXT: stubs-src
-          UNPACK_ROOTFS: true
-          LABEL_release_sha: ((.:release-sha))
-          LABEL_build_date: ((.:date))
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: concourse/oci-build-task
-          inputs:
-            - name: stubs-src
-            - name: docker_creds
-          outputs:
-            - name: image
-          run:
-            path: build
-      - put: stubs-ecr-registry-deploy
-        params:
-          image: image/image.tar
-          additional_tags: tags/tags
-        get_params:
-          skip_download: true
-    on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: "#govuk-pay-starling"
-        silent: true
-        text: ":red-circle: Failed to build and push stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        icon_emoji: ":concourse:"
-        username: pay-concourse
-    on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: "#govuk-pay-activity"
-        silent: true
-        text: ":green-circle: Built and pushed stubs image - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
         icon_emoji: ":concourse:"
         username: pay-concourse


### PR DESCRIPTION
e2e-helpers pipeline now builds multi-arch images, and pushes those multi-arch images into deploy ECR.

This PR stops us rebuilding them in the deploy account, and instead uses the pushed images built in test

I applied it and you can see the deployment in https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/stubs and the successful deployment of the multi-arch image https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/stubs/jobs/deploy-stubs/builds/26