### PR TITLE
PP-12074-copy-all-multiarch-builds-to-prod

### DIFF
--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -392,13 +392,6 @@ resources:
       repository: govukpay/webhooks
       variant: release
       <<: *aws_staging_config
-  - name: webhooks-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/webhooks
-      variant: release
-      <<: *aws_production_config
   - name: notifications-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -3076,15 +3069,35 @@ jobs:
 
   - name: push-webhooks-to-production-ecr
     plan:
-      - get: webhooks-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: webhooks-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [webhooks-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: webhooks-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [webhooks-pact-tag]
-      - put: webhooks-ecr-registry-prod
-        params:
-          image: webhooks-ecr-registry-staging/image.tar
-          additional_tags: webhooks-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/webhooks"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: webhooks-db-migration-staging
     plan:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -392,12 +392,6 @@ resources:
       repository: govukpay/nginx-forward-proxy
       variant: release
       <<: *aws_staging_config
-  - name: nginx-forward-proxy-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/nginx-forward-proxy
-      <<: *aws_production_config
   - name: notifications-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -3201,15 +3195,35 @@ jobs:
 
   - name: push-nginx-forward-proxy-to-production-ecr
     plan:
-      - get: nginx-forward-proxy-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: nginx-forward-proxy-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [smoke-test-frontend-on-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: nginx-forward-proxy-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [smoke-test-frontend-on-staging]
-      - put: nginx-forward-proxy-ecr-registry-prod
-        params:
-          image: nginx-forward-proxy-ecr-registry-staging/image.tar
-          additional_tags: nginx-forward-proxy-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/nginx-forward-proxy"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-notifications-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -385,12 +385,6 @@ resources:
       repository: govukpay/docker-nginx-proxy
       variant: release
       <<: *aws_staging_config
-  - name: nginx-proxy-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/docker-nginx-proxy
-      <<: *aws_production_config
   - name: nginx-forward-proxy-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -3175,15 +3169,36 @@ jobs:
 
   - name: push-nginx-proxy-to-production-ecr
     plan:
-      - get: nginx-proxy-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: nginx-proxy-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [deploy-toolbox-to-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: nginx-proxy-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [deploy-toolbox-to-staging]
-      - put: nginx-proxy-ecr-registry-prod
-        params:
-          image: nginx-proxy-ecr-registry-staging/image.tar
-          additional_tags: nginx-proxy-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/docker-nginx-proxy"
+          <<: *copy_ecr_from_staging_to_prod_params
+
   - name: push-nginx-forward-proxy-to-production-ecr
     plan:
       - get: nginx-forward-proxy-ecr-registry-staging

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -308,13 +308,6 @@ resources:
       repository: govukpay/webhooks-egress
       variant: release
       <<: *aws_staging_config
-  - name: webhooks-egress-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/webhooks-egress
-      variant: release
-      <<: *aws_production_config
   - name: frontend-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -1388,15 +1381,35 @@ jobs:
 
   - name: push-webhooks-egress-to-production-ecr
     plan:
-      - get: webhooks-egress-ecr-registry-staging
-        passed: [smoke-test-webhooks-egress-on-staging]
+      - in_parallel:
+          steps:
+          - get: webhooks-egress-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [smoke-test-webhooks-egress-on-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: webhooks-egress-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-      - put: webhooks-egress-ecr-registry-prod
-        params:
-          image: webhooks-egress-ecr-registry-staging/image.tar
-          additional_tags: webhooks-egress-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/webhooks-egress"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-frontend-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -392,12 +392,6 @@ resources:
       repository: govukpay/nginx-forward-proxy
       variant: release
       <<: *aws_staging_config
-  - name: notifications-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/notifications
-      <<: *aws_production_config
   - name: stream-s3-sqs-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -3340,12 +3334,32 @@ jobs:
 
   - name: push-notifications-to-production-ecr
     plan:
-      - get: notifications-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: notifications-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [smoke-test-notifications-on-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: notifications-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [smoke-test-notifications-on-staging]
-      - put: notifications-ecr-registry-prod
-        params:
-          image: notifications-ecr-registry-staging/image.tar
-          additional_tags: notifications-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/notifications"
+          <<: *copy_ecr_from_staging_to_prod_params

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -435,12 +435,6 @@ resources:
       repository: govukpay/webhooks
       variant: release
       <<: *aws_production_config
-  - name: ledger-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/ledger
-      <<: *aws_production_config
   - name: notifications-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -2852,24 +2846,35 @@ jobs:
 
   - name: push-ledger-to-production-ecr
     plan:
-      - get: ledger-ecr-registry-staging
-        params:
-          format: oci
-        trigger: true
-        passed: [ledger-pact-tag]
-      - get: pay-ci
-      - task: parse-staging-release-tag
-        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+      - in_parallel:
+          steps:
+          - get: ledger-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [ledger-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
-          ecr-repo: ledger-ecr-registry-staging
-      - load_var: application_image_tag
-        file: ledger-ecr-registry-staging/tag
-      - load_var: parse_staging_release_tag
-        file: parse-staging-release-tag/tag
-      - put: ledger-ecr-registry-prod
+          ecr-image: ledger-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          image: ledger-ecr-registry-staging/image.tar
-          additional_tags: ledger-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/ledger"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-webhooks-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -396,12 +396,6 @@ resources:
       repository: govukpay/publicapi
       variant: release
       <<: *aws_staging_config
-  - name: publicapi-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/publicapi
-      <<: *aws_production_config
   - name: ledger-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -2662,15 +2656,35 @@ jobs:
           
   - name: push-publicapi-to-production-ecr
     plan:
-      - get: publicapi-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: publicapi-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [publicapi-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: publicapi-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [publicapi-pact-tag]
-      - put: publicapi-ecr-registry-prod
-        params:
-          image: publicapi-ecr-registry-staging/image.tar
-          additional_tags: publicapi-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/publicapi"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-ledger-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -356,12 +356,6 @@ resources:
       repository: govukpay/publicauth
       variant: release
       <<: *aws_staging_config
-  - name: publicauth-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/publicauth
-      <<: *aws_production_config
   - name: cardid-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -2335,15 +2329,35 @@ jobs:
 
   - name: push-publicauth-to-production-ecr
     plan:
-      - get: publicauth-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: publicauth-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [smoke-test-publicauth-on-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: publicauth-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [smoke-test-publicauth-on-staging]
-      - put: publicauth-ecr-registry-prod
-        params:
-          image: publicauth-ecr-registry-staging/image.tar
-          additional_tags: publicauth-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/publicauth"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-cardid-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -342,12 +342,6 @@ resources:
       repository: govukpay/products
       variant: release
       <<: *aws_staging_config
-  - name: products-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/products
-      <<: *aws_production_config
   - name: products-ui-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -1972,15 +1966,35 @@ jobs:
 
   - name: push-products-to-production-ecr
     plan:
-      - get: products-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: products-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [products-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: products-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [products-pact-tag]
-      - put: products-ecr-registry-prod
-        params:
-          image: products-ecr-registry-staging/image.tar
-          additional_tags: products-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/products"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: products-db-migration-staging
     plan:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -321,12 +321,6 @@ resources:
       repository: govukpay/webhooks-egress
       variant: release
       <<: *aws_production_config
-  - name: egress-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/egress
-      <<: *aws_production_config
   - name: frontend-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -1306,15 +1300,35 @@ jobs:
 
   - name: push-egress-to-production-ecr
     plan:
-      - get: egress-ecr-registry-staging
-        passed: [smoke-test-egress-on-staging]
+      - in_parallel:
+          steps:
+          - get: egress-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [smoke-test-egress-on-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: egress-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-      - put: egress-ecr-registry-prod
-        params:
-          image: egress-ecr-registry-staging/image.tar
-          additional_tags: egress-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/egress"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-webhooks-egress-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -294,12 +294,6 @@ resources:
       repository: govukpay/toolbox
       variant: release
       <<: *aws_staging_config
-  - name: toolbox-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/toolbox
-      <<: *aws_production_config
   - name: egress-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -1159,24 +1153,35 @@ jobs:
 
   - name: push-toolbox-to-production-ecr
     plan:
-      - get: toolbox-ecr-registry-staging
-        params:
-          format: oci
-        trigger: true
-        passed: [deploy-toolbox-to-staging]
-      - get: pay-ci
-      - task: parse-staging-release-tag
-        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+      - in_parallel:
+          steps:
+          - get: toolbox-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [deploy-toolbox-to-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
-          ecr-repo: toolbox-ecr-registry-staging
-      - load_var: application_image_tag
-        file: toolbox-ecr-registry-staging/tag
-      - load_var: parse_staging_release_tag
-        file: parse-staging-release-tag/tag
-      - put: toolbox-ecr-registry-prod
+          ecr-image: toolbox-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          image: toolbox-ecr-registry-staging/image.tar
-          additional_tags: toolbox-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/toolbox"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-egress-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -400,12 +400,6 @@ resources:
       repository: govukpay/connector
       variant: release
       <<: *aws_staging_config
-  - name: connector-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/connector
-      <<: *aws_production_config
   - name: selfservice-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -1107,15 +1101,35 @@ jobs:
 
   - name: push-connector-to-production-ecr
     plan:
-      - get: connector-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: connector-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [connector-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: connector-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [connector-pact-tag]
-      - put: connector-ecr-registry-prod
-        params:
-          image: connector-ecr-registry-staging/image.tar
-          additional_tags: connector-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/connector"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-toolbox-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -349,12 +349,6 @@ resources:
       repository: govukpay/products-ui
       variant: release
       <<: *aws_staging_config
-  - name: products-ui-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/products-ui
-      <<: *aws_production_config
   - name: publicauth-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -2181,15 +2175,35 @@ jobs:
 
   - name: push-products-ui-to-production-ecr
     plan:
-      - get: products-ui-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: products-ui-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [products-ui-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: products-ui-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [products-ui-pact-tag]
-      - put: products-ui-ecr-registry-prod
-        params:
-          image: products-ui-ecr-registry-staging/image.tar
-          additional_tags: products-ui-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/products-ui"
+          <<: *copy_ecr_from_staging_to_prod_params
           
   - name: deploy-publicauth-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -62,7 +62,6 @@ check_release_versions_params: &check_release_versions_params
   APPLICATION_IMAGE_TAG: ((.:application_image_tag))
   ADOT_IMAGE_TAG: ((.:adot_image_tag))
   NGINX_IMAGE_TAG: ((.:nginx_image_tag))
-
   
 aws_production_config: &aws_production_config
   aws_access_key_id: ((readonly_access_key_id))
@@ -267,13 +266,6 @@ resources:
       repository: govukpay/adot
       variant: release
       <<: *aws_staging_config
-  - name: adot-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/adot
-      variant: release
-      <<: *aws_production_config
   - name: alpine-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -573,23 +565,34 @@ groups:
 jobs:
   - name: push-adot-to-production-ecr
     plan:
-      - get: adot-ecr-registry-staging
-        params:
-          format: oci
-        trigger: true
-      - load_var: application_image_tag
-        file: adot-ecr-registry-staging/tag
-      - get: pay-ci
-      - task: parse-staging-release-tag
-        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+      - in_parallel:
+          steps:
+          - get: adot-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
-          ecr-repo: adot-ecr-registry-staging
-      - load_var: parse_staging_release_tag
-        file: parse-staging-release-tag/tag
-      - put: adot-ecr-registry-prod
+          ecr-image: adot-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          image: adot-ecr-registry-staging/image.tar
-          additional_tags: adot-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/adot"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: push-stream-s3-sqs-to-production-ecr
     plan:        

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -377,12 +377,6 @@ resources:
       repository: govukpay/selfservice
       variant: release
       <<: *aws_staging_config
-  - name: selfservice-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/selfservice
-      <<: *aws_production_config
   - name: publicapi-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -854,24 +848,35 @@ jobs:
 
   - name: push-selfservice-to-production-ecr
     plan:
-      - get: selfservice-ecr-registry-staging
-        params:
-          format: oci
-        trigger: true
-        passed: [selfservice-pact-tag]
-      - get: pay-ci
-      - task: parse-staging-release-tag
-        file: pay-ci/ci/tasks/parse-staging-release-tag.yml
+      - in_parallel:
+          steps:
+          - get: selfservice-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [selfservice-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
-          ecr-repo: selfservice-ecr-registry-staging
-      - load_var: application_image_tag
-        file: selfservice-ecr-registry-staging/tag
-      - load_var: parse_staging_release_tag
-        file: parse-staging-release-tag/tag
-      - put: selfservice-ecr-registry-prod
+          ecr-image: selfservice-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          image: selfservice-ecr-registry-staging/image.tar
-          additional_tags: selfservice-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/selfservice"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-connector-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -399,13 +399,6 @@ resources:
       repository: govukpay/stream-s3-sqs
       variant: release
       <<: *aws_staging_config
-  - name: stream-s3-sqs-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/stream-s3-sqs
-      variant: release
-      <<: *aws_production_config            
   - name: slack-notification
     type: slack-notification
     source:
@@ -572,17 +565,35 @@ jobs:
 
   - name: push-stream-s3-sqs-to-production-ecr
     plan:        
-      - get: stream-s3-sqs-ecr-registry-staging
-        passed: [deploy-scheduled-tasks]
+      - in_parallel:
+          steps:
+          - get: stream-s3-sqs-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [deploy-scheduled-tasks]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: stream-s3-sqs-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-      - put: stream-s3-sqs-ecr-registry-prod
-        params:
-          image: stream-s3-sqs-ecr-registry-staging/image.tar
-          additional_tags: stream-s3-sqs-ecr-registry-staging/tag
-        get_params:
-          skip_download: true  
+          ECR_REPO_NAME: "govukpay/stream-s3-sqs"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: update-deploy-to-staging-pipeline
     plan:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -328,12 +328,6 @@ resources:
       repository: govukpay/frontend
       variant: release
       <<: *aws_staging_config
-  - name: frontend-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/frontend
-      <<: *aws_production_config
   - name: adminusers-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -1581,15 +1575,35 @@ jobs:
 
   - name: push-frontend-to-production-ecr
     plan:
-      - get: frontend-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: frontend-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [frontend-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: frontend-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [frontend-pact-tag]
-      - put: frontend-ecr-registry-prod
-        params:
-          image: frontend-ecr-registry-staging/image.tar
-          additional_tags: frontend-ecr-registry-staging/tag
+          ECR_REPO_NAME: "govukpay/frontend"
+          <<: *copy_ecr_from_staging_to_prod_params
           
   - name: deploy-adminusers-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -273,12 +273,6 @@ resources:
       repository: govukpay/alpine
       variant: release
       <<: *aws_staging_config
-  - name: alpine-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/alpine
-      <<: *aws_production_config
   - name: toolbox-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -667,17 +661,35 @@ jobs:
 
   - name: push-alpine-to-production-ecr
     plan:
-      - get: alpine-ecr-registry-staging
-        passed: [deploy-scheduled-tasks]
+      - in_parallel:
+          steps:
+          - get: alpine-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [deploy-scheduled-tasks]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: alpine-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-      - put: alpine-ecr-registry-prod
-        params:
-          image: alpine-ecr-registry-staging/image.tar
-          additional_tags: alpine-ecr-registry-staging/tag
-        get_params:
-          skip_download: true
+          ECR_REPO_NAME: "govukpay/alpine"
+          <<: *copy_ecr_from_staging_to_prod_params
 
   - name: deploy-selfservice-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -393,12 +393,6 @@ resources:
       repository: govukpay/cardid
       variant: release
       <<: *aws_staging_config
-  - name: cardid-ecr-registry-prod
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/cardid
-      <<: *aws_production_config
   - name: connector-ecr-registry-staging
     type: registry-image
     icon: docker
@@ -2433,15 +2427,35 @@ jobs:
 
   - name: push-cardid-to-production-ecr
     plan:
-      - get: cardid-ecr-registry-staging
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [cardid-pact-tag]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: cardid-ecr-registry-staging
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_staging_ecr_role
+          - *assume_write_to_prod_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_staging_ecr_role
+          - *load_write_to_prod_ecr_role
+      - task: copy-images-to-prod
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          format: oci
-        trigger: true
-        passed: [cardid-pact-tag]
-      - put: cardid-ecr-registry-prod
-        params:
-          image: cardid-ecr-registry-staging/image.tar
-          additional_tags: cardid-ecr-registry-staging/tag
+         ECR_REPO_NAME: "govukpay/cardid"
+         <<: *copy_ecr_from_staging_to_prod_params
           
   - name: deploy-publicapi-to-staging
     serial: true


### PR DESCRIPTION
Push all multiarch builds from staging to production. Adminusers has already been done, in #1037.

This is a big change, but to make reviewing as easy as possible, each application is in its own commit. (Which will be squashed on merge.)

Everything has been tested by running the relevant `push-XXXX-to-production-ecr` job in Concourse.