### PR TITLE
PP-12074: Copy multi-arch images from test to staging for adminusers

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1,3 +1,40 @@
+definitions:
+  - &assume_copy_from_test_ecr_role
+    task: assume-copy-from-ecr-test-role
+    file: pay-ci/ci/tasks/assume-role.yml
+    output_mapping:
+      assume-role: assume-copy-from-ecr-test-role
+    params:
+      AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      AWS_ROLE_SESSION_NAME: copy-from-ecr-in-test
+  - &assume_write_to_staging_ecr_role
+    task: assume-write-to-ecr-staging-role
+    file: pay-ci/ci/tasks/assume-role.yml
+    output_mapping:
+      assume-role: assume-write-to-ecr-staging-role
+    params:
+      AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+      AWS_ROLE_SESSION_NAME: copy-to-ecr-in-staging
+  - &load_copy_from_test_ecr_role
+    load_var: copy-from-test-ecr-role
+    file: assume-copy-from-ecr-test-role/assume-role.json
+    format: json
+  - &load_write_to_staging_ecr_role
+    load_var: write-to-staging-ecr-role
+    file: assume-write-to-ecr-staging-role/assume-role.json
+    format: json
+
+copy_ecr_from_test_to_staging_params: &copy_ecr_from_test_to_staging_params
+  RELEASE_NUMBER:  ((.:release_number))
+  SOURCE_ECR_REGISTRY: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+  DESTINATION_ECR_REGISTRY: "((pay_aws_staging_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+  SOURCE_AWS_ACCESS_KEY_ID: ((.:copy-from-test-ecr-role.AWS_ACCESS_KEY_ID))
+  SOURCE_AWS_SECRET_ACCESS_KEY: ((.:copy-from-test-ecr-role.AWS_SECRET_ACCESS_KEY))
+  SOURCE_AWS_SESSION_TOKEN: ((.:copy-from-test-ecr-role.AWS_SESSION_TOKEN))
+  DESTINATION_AWS_ACCESS_KEY_ID: ((.:write-to-staging-ecr-role.AWS_ACCESS_KEY_ID))
+  DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:write-to-staging-ecr-role.AWS_SECRET_ACCESS_KEY))
+  DESTINATION_AWS_SESSION_TOKEN: ((.:write-to-staging-ecr-role.AWS_SESSION_TOKEN))
+
 aws_test_config: &aws_test_config
   aws_access_key_id: ((readonly_access_key_id))
   aws_secret_access_key: ((readonly_secret_access_key))
@@ -585,12 +622,6 @@ resources:
     icon: docker
     source:
       repository: govukpay/frontend
-      <<: *aws_staging_config
-  - name: adminusers-ecr-registry-staging
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/adminusers
       <<: *aws_staging_config
   - name: connector-ecr-registry-staging
     type: registry-image
@@ -2437,15 +2468,35 @@ jobs:
 
   - name: push-adminusers-to-staging-ecr
     plan:
-      - get: adminusers-ecr-registry-test
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-test
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [adminusers-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: adminusers-ecr-registry-test
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_test_ecr_role
+          - *assume_write_to_staging_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_test_ecr_role
+          - *load_write_to_staging_ecr_role
+      - task: copy-images-to-staging
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [adminusers-pact-tag]
-      - put: adminusers-ecr-registry-staging
-        params:
-          image: adminusers-ecr-registry-test/image.tar
-          additional_tags: adminusers-ecr-registry-test/tag
+          ECR_REPO_NAME: "govukpay/adminusers"
+          <<: *copy_ecr_from_test_to_staging_params
 
   - name: build-and-push-connector-candidate
     plan:

--- a/ci/tasks/parse-ecr-release-tag.yml
+++ b/ci/tasks/parse-ecr-release-tag.yml
@@ -1,0 +1,21 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: alpine
+    tag: latest
+inputs:
+  - name: ecr-image
+outputs:
+  - name: ecr-release-info
+run:
+  path: ash
+  args:
+    - -ec
+    - |
+      echo -n "ECR Image Tag: "
+      cat ecr-image/tag
+      RELEASE_NUMBER=$(cut -f 1 -d "-" < ecr-image/tag)
+      echo -n "Release number: "
+      echo "${RELEASE_NUMBER}" | tee ecr-release-info/release-number
+


### PR DESCRIPTION
Copy multi-arch images for adminusers from test to staging.

I've made some of the config anchors so they can be reused in the million other places they are needed and they don't change at all.

You can see a successful copy:

![Screenshot 2024-01-22 at 15 44 25](https://github.com/alphagov/pay-ci/assets/2170030/eb211dac-8af9-4732-bd3f-b092c45f71d7)

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/push-adminusers-to-staging-ecr/builds/605