### PR TITLE
BAU: Remove Stripe 3DS smoke test temporarily

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -183,12 +183,6 @@ efinitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_prod"
-      - task: run_create_card_payment_stripe_3ds-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_stripe_3ds_prod"
       - task: run_recurring_card_payment_stripe-production
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -184,12 +184,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_stag"
-      - task: run_create_card_payment_stripe_3ds-staging
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_stripe_3ds_stag"
       - task: run_recurring_card_payment_stripe-staging
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -892,12 +892,6 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_test"
-      - task: run_create_card_payment_stripe_3ds-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_stripe_3ds_test"
       - task: run_recurring_card_payment_stripe-test
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:


### PR DESCRIPTION
## WHAT
- The Stripe 3DS smoke test has been failing with the below error message. It looks like Stripe 3DS iframe DOM has changed

> Failure Reason: "TimeoutError: Waiting for selector `iframe.FullscreenFrame` failed: Waiting failed: 30000ms exceeded Stack: TimeoutError: Waiting for selector `iframe.FullscreenFrame` failed: Waiting failed: 30000ms exceeded\n    at Timeout.<anonymous> (/opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/common/WaitTask.js:65:32)\n    at listOnTimeout (node:internal/timers:569:17)\n    at process.processTimers (node:internal/timers:512:7) for step: Click submit button on 3DS page"

- Temporarily remove the test while we investigate and fix the test