### PR TITLE
PP-12032 Update nginx-forward-proxy pipeline to use `alpha_release` tags

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -138,7 +138,7 @@ resources:
     source:
       uri: https://github.com/alphagov/pay-nginx-forward-proxy
       branch: main
-      tag_regex: "(.*)-release"
+      tag_regex: "alpha_release-(.*)"
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
 


### PR DESCRIPTION
## WHAT
- Tagging for nginx-forward-proxy has been changed in https://github.com/alphagov/pay-nginx-forward-proxy/pull/90. Use alpha_release tags in CI pipelines