### PR TITLE
PP-12033: Build notifications multi-arch

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -5751,47 +5751,104 @@ jobs:
         input_mapping:
           git-release: notifications-git-release
       - in_parallel:
-        - load_var: release-name
-          file: notifications-git-release/.git/ref
-        - load_var: release-tag
-          file: tags/tags
-        - load_var: release-number
-          file: tags/release-number
-        - load_var: release-sha
-          file: tags/release-sha
-        - load_var: date
-          file: tags/date
-      - task: generate-docker-creds-config
-        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+          steps:
+          - load_var: release-name
+            file: notifications-git-release/.git/ref
+          - load_var: release-tag
+            file: tags/tags
+          - load_var: release-number
+            file: tags/release-number
+          - load_var: release-sha
+            file: tags/release-sha
+          - load_var: candidate_image_tag
+            file: tags/candidate-tag
+          - load_var: date
+            file: tags/date
+          - task: assume-role
+            file: pay-ci/ci/tasks/assume-role.yml
+            params:
+              AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
+              AWS_ROLE_SESSION_NAME: codebuild-assume-role
+          - task: assume-retag-role
+            file: pay-ci/ci/tasks/assume-role.yml
+            output_mapping:
+              assume-role: assume-retag-role
+            params:
+              AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+              AWS_ROLE_SESSION_NAME: retag-ecr-image-as-release
+          - task: generate-docker-creds-config
+            file: pay-ci/ci/tasks/generate-docker-config-file.yml
+            params:
+              USERNAME: ((docker-username))
+              PASSWORD: ((docker-access-token))
+              EMAIL: ((docker-email))
+      - in_parallel:
+          steps:
+          - load_var: role
+            file: assume-role/assume-role.json
+            format: json
+          - load_var: retag-role
+            file: assume-retag-role/assume-role.json
+            format: json
+      - task: prepare-codebuild
+        file: pay-ci/ci/tasks/prepare-codebuild-multiarch.yml
         params:
-          USERNAME: ((docker-username))
-          PASSWORD: ((docker-access-token))
-          EMAIL: ((docker-email))
-      - task: build-notifications-image
-        privileged: true
+          PROJECT_TO_BUILD: notifications
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          RELEASE_NUMBER: ((.:release-number))
+          RELEASE_NAME: ((.:release-name))
+          RELEASE_SHA: ((.:release-sha))
+          BUILD_DATE: ((.:date))
+      - in_parallel:
+          steps:
+          - task: run-codebuild-nginx-proxy-amd64
+            attempts: 3
+            file: pay-ci/ci/tasks/run-codebuild.yml
+            params:
+              PATH_TO_CONFIG: "../../../../run-codebuild-configuration/notifications-amd64.json"
+              AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+              AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+              AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          - task: run-codebuild-nginx-proxy-armv8
+            attempts: 3
+            file: pay-ci/ci/tasks/run-codebuild.yml
+            params:
+              PATH_TO_CONFIG: "../../../../run-codebuild-configuration/notifications-armv8.json"
+              AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+              AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+              AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: run-codebuild-nginx-proxy-manifest
+        attempts: 3
+        file: pay-ci/ci/tasks/run-codebuild.yml
         params:
-          DOCKER_CONFIG: docker_creds
-          CONTEXT: notifications-git-release
-          LABEL_release_number: ((.:release-number))
-          LABEL_release_name: ((.:release-name))
-          LABEL_release_sha: ((.:release-sha))
-          LABEL_build_date: ((.:date))
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: concourse/oci-build-task
-          inputs:
-            - name: notifications-git-release
-          outputs:
-            - name: image
-          run:
-            path: build
-      - put: notifications-ecr-registry-test
-        params:
-          image: image/image.tar
-          additional_tags: tags/all-release-tags
+          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/notifications-manifest.json"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - in_parallel:
+          steps:
+            - task: retag-candidate-as-release-in-ecr
+              file: pay-ci/ci/tasks/manifest-retag.yml
+              params:
+                DOCKER_LOGIN_ECR: 1
+                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/notifications:((.:candidate_image_tag))"
+                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/notifications:((.:release-tag))"
+                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+            - task: retag-candidate-as-latest-in-ecr
+              file: pay-ci/ci/tasks/manifest-retag.yml
+              params:
+                DOCKER_LOGIN_ECR: 1
+                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/notifications:((.:candidate_image_tag))"
+                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/notifications:latest"
+                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
     on_failure:
       put: slack-notification
       attempts: 10
@@ -5817,7 +5874,6 @@ jobs:
     plan:
       - get: notifications-ecr-registry-test
         trigger: true
-        passed: [build-and-push-notifications-to-test-ecr]
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag


### PR DESCRIPTION
Requires https://github.com/alphagov/pay-infra/pull/4711

Notifications doesn't go to dockerhub so:

[successful build](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-notifications-to-test-ecr/builds/35)
[ECR Images](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/223851549868/govukpay/notifications?region=eu-west-1)

![Screenshot 2024-01-15 at 16 07 19](https://github.com/alphagov/pay-ci/assets/2170030/e4cfdf03-afb6-4033-bde4-7f36eea5eebb)
