### PR TITLE
BAU pin `dind` for concourse runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+    - dependency-name: "docker"
+      update-types: ["version-update:semver-major"]
   open-pull-requests-limit: 10
   labels:
     - dependencies


### PR DESCRIPTION
### WHAT

Stop dependabot from trying to update to a `dind` version that pact tests are not compatible with.