### PR TITLE
PP-12075-copy-adminusers-to-test-perf

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1,200 +1,236 @@
-efinitions:
-  aws_assumed_role_creds: &aws_assumed_role_creds
-    AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-    AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-    AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+definitions:
+  - &assume_copy_from_prod_ecr_role
+    task: assume-copy-from-ecr-prod-role
+    file: pay-ci/ci/tasks/assume-role.yml
+    output_mapping:
+      assume-role: assume-copy-from-ecr-prod-role
+    params:
+      AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+      AWS_ROLE_SESSION_NAME: copy-from-ecr-in-prod
+  - &assume_write_to_test_ecr_role
+    task: assume-write-to-ecr-test-role
+    file: pay-ci/ci/tasks/assume-role.yml
+    output_mapping:
+      assume-role: assume-write-to-ecr-test-role
+    params:
+      AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+      AWS_ROLE_SESSION_NAME: copy-to-ecr-in-test
+  - &load_copy_from_prod_ecr_role
+    load_var: copy-from-prod-ecr-role
+    file: assume-copy-from-ecr-prod-role/assume-role.json
+    format: json
+  - &load_write_to_test_ecr_role
+    load_var: write-to-test-ecr-role
+    file: assume-write-to-ecr-test-role/assume-role.json
+    format: json
 
-  wait_for_deploy_params: &wait_for_deploy_params
-    <<: *aws_assumed_role_creds
-    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
-    ADOT_IMAGE_TAG: ((.:adot_image_tag))
-    ENVIRONMENT: production-2
+copy_ecr_from_prod_to_test_params: &copy_ecr_from_prod_to_test_params
+  RELEASE_NUMBER:  ((.:release_number))
+  SOURCE_ECR_REGISTRY: "((pay_aws_prod_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+  DESTINATION_ECR_REGISTRY: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+  SOURCE_AWS_ACCESS_KEY_ID: ((.:copy-from-prod-ecr-role.AWS_ACCESS_KEY_ID))
+  SOURCE_AWS_SECRET_ACCESS_KEY: ((.:copy-from-prod-ecr-role.AWS_SECRET_ACCESS_KEY))
+  SOURCE_AWS_SESSION_TOKEN: ((.:copy-from-prod-ecr-role.AWS_SESSION_TOKEN))
+  DESTINATION_AWS_ACCESS_KEY_ID: ((.:write-to-test-ecr-role.AWS_ACCESS_KEY_ID))
+  DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:write-to-test-ecr-role.AWS_SECRET_ACCESS_KEY))
+  DESTINATION_AWS_SESSION_TOKEN: ((.:write-to-test-ecr-role.AWS_SESSION_TOKEN))
 
-  deploy_params: &deploy_params
-    <<: *aws_assumed_role_creds
-    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
-    ADOT_IMAGE_TAG: ((.:adot_image_tag))
-    ACCOUNT: production
-    ENVIRONMENT: production-2
+aws_assumed_role_creds: &aws_assumed_role_creds
+  AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+  AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+  AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
-  check_release_versions_params: &check_release_versions_params
-    <<: *aws_assumed_role_creds
-    AWS_REGION: "eu-west-1"
-    CLUSTER_NAME: "production-2-fargate"
-    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-    ADOT_IMAGE_TAG: ((.:adot_image_tag))
-    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+wait_for_deploy_params: &wait_for_deploy_params
+  <<: *aws_assumed_role_creds
+  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+  ADOT_IMAGE_TAG: ((.:adot_image_tag))
+  ENVIRONMENT: production-2
 
-  aws_prod_config: &aws_prod_config
-    aws_access_key_id: ((readonly_access_key_id))
-    aws_secret_access_key: ((readonly_secret_access_key))
-    aws_session_token: ((readonly_session_token))
-    aws_role_arn: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
-    aws_ecr_registry_id: "((pay_aws_prod_account_id))"
-    aws_region: eu-west-1
+deploy_params: &deploy_params
+  <<: *aws_assumed_role_creds
+  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+  ADOT_IMAGE_TAG: ((.:adot_image_tag))
+  ACCOUNT: production
+  ENVIRONMENT: production-2
 
-  aws_test_config: &aws_test_config
-    aws_access_key_id: ((readonly_access_key_id))
-    aws_secret_access_key: ((readonly_secret_access_key))
-    aws_session_token: ((readonly_session_token))
-    aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse_deploy_worker_ecr_access
-    aws_ecr_registry_id: "((pay_aws_test_account_id))"
-    aws_region: eu-west-1
+check_release_versions_params: &check_release_versions_params
+  <<: *aws_assumed_role_creds
+  AWS_REGION: "eu-west-1"
+  CLUSTER_NAME: "production-2-fargate"
+  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+  ADOT_IMAGE_TAG: ((.:adot_image_tag))
+  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
 
-  put_start_slack_notification: &put_start_slack_notification
+aws_prod_config: &aws_prod_config
+  aws_access_key_id: ((readonly_access_key_id))
+  aws_secret_access_key: ((readonly_secret_access_key))
+  aws_session_token: ((readonly_session_token))
+  aws_role_arn: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
+  aws_ecr_registry_id: "((pay_aws_prod_account_id))"
+  aws_region: eu-west-1
+
+aws_test_config: &aws_test_config
+  aws_access_key_id: ((readonly_access_key_id))
+  aws_secret_access_key: ((readonly_secret_access_key))
+  aws_session_token: ((readonly_session_token))
+  aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse_deploy_worker_ecr_access
+  aws_ecr_registry_id: "((pay_aws_test_account_id))"
+  aws_region: eu-west-1
+
+put_start_slack_notification: &put_start_slack_notification
+  put: slack-notification
+  params:
+    channel: '#govuk-pay-announce'
+    icon_emoji: ":fargate:"
+    username: pay-concourse
+    text: "((.:start_snippet)) \n\n
+          <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+put_success_slack_notification_p1: &put_success_slack_notification_p1
+  on_success:
     put: slack-notification
     params:
       channel: '#govuk-pay-announce'
       icon_emoji: ":fargate:"
       username: pay-concourse
-      text: "((.:start_snippet)) \n\n
+      text: "((.:success_snippet)) \n\n
             <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-  put_success_slack_notification_p1: &put_success_slack_notification_p1
-    on_success:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-announce'
-        icon_emoji: ":fargate:"
-        username: pay-concourse
-        text: "((.:success_snippet)) \n\n
-              <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+put_success_slack_notification: &put_success_slack_notification
+  on_success:
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-activity'
+      icon_emoji: ":fargate:"
+      username: pay-concourse
+      text: "((.:success_snippet)) \n\n
+            Build: https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
 
-  put_success_slack_notification: &put_success_slack_notification
-    on_success:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-activity'
-        icon_emoji: ":fargate:"
-        username: pay-concourse
-        text: "((.:success_snippet)) \n\n
-              Build: https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+put_failure_slack_notification: &put_failure_slack_notification
+  on_failure:
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-announce'
+      icon_emoji: ":fargate:"
+      username: pay-concourse
+      text: "((.:failure_snippet)) \n
+            - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-  put_failure_slack_notification: &put_failure_slack_notification
-    on_failure:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-announce'
-        icon_emoji: ":fargate:"
-        username: pay-concourse
-        text: "((.:failure_snippet)) \n
-              - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+put_db_migration_slack_notification: &put_db_migration_slack_notification
+  put: slack-notification
+  params:
+    channel: '#govuk-pay-announce'
+    icon_emoji: ":postgres:"
+    username: pay-concourse
+    text: ":postgres: starting $BUILD_JOB_NAME on production-2\n
+          - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-  put_db_migration_slack_notification: &put_db_migration_slack_notification
+put_db_migration_success_slack_notification: &put_db_migration_success_slack_notification
+  on_success:
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-activity'
+      icon_emoji: ":postgres:"
+      username: pay-concourse
+      text: ":green-circle: $BUILD_JOB_NAME completed successfully on production-2\n
+            - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+put_db_migration_failure_slack_notification: &put_db_migration_failure_slack_notification
+  on_failure:
     put: slack-notification
     params:
       channel: '#govuk-pay-announce'
       icon_emoji: ":postgres:"
       username: pay-concourse
-      text: ":postgres: starting $BUILD_JOB_NAME on production-2\n
+      text: ":red-circle: $BUILD_JOB_NAME failed on production-2\n
             - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-  put_db_migration_success_slack_notification: &put_db_migration_success_slack_notification
-    on_success:
-      put: slack-notification
+snippet_params_all_versions: &snippet_params_all_versions
+  ENV: production-2
+  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+  ADOT_IMAGE_TAG: ((.:adot_image_tag))
+  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+
+snippet_params_app_version: &snippet_params_app_version
+  ENV: production-2
+  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+
+# Separate tasks for each combination of scenario/environment
+smoke-test-run-all-on-production: &smoke-test-run-all-on-production
+  limit: 8
+  steps:
+    - task: run_create_card_payment_sandbox-production
+      file: pay-ci/ci/tasks/run-smoke-test.yml
       params:
-        channel: '#govuk-pay-activity'
-        icon_emoji: ":postgres:"
-        username: pay-concourse
-        text: ":green-circle: $BUILD_JOB_NAME completed successfully on production-2\n
-              - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-
-  put_db_migration_failure_slack_notification: &put_db_migration_failure_slack_notification
-    on_failure:
-      put: slack-notification
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "card_sandbox_prod"
+    - task: run_recurring_card_payment_sandbox-production
+      file: pay-ci/ci/tasks/run-smoke-test.yml
       params:
-        channel: '#govuk-pay-announce'
-        icon_emoji: ":postgres:"
-        username: pay-concourse
-        text: ":red-circle: $BUILD_JOB_NAME failed on production-2\n
-              - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-
-  snippet_params_all_versions: &snippet_params_all_versions
-    ENV: production-2
-    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-    ADOT_IMAGE_TAG: ((.:adot_image_tag))
-    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
-
-  snippet_params_app_version: &snippet_params_app_version
-    ENV: production-2
-    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-
-  # Separate tasks for each combination of scenario/environment
-  smoke-test-run-all-on-production: &smoke-test-run-all-on-production
-    limit: 8
-    steps:
-      - task: run_create_card_payment_sandbox-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_sandbox_prod"
-      - task: run_recurring_card_payment_sandbox-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "rec_card_sandbox_prod"
-      - task: run_create_card_payment_worldpay_with_3ds2-production
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds2_prod"
-      - task: run_create_card_payment_worldpay_with_3ds2_exemption-production
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds2ex_prod"
-      - task: run_create_card_payment_worldpay_without_3ds-production
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_prod"
-      - task: run_recurring_card_payment_worldpay-production
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "reccard_worldpay_prod"
-      - task: run_cancel_card_payment_sandbox-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "cancel_sandbox_prod"
-      - task: run_use_payment_link_sandbox-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "pymntlnk_sandbox_prod"
-      - task: run_create_card_payment_stripe-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_stripe_prod"
-      - task: run_recurring_card_payment_stripe-production
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "rec_card_stripe_prod"
-      - task: run_notifications_sandbox-prod
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "notifcatns_sndbx_prod"
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "rec_card_sandbox_prod"
+    - task: run_create_card_payment_worldpay_with_3ds2-production
+      attempts: 10
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "card_wpay_3ds2_prod"
+    - task: run_create_card_payment_worldpay_with_3ds2_exemption-production
+      attempts: 10
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "card_wpay_3ds2ex_prod"
+    - task: run_create_card_payment_worldpay_without_3ds-production
+      attempts: 10
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "card_wpay_prod"
+    - task: run_recurring_card_payment_worldpay-production
+      attempts: 10
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "reccard_worldpay_prod"
+    - task: run_cancel_card_payment_sandbox-production
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "cancel_sandbox_prod"
+    - task: run_use_payment_link_sandbox-production
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "pymntlnk_sandbox_prod"
+    - task: run_create_card_payment_stripe-production
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "card_stripe_prod"
+    - task: run_recurring_card_payment_stripe-production
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "rec_card_stripe_prod"
+    - task: run_notifications_sandbox-prod
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "notifcatns_sndbx_prod"
 
 resources:
   - name: deploy-to-prod-pipeline-definition
@@ -308,12 +344,12 @@ resources:
       repository: govukpay/adminusers
       variant: release
       <<: *aws_prod_config
-  - name: adminusers-ecr-registry-test
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/adminusers
-      <<: *aws_test_config
+  # - name: adminusers-ecr-registry-test
+  #   type: registry-image
+  #   icon: docker
+  #   source:
+  #     repository: govukpay/adminusers
+  #     <<: *aws_test_config
   - name: products-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -1498,20 +1534,39 @@ jobs:
 
   - name: retag-adminusers-image-for-test-perf-db
     plan:
-      - get: pay-ci
-      - get: adminusers-ecr-registry-prod
-        params:
-          format: oci
-        passed: [adminusers-db-migration-prod]
-        trigger: true
+    plan:
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-staging
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [adminusers-pact-tag]
+          - get: pay-ci
       - task: parse-perf-release-tag
         file: pay-ci/ci/tasks/parse-perf-db-release-tag.yml
         input_mapping:
           ecr-repo: adminusers-ecr-registry-prod
-      - put: adminusers-ecr-registry-test
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_prod_ecr_role
+          - *assume_write_to_test_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_prod_ecr_role
+          - *load_write_to_test_ecr_role
+      - load_var: perf-tag
+        file: parse-perf-db-release-tag/tag
+      - task: copy-images-to-test-perf
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          image: adminusers-ecr-registry-prod/image.tar
-          additional_tags: parse-perf-db-release-tag/tag
+          TAG_LABEL: "test"
+          ECR_REPO_NAME: "govukpay/adminusers"
+          <<: *copy_ecr_from_prod_to_test_params
 
   - name: smoke-test-adminusers-on-prod
     serial_groups: [smoke-test]

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -344,12 +344,6 @@ resources:
       repository: govukpay/adminusers
       variant: release
       <<: *aws_prod_config
-  # - name: adminusers-ecr-registry-test
-  #   type: registry-image
-  #   icon: docker
-  #   source:
-  #     repository: govukpay/adminusers
-  #     <<: *aws_test_config
   - name: products-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -1534,10 +1528,9 @@ jobs:
 
   - name: retag-adminusers-image-for-test-perf-db
     plan:
-    plan:
       - in_parallel:
           steps:
-          - get: adminusers-ecr-registry-staging
+          - get: adminusers-ecr-registry-prod
             params:
               skip_download: true
               format: oci
@@ -1602,20 +1595,38 @@ jobs:
 
   - name: retag-adminusers-image-for-test-perf
     plan:
-      - get: pay-ci
-      - get: adminusers-ecr-registry-prod
-        params:
-          format: oci
-        passed: [smoke-test-adminusers-on-prod]
-        trigger: true
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-prod
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [adminusers-pact-tag]
+          - get: pay-ci
       - task: parse-perf-release-tag
-        file: pay-ci/ci/tasks/parse-perf-release-tag.yml
+        file: pay-ci/ci/tasks/parse-perf-db-release-tag.yml
         input_mapping:
-          ecr-repo: adminusers-ecr-registry-prod        
-      - put: adminusers-ecr-registry-test
+          ecr-repo: adminusers-ecr-registry-prod
+      - load_var: release_number
+        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *assume_copy_from_prod_ecr_role
+          - *assume_write_to_test_ecr_role
+      - in_parallel:
+          steps:
+          - *load_copy_from_prod_ecr_role
+          - *load_write_to_test_ecr_role
+      - load_var: perf-tag
+        file: parse-perf-release-tag/tag
+      - task: copy-images-to-test-perf
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
         params:
-          image: adminusers-ecr-registry-prod/image.tar
-          additional_tags: parse-perf-release-tag/tag        
+          TAG_LABEL: "test"
+          ECR_REPO_NAME: "govukpay/adminusers"
+          <<: *copy_ecr_from_prod_to_test_params
 
   - name: adminusers-pact-tag
     plan:

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -30,7 +30,7 @@ run:
         echo "CLEANUP COMPLETE"
       }
 
-      RELEASE_LABEL=${TAG_LABEL:-candidate}
+      TAG_LABEL=${TAG_LABEL:-candidate}
 
       trap cleanup EXIT
       source /docker-helpers.sh

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -15,6 +15,7 @@ params:
   DESTINATION_AWS_ACCESS_KEY_ID:
   DESTINATION_AWS_SECRET_ACCESS_KEY:
   DESTINATION_AWS_SESSION_TOKEN:
+  TAG_LABEL:
 
 run:
   path: bash
@@ -28,6 +29,8 @@ run:
         stop_docker
         echo "CLEANUP COMPLETE"
       }
+
+      RELEASE_LABEL=${TAG_LABEL:-candidate}
 
       trap cleanup EXIT
       source /docker-helpers.sh
@@ -46,15 +49,15 @@ run:
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
 
       echo "Pulling images"
-      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
-      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" &
 
       echo "Waiting for pulls to complete"
       wait
 
       echo "Retagging images locally"
-      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8"
-      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64"
 
       set +x # This is a safety measure to prevent us accidentally leaking AWS secrets in the future
       AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
@@ -68,8 +71,8 @@ run:
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
 
       echo "Pushing images"
-      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
-      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" &
 
       echo "Waiting for pushes to complete"
       wait
@@ -77,5 +80,5 @@ run:
       echo "Creating release manifest in destination registry"
       docker buildx imagetools create \
         -t "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-release" \
-        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" \
-        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" \
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64"


### PR DESCRIPTION
Copy an the adminusers image from production ECR back to test-perf.

I have modified `ci/tasks/copy-multiarch-image-to-other-account.yml` to allow a tag fragment other than `candidate`. Images are tagged "xxx-test", which I think is the right thing to do.

There is a lot of whitespace in this change, to make the top definitions syntactically correct.