### PR TITLE
PP-12025-build-egress-in-codebuild

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1472,21 +1472,30 @@ jobs:
         input_mapping:
           git-release: egress-git-release
       - in_parallel:
-        - load_var: release-number
-          file: tags/release-number
-        - load_var: release-name
-          file: egress-git-release/.git/ref
-        - load_var: release-sha
-          file: tags/release-sha
-        - load_var: candidate-image-tag
-          file: tags/candidate-tag
-        - load_var: date
-          file: tags/date
-        - task: assume-role
-          file: pay-ci/ci/tasks/assume-role.yml
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
-            AWS_ROLE_SESSION_NAME: codebuild-assume-role
+          steps:
+            - load_var: release-number
+              file: tags/release-number
+            - load_var: release-name
+              file: egress-git-release/.git/ref
+            - load_var: release-sha
+              file: tags/release-sha
+            - load_var: date
+              file: tags/date
+            - load_var: release-tag
+              file: tags/tags
+      - in_parallel:
+          steps:
+            - task: generate-docker-creds-config
+              file: pay-ci/ci/tasks/generate-docker-config-file.yml
+              params:
+                USERNAME: ((docker-username))
+                PASSWORD: ((docker-access-token))
+                EMAIL: ((docker-email))
+            - task: assume-role
+              file: pay-ci/ci/tasks/assume-role.yml
+              params:
+                AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
+                AWS_ROLE_SESSION_NAME: codebuild-assume-role
       - load_var: role
         file: assume-role/assume-role.json
         format: json
@@ -1508,22 +1517,23 @@ jobs:
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
       - in_parallel:
-          - task: run-codebuild-egress-amd64
-            attempts: 3
-            file: pay-ci/ci/tasks/run-codebuild.yml
-            params:
-              PATH_TO_CONFIG: "../../../../run-codebuild-configuration/egress-amd64.json"
-              AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-              AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-              AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-          - task: run-codebuild-egress-armv8
-            attempts: 3
-            file: pay-ci/ci/tasks/run-codebuild.yml
-            params:
-              PATH_TO_CONFIG: "../../../../run-codebuild-configuration/egress-armv8.json"
-              AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-              AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-              AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          steps:
+            - task: run-codebuild-egress-amd64
+              attempts: 3
+              file: pay-ci/ci/tasks/run-codebuild.yml
+              params:
+                PATH_TO_CONFIG: "../../../../run-codebuild-configuration/egress-amd64.json"
+                AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+            - task: run-codebuild-egress-armv8
+              attempts: 3
+              file: pay-ci/ci/tasks/run-codebuild.yml
+              params:
+                PATH_TO_CONFIG: "../../../../run-codebuild-configuration/egress-armv8.json"
+                AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - task: run-codebuild-egress-manifest
         attempts: 3
         file: pay-ci/ci/tasks/run-codebuild.yml
@@ -1532,6 +1542,18 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: assume-retag-role
+        file: pay-ci/ci/tasks/assume-role.yml
+        output_mapping:
+          assume-role: assume-retag-role
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+          AWS_ROLE_SESSION_NAME: retag-ecr-image-as-release
+      - load_var: retag-role
+        file: assume-retag-role/assume-role.json
+        format: json
+      - load_var: candidate-image-tag
+        file: tags/candidate-tag
       - in_parallel:
           steps:
             - task: retag-candidate-as-release-in-ecr
@@ -1539,7 +1561,7 @@ jobs:
               params:
                 DOCKER_LOGIN_ECR: 1
                 AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate_image_tag))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate-image-tag))"
                 NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:release-tag))"
                 AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
                 AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
@@ -1549,7 +1571,7 @@ jobs:
               params:
                 DOCKER_LOGIN_ECR: 1
                 AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate_image_tag))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate-image-tag))"
                 NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:latest"
                 AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
                 AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1532,6 +1532,28 @@ jobs:
           AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - in_parallel:
+          steps:
+            - task: retag-candidate-as-release-in-ecr
+              file: pay-ci/ci/tasks/manifest-retag.yml
+              params:
+                DOCKER_LOGIN_ECR: 1
+                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate_image_tag))"
+                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:release-tag))"
+                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+            - task: retag-candidate-as-latest-in-ecr
+              file: pay-ci/ci/tasks/manifest-retag.yml
+              params:
+                DOCKER_LOGIN_ECR: 1
+                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate_image_tag))"
+                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:latest"
+                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
     on_failure:
       put: slack-notification
       attempts: 10

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1510,12 +1510,6 @@ jobs:
           RELEASE_NAME: ((.:release-name))
           RELEASE_SHA: ((.:release-sha))
           BUILD_DATE: ((.:date))
-      - task: generate-docker-creds-config
-        file: pay-ci/ci/tasks/generate-docker-config-file.yml
-        params:
-          USERNAME: ((docker-username))
-          PASSWORD: ((docker-access-token))
-          EMAIL: ((docker-email))
       - in_parallel:
           steps:
             - task: run-codebuild-egress-amd64

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -161,6 +161,15 @@ resources:
       tag_regex: "alpha_release-(.*)"
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
+  - name: egress-git-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-dockerfiles
+      branch: main
+      tag_regex: "alpha_release-(.*)"
+      username: alphagov-pay-ci-concourse
+      password: ((github-access-token))
   - name: frontend-git-release
     type: git
     icon: github
@@ -709,6 +718,7 @@ groups:
       - connector-db-migration
   - name: egress
     jobs:
+      - build-and-push-egress-candidate
       - deploy-egress
       - smoke-test-egress
       - push-egress-to-staging-ecr
@@ -1451,12 +1461,102 @@ jobs:
           image: toolbox-ecr-registry-test/image.tar
           additional_tags: toolbox-ecr-registry-test/tag
 
+  - name: build-and-push-egress-candidate
+    plan:
+      - in_parallel:
+        - get: pay-ci
+        - get: egress-git-release
+          trigger: true
+      - task: parse-release-tag
+        file: pay-ci/ci/tasks/parse-release-tag.yml
+        input_mapping:
+          git-release: egress-git-release
+      - in_parallel:
+        - load_var: release-number
+          file: tags/release-number
+        - load_var: release-name
+          file: egress-git-release/.git/ref
+        - load_var: release-sha
+          file: tags/release-sha
+        - load_var: candidate-image-tag
+          file: tags/candidate-tag
+        - load_var: date
+          file: tags/date
+        - task: assume-role
+          file: pay-ci/ci/tasks/assume-role.yml
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
+            AWS_ROLE_SESSION_NAME: codebuild-assume-role
+      - load_var: role
+        file: assume-role/assume-role.json
+        format: json
+      - task: prepare-codebuild
+        file: pay-ci/ci/tasks/prepare-codebuild-multiarch.yml
+        params:
+          PROJECT_TO_BUILD: egress
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          RELEASE_NUMBER: ((.:release-number))
+          RELEASE_NAME: ((.:release-name))
+          RELEASE_SHA: ((.:release-sha))
+          BUILD_DATE: ((.:date))
+      - task: generate-docker-creds-config
+        file: pay-ci/ci/tasks/generate-docker-config-file.yml
+        params:
+          USERNAME: ((docker-username))
+          PASSWORD: ((docker-access-token))
+          EMAIL: ((docker-email))
+      - in_parallel:
+          - task: run-codebuild-egress-amd64
+            attempts: 3
+            file: pay-ci/ci/tasks/run-codebuild.yml
+            params:
+              PATH_TO_CONFIG: "../../../../run-codebuild-configuration/egress-amd64.json"
+              AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+              AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+              AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+          - task: run-codebuild-egress-armv8
+            attempts: 3
+            file: pay-ci/ci/tasks/run-codebuild.yml
+            params:
+              PATH_TO_CONFIG: "../../../../run-codebuild-configuration/egress-armv8.json"
+              AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+              AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+              AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+      - task: run-codebuild-egress-manifest
+        attempts: 3
+        file: pay-ci/ci/tasks/run-codebuild.yml
+        params:
+          PATH_TO_CONFIG: "../../../../run-codebuild-configuration/egress-manifest.json"
+          AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-announce'
+        silent: true
+        text: ':red-circle: egress candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: '#govuk-pay-activity'
+        silent: true
+        text: ':hammer: egress candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
   - name: deploy-egress
     serial: true
     serial_groups: [deploy-application]
     plan:
       - get: egress-ecr-registry-test
-        trigger: true
+        # trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag
@@ -1504,7 +1604,6 @@ jobs:
           ENVIRONMENT: test-12
     <<: *put_success_slack_notification
     <<: *put_failure_slack_notification
-
 
   - name: smoke-test-egress
     serial_groups: [smoke-test]

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1556,7 +1556,7 @@ jobs:
     serial_groups: [deploy-application]
     plan:
       - get: egress-ecr-registry-test
-        # trigger: true
+        trigger: true
       - get: pay-infra
       - get: pay-ci
       - load_var: application_image_tag

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -167,7 +167,7 @@ resources:
     source:
       uri: https://github.com/alphagov/pay-dockerfiles
       branch: main
-      tag_regex: "alpha_release-(.*)"
+      tag_regex: "egress_alpha_release-(.*)"
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
   - name: frontend-git-release


### PR DESCRIPTION
Build multi-arch egress proxy in CodeBuild, and push to ECR. This is not pushed to Docker Hub.

* [Concourse Build](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-egress-candidate/builds/16)
* [Images in ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/223851549868/govukpay/egress?region=eu-west-1)
* [Smoke test](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/smoke-test-egress/builds/52) 