### PR TITLE
PP-12035-reverse-proxy-codebuild

### DIFF
--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -384,7 +384,8 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
           RELEASE_NUMBER: ((.:release-number))
           RELEASE_NAME: ((.:release-name))
-          RELEASE_SHA: ((.:release-sha))
+          #RELEASE_SHA: ((.:release-sha))
+          RELEASE_SHA: PP-12035-reverse-proxy-codebuild
           BUILD_DATE: ((.:date))
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml
@@ -545,6 +546,11 @@ jobs:
                 AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
                 AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
                 AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+            - task: retag-candidate-as-release-in-dockerhub
+              file: pay-ci/ci/tasks/manifest-retag.yml
+              params:
+                SOURCE_MANIFEST: "governmentdigitalservice/pay-reverse-proxy:((.:candidate_image_tag))"
+                NEW_MANIFEST: "governmentdigitalservice/pay-reverse-proxy:latest-master"
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -39,17 +39,6 @@ resources:
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
 
-  - name: pay-infra-src
-    type: git
-    icon: github
-    source:
-      uri: https://github.com/alphagov/pay-infra
-      branch: master
-      username: alphagov-pay-ci-concourse
-      password: ((github-access-token))
-      paths:
-        - provisioning/terraform/modules/pay_microservices_v2  # NAXSI config
-
   - name: pay-ci
     type: git
     icon: github
@@ -93,28 +82,6 @@ resources:
       aws_ecr_registry_id: "((pay_aws_test_account_id))"
       aws_region: eu-west-1
       variant: candidate
-
-  - name: reverse-proxy-ecr-registry-test
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/reverse-proxy
-      tag: latest
-      aws_access_key_id: ((readonly_access_key_id))
-      aws_secret_access_key: ((readonly_secret_access_key))
-      aws_session_token: ((readonly_session_token))
-      aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      aws_ecr_registry_id: "((pay_aws_test_account_id))"
-      aws_region: eu-west-1
-
-  - name: reverse-proxy-dockerhub
-    type: registry-image
-    icon: docker
-    source:
-      repository: governmentdigitalservice/pay-reverse-proxy
-      tag: latest-master
-      password: ((docker-access-token))
-      username: ((docker-username))
 
   - name: reverse-proxy-candidate-ecr-registry-test
     type: registry-image
@@ -382,74 +349,74 @@ jobs:
   - name: build-and-push-reverse-proxy-candidate
     plan:
       - in_parallel:
-          - get: reverse-proxy-git-release
-            trigger: true
-          - get: pay-infra-src
-            trigger: true
-          - get: pay-ci
+        - get: pay-ci
+        - get: reverse-proxy-git-release
+          trigger: true
       - task: parse-release-tag
         file: pay-ci/ci/tasks/parse-release-tag.yml
         input_mapping:
           git-release: reverse-proxy-git-release
-      - load_var: release_number_tag
-        file: tags/release-number
       - in_parallel:
-          - do:
-              - task: find-and-compile-naxsi-rules
-                config:
-                  container_limits: {}
-                  platform: linux
-                  image_resource:
-                    type: registry-image
-                    source:
-                      repository: governmentdigitalservice/pay-concourse-runner
-                  inputs:
-                    - name: pay-infra-src
-                    - name: reverse-proxy-git-release
-                  outputs:
-                    - name: reverse-proxy-git-release
-                  run:
-                    path: /bin/sh
-                    args:
-                      - -ec
-                      - |
-                        cd reverse-proxy-git-release/images/reverse_proxy
-                        mkdir target
-
-                        # Search pay-infra files for naxsi rules and copy to current 'target' directory
-                        # See https://github.com/alphagov/pay-scripts/blob/master/images/proxy/build-latest-master.sh
-                        prod_naxsi_rules_source=../../../pay-infra-src/provisioning/terraform/modules/pay_microservices_v2
-                        find "$prod_naxsi_rules_source" -name \*.naxsi -exec cp {} target \;
-              - task: generate-docker-creds-config
-                file: pay-ci/ci/tasks/generate-docker-config-file.yml
-                params:
-                  USERNAME: ((docker-username))
-                  PASSWORD: ((docker-access-token))
-                  EMAIL: ((docker-email))
-              - task: build-reverse-proxy-image
-                privileged: true
-                params:
-                  CONTEXT: reverse-proxy-git-release/images/reverse_proxy/
-                  DOCKER_CONFIG: docker_creds
-                config:
-                  platform: linux
-                  image_resource:
-                    type: registry-image
-                    source:
-                      repository: concourse/oci-build-task
-                  inputs:
-                    - name: reverse-proxy-git-release
-                  outputs:
-                    - name: image
-                  run:
-                    path: build
-      - in_parallel:
-        - put: reverse-proxy-candidate-ecr-registry-test
+        - load_var: release-number
+          file: tags/release-number
+        - load_var: release-name
+          file: reverse-proxy-git-release/.git/ref
+        - load_var: release-sha
+          file: tags/release-sha
+        - load_var: candidate-image-tag
+          file: tags/candidate-tag
+        - load_var: date
+          file: tags/date
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
           params:
-            image: image/image.tar
-            additional_tags: tags/candidate-tag
-          get_params:
-            skip_download: true
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
+            AWS_ROLE_SESSION_NAME: codebuild-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: prepare-codebuild
+        file: pay-ci/ci/tasks/prepare-codebuild-multiarch.yml
+        params:
+          PROJECT_TO_BUILD: reverse-proxy
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          RELEASE_NUMBER: ((.:release-number))
+          RELEASE_NAME: ((.:release-name))
+          RELEASE_SHA: ((.:release-sha))
+          BUILD_DATE: ((.:date))
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-access-token))
+          EMAIL: ((docker-email))
+      - in_parallel:
+        - task: run-codebuild-reverse-proxy-amd64
+          attempts: 3
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/reverse-proxy-amd64.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+        - task: run-codebuild-reverse-proxy-armv8
+          attempts: 3
+          file: pay-ci/ci/tasks/run-codebuild.yml
+          params:
+            PATH_TO_CONFIG: "../../../../run-codebuild-configuration/reverse-proxy-armv8.json"
+            AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+            AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+            AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: run-codebuild-reverse-proxy-manifest
+        attempts: 3
+        file: pay-ci/ci/tasks/run-codebuild.yml
+        params:
+          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/reverse-proxy-manifest.json"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     on_failure:
       put: slack-notification
       attempts: 10
@@ -473,7 +440,6 @@ jobs:
     plan:
       - in_parallel:
           - get: reverse-proxy-candidate-ecr-registry-test
-            passed: [build-and-push-reverse-proxy-candidate]
             trigger: true
             params:
               format: oci
@@ -527,17 +493,58 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:
-        - put: reverse-proxy-ecr-registry-test
-          params:
-            image: reverse-proxy-candidate-ecr-registry-test/image.tar
-            additional_tags: parse-candidate-tag/release-tag
-          get_params:
-            skip_download: true
-        - put: reverse-proxy-dockerhub
-          params:
-            image: reverse-proxy-candidate-ecr-registry-test/image.tar
-          get_params:
-            skip_download: true
+           steps:
+            - task: generate-docker-creds-config
+              file: pay-ci/ci/tasks/generate-docker-config-file.yml
+              params:
+                USERNAME: ((docker-username))
+                PASSWORD: ((docker-access-token))
+                EMAIL: ((docker-email))
+            - task: parse-candidate-tag
+              file: pay-ci/ci/tasks/parse-candidate-tag.yml
+              input_mapping:
+                ecr-repo: reverse-proxy-candidate-ecr-registry-test
+            - task: assume-role
+              file: pay-ci/ci/tasks/assume-role.yml
+              params:
+                AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12
+                AWS_ROLE_SESSION_NAME: e2e-test-assume-role
+            - task: assume-retag-role
+              file: pay-ci/ci/tasks/assume-role.yml
+              output_mapping:
+                assume-role: assume-retag-role
+              params:
+                AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+                AWS_ROLE_SESSION_NAME: retag-ecr-image-as-release
+      - in_parallel:
+          steps:
+            - load_var: retag-role
+              file: assume-retag-role/assume-role.json
+              format: json
+            - load_var: release_image_tag
+              file: parse-candidate-tag/release-tag
+      - in_parallel:
+          steps:
+            - task: retag-candidate-as-release-in-ecr
+              file: pay-ci/ci/tasks/manifest-retag.yml
+              params:
+                DOCKER_LOGIN_ECR: 1
+                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/reverse-proxy:((.:candidate_image_tag))"
+                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/reverse-proxy:((.:release_image_tag))"
+                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+            - task: retag-candidate-as-latest-in-ecr
+              file: pay-ci/ci/tasks/manifest-retag.yml
+              params:
+                DOCKER_LOGIN_ECR: 1
+                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/reverse-proxy:((.:candidate_image_tag))"
+                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/reverse-proxy:latest"
+                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/e2e-helpers.yml
+++ b/ci/pipelines/e2e-helpers.yml
@@ -384,8 +384,7 @@ jobs:
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
           RELEASE_NUMBER: ((.:release-number))
           RELEASE_NAME: ((.:release-name))
-          #RELEASE_SHA: ((.:release-sha))
-          RELEASE_SHA: PP-12035-reverse-proxy-codebuild
+          RELEASE_SHA: ((.:release-sha))
           BUILD_DATE: ((.:date))
       - task: generate-docker-creds-config
         file: pay-ci/ci/tasks/generate-docker-config-file.yml


### PR DESCRIPTION
Build multiarch reverse-proxy images in CodeBuild. Because those images need to include naxsi rules which are stored in pay-infra, I have also had to make changes to [pay-infra](https://github.com/alphagov/pay-infra/pull/4714) and [pay-scripts](https://github.com/alphagov/pay-scripts/pull/1436).

* [Concourse run of build job](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/build-and-push-reverse-proxy-candidate/builds/417.2)
* [Concourse run of e2e job](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/reverse-proxy-e2e/builds/391)
* [Images in ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/223851549868/govukpay/reverse-proxy?region=eu-west-1)
* [Images in Docker Hub](https://hub.docker.com/repository/docker/governmentdigitalservice/pay-reverse-proxy/general)
