### PR TITLE
PP-12075-retag-adminusers-for-perf-test

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -301,6 +301,13 @@ resources:
     source:
       repository: govukpay/frontend
       <<: *aws_test_config
+  - name: adminusers-candidate
+    type: registry-image
+    icon: docker
+    source:
+      repository: govukpay/adminusers
+      variant: candidate
+      <<: *aws_test_config
   - name: adminusers-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -1579,14 +1586,28 @@ jobs:
             trigger: true
             passed: [adminusers-pact-tag]
           - get: pay-ci
+      # - task: parse-perf-release-tag
+      #   file: pay-ci/ci/tasks/parse-perf-release-tag.yml
+      #   input_mapping:
+      #     ecr-repo: adminusers-ecr-registry-prod
       - task: parse-perf-release-tag
         file: pay-ci/ci/tasks/parse-perf-release-tag.yml
         input_mapping:
           ecr-repo: adminusers-ecr-registry-prod
+      # - task: parse-release-tag
+      #   file: pay-ci/ci/tasks/parse-release-tag.yml
+      #   input_mapping:
+      #     git-release: pay-adminusers-git-release
+      # - put: products-ecr-registry-test
+      #   params:
+      #     image: products-ecr-registry-prod/image.tar
+      #     additional_tags: parse-perf-release-tag/tag
       - in_parallel:
           steps:
-          - load_var: release_number
-            file: ecr-release-info/release-number
+          # - load_var: release_number
+          #   file: ecr-release-info/release-number
+          - load_var: candidate_image_tag
+            file: tags/candidate-tag
           - load_var: perf-tag
             file: parse-perf-release-tag/tag
           - task: assume-retag-role

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1,3 +1,4 @@
+
 definitions:
   aws_assumed_role_creds: &aws_assumed_role_creds
     AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
@@ -110,6 +111,27 @@ definitions:
         username: pay-concourse
         text: ":red-circle: $BUILD_JOB_NAME failed on production-2\n
               - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+  copy_to_eu_west_params: &copy_to_eu_west_params
+    RELEASE_NUMBER:  ((.:release-number))
+    SOURCE_ECR_REGISTRY: "((pay_aws_test_account_id)).dkr.ecr.eu-central-1.amazonaws.com"
+    DESTINATION_ECR_REGISTRY: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+    SOURCE_AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+    SOURCE_AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+    SOURCE_AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+    SOURCE_REGION: eu-central-1
+    DESTINATION_AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+    DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+    DESTINATION_AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+    DESTINATION_REGION: eu-west-1
+
+  retag_for_perf_test: &retag_for_perf_test
+    DOCKER_LOGIN_ECR: 1
+    AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+    SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:release-number))-candidate"
+    AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+    AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+    AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
 
   snippet_params_all_versions: &snippet_params_all_versions
     ENV: production-2
@@ -1533,18 +1555,18 @@ jobs:
       - load_var: retag-role
         file: assume-retag-role/assume-role.json
         format: json
+      - task: copy-images-to-eu-west
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
+        params:
+          ECR_REPO_NAME: "govukpay/adminusers"
+          <<: *copy_to_eu_west_params
       - task: retag-candidate-as-perf-in-ecr
         file: pay-ci/ci/tasks/manifest-retag.yml
         params:
-          DOCKER_LOGIN_ECR: 1
-          REGION: eu-central-1
-          AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:release-number))-candidate"
+          <<: *retag_for_perf_test
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:perf-tag))"
-          AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
-
+          
   - name: smoke-test-adminusers-on-prod
     serial_groups: [smoke-test]
     plan:
@@ -1620,16 +1642,17 @@ jobs:
       - load_var: retag-role
         file: assume-retag-role/assume-role.json
         format: json
+      - task: copy-images-to-eu-west
+        file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
+        privileged: true
+        params:
+          ECR_REPO_NAME: "govukpay/adminusers"
+          <<: *copy_to_eu_west_params
       - task: retag-candidate-as-perf-in-ecr
         file: pay-ci/ci/tasks/manifest-retag.yml
         params:
-          DOCKER_LOGIN_ECR: 1
-          AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:release-number))-candidate"
+          <<: *retag_for_perf_test
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:perf-tag))"
-          AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
-          AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
-          AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
 
   - name: adminusers-pact-tag
     plan:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -234,7 +234,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-12075-retag-adminusers-for-perf-test
+      branch: master
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
   - name: pay-infra

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1530,8 +1530,8 @@ jobs:
         params:
           DOCKER_LOGIN_ECR: 1
           AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate-image-tag))"
-          NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:perf-tag))"
+          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:candidate-image-tag))"
+          NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:perf-tag))"
           AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
@@ -1608,8 +1608,8 @@ jobs:
         params:
           DOCKER_LOGIN_ECR: 1
           AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate-image-tag))"
-          NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:perf-tag))"
+          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:candidate-image-tag))"
+          NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:perf-tag))"
           AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -301,13 +301,6 @@ resources:
     source:
       repository: govukpay/frontend
       <<: *aws_test_config
-  - name: adminusers-ecr-registry-test
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/adminusers
-      variant: release
-      <<: *aws_test_config
   - name: adminusers-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -1501,7 +1494,6 @@ jobs:
     plan:
       - in_parallel:
           steps:
-          - get: adminusers-ecr-registry-test
           - get: adminusers-ecr-registry-prod
             params:
               skip_download: true
@@ -1514,7 +1506,7 @@ jobs:
           - task: parse-ecr-release-tag
             file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
             input_mapping:
-              ecr-image: adminusers-ecr-registry-test
+              ecr-image: adminusers-ecr-registry-prod
           - task: parse-perf-release-tag
             file: pay-ci/ci/tasks/parse-perf-db-release-tag.yml
             input_mapping:
@@ -1588,7 +1580,6 @@ jobs:
     plan:
       - in_parallel:
           steps:
-          - get: adminusers-ecr-registry-test
           - get: adminusers-ecr-registry-prod
             params:
               skip_download: true
@@ -1601,7 +1592,7 @@ jobs:
           - task: parse-ecr-release-tag
             file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
             input_mapping:
-              ecr-image: adminusers-ecr-registry-test
+              ecr-image: adminusers-ecr-registry-prod
           - task: parse-perf-release-tag
             file: pay-ci/ci/tasks/parse-perf-release-tag.yml
             input_mapping:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -212,7 +212,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: PP-12075-retag-adminusers-for-perf-test
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
   - name: pay-infra
@@ -1537,6 +1537,7 @@ jobs:
         file: pay-ci/ci/tasks/manifest-retag.yml
         params:
           DOCKER_LOGIN_ECR: 1
+          REGION: eu-central-1
           AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
           SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:release-number))-candidate"
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:perf-tag))"

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1,4 +1,4 @@
-efinitions:
+definitions:
   aws_assumed_role_creds: &aws_assumed_role_creds
     AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
     AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
@@ -308,12 +308,6 @@ resources:
       repository: govukpay/adminusers
       variant: release
       <<: *aws_prod_config
-  - name: adminusers-ecr-registry-test
-    type: registry-image
-    icon: docker
-    source:
-      repository: govukpay/adminusers
-      <<: *aws_test_config
   - name: products-ecr-registry-prod
     type: registry-image
     icon: docker
@@ -1498,20 +1492,49 @@ jobs:
 
   - name: retag-adminusers-image-for-test-perf-db
     plan:
-      - get: pay-ci
-      - get: adminusers-ecr-registry-prod
-        params:
-          format: oci
-        passed: [adminusers-db-migration-prod]
-        trigger: true
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-prod
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [adminusers-pact-tag]
+          - get: pay-ci
       - task: parse-perf-release-tag
         file: pay-ci/ci/tasks/parse-perf-db-release-tag.yml
         input_mapping:
           ecr-repo: adminusers-ecr-registry-prod
-      - put: adminusers-ecr-registry-test
+      - in_parallel:
+          steps:
+          - load_var: release_number
+            file: ecr-release-info/release-number
+          - load_var: perf-tag
+            file: parse-perf-release-tag/tag
+          - task: assume-retag-role
+            file: pay-ci/ci/tasks/assume-role.yml
+            output_mapping:
+              assume-role: assume-retag-role
+            params:
+              AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+              AWS_ROLE_SESSION_NAME: retag-ecr-image-as-perf
+      - in_parallel:
+          steps:
+            - load_var: retag-role
+              file: assume-retag-role/assume-role.json
+              format: json
+            - load_var: candidate-image-tag
+              file: tags/candidate-tag
+      - task: retag-candidate-as-perf-in-ecr
+        file: pay-ci/ci/tasks/manifest-retag.yml
         params:
-          image: adminusers-ecr-registry-prod/image.tar
-          additional_tags: parse-perf-db-release-tag/tag
+          DOCKER_LOGIN_ECR: 1
+          AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate-image-tag))"
+          NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:perf-tag))"
+          AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
 
   - name: smoke-test-adminusers-on-prod
     serial_groups: [smoke-test]
@@ -1547,20 +1570,49 @@ jobs:
 
   - name: retag-adminusers-image-for-test-perf
     plan:
-      - get: pay-ci
-      - get: adminusers-ecr-registry-prod
-        params:
-          format: oci
-        passed: [smoke-test-adminusers-on-prod]
-        trigger: true
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-prod
+            params:
+              skip_download: true
+              format: oci
+            trigger: true
+            passed: [adminusers-pact-tag]
+          - get: pay-ci
       - task: parse-perf-release-tag
         file: pay-ci/ci/tasks/parse-perf-release-tag.yml
         input_mapping:
-          ecr-repo: adminusers-ecr-registry-prod        
-      - put: adminusers-ecr-registry-test
+          ecr-repo: adminusers-ecr-registry-prod
+      - in_parallel:
+          steps:
+          - load_var: release_number
+            file: ecr-release-info/release-number
+          - load_var: perf-tag
+            file: parse-perf-release-tag/tag
+          - task: assume-retag-role
+            file: pay-ci/ci/tasks/assume-role.yml
+            output_mapping:
+              assume-role: assume-retag-role
+            params:
+              AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+              AWS_ROLE_SESSION_NAME: retag-ecr-image-as-perf
+      - in_parallel:
+          steps:
+            - load_var: retag-role
+              file: assume-retag-role/assume-role.json
+              format: json
+            - load_var: candidate-image-tag
+              file: tags/candidate-tag
+      - task: retag-candidate-as-perf-in-ecr
+        file: pay-ci/ci/tasks/manifest-retag.yml
         params:
-          image: adminusers-ecr-registry-prod/image.tar
-          additional_tags: parse-perf-release-tag/tag        
+          DOCKER_LOGIN_ECR: 1
+          AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:candidate-image-tag))"
+          NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/egress:((.:perf-tag))"
+          AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+          AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+          AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
 
   - name: adminusers-pact-tag
     plan:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -301,12 +301,12 @@ resources:
     source:
       repository: govukpay/frontend
       <<: *aws_test_config
-  - name: adminusers-candidate
+  - name: adminusers-ecr-registry-test
     type: registry-image
     icon: docker
     source:
       repository: govukpay/adminusers
-      variant: candidate
+      variant: release
       <<: *aws_test_config
   - name: adminusers-ecr-registry-prod
     type: registry-image
@@ -1501,6 +1501,7 @@ jobs:
     plan:
       - in_parallel:
           steps:
+          - get: adminusers-ecr-registry-test
           - get: adminusers-ecr-registry-prod
             params:
               skip_download: true
@@ -1508,16 +1509,22 @@ jobs:
             trigger: true
             passed: [adminusers-pact-tag]
           - get: pay-ci
-      - task: parse-perf-release-tag
-        file: pay-ci/ci/tasks/parse-perf-db-release-tag.yml
-        input_mapping:
-          ecr-repo: adminusers-ecr-registry-prod
       - in_parallel:
           steps:
-          - load_var: release_number
+          - task: parse-ecr-release-tag
+            file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+            input_mapping:
+              ecr-image: adminusers-ecr-registry-test
+          - task: parse-perf-release-tag
+            file: pay-ci/ci/tasks/parse-perf-db-release-tag.yml
+            input_mapping:
+              ecr-repo: adminusers-ecr-registry-prod
+      - in_parallel:
+          steps:
+          - load_var: release-number
             file: ecr-release-info/release-number
           - load_var: perf-tag
-            file: parse-perf-release-tag/tag
+            file: parse-perf-db-release-tag/tag
           - task: assume-retag-role
             file: pay-ci/ci/tasks/assume-role.yml
             output_mapping:
@@ -1525,19 +1532,21 @@ jobs:
             params:
               AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
               AWS_ROLE_SESSION_NAME: retag-ecr-image-as-perf
-      - in_parallel:
-          steps:
-            - load_var: retag-role
-              file: assume-retag-role/assume-role.json
-              format: json
-            - load_var: candidate-image-tag
-              file: tags/candidate-tag
+          - task: generate-docker-creds-config
+            file: pay-ci/ci/tasks/generate-docker-config-file.yml
+            params:
+              USERNAME: ((docker-username))
+              PASSWORD: ((docker-access-token))
+              EMAIL: ((docker-email))
+      - load_var: retag-role
+        file: assume-retag-role/assume-role.json
+        format: json
       - task: retag-candidate-as-perf-in-ecr
         file: pay-ci/ci/tasks/manifest-retag.yml
         params:
           DOCKER_LOGIN_ECR: 1
           AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:candidate-image-tag))"
+          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:release-number))-candidate"
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:perf-tag))"
           AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
@@ -1579,6 +1588,7 @@ jobs:
     plan:
       - in_parallel:
           steps:
+          - get: adminusers-ecr-registry-test
           - get: adminusers-ecr-registry-prod
             params:
               skip_download: true
@@ -1586,28 +1596,20 @@ jobs:
             trigger: true
             passed: [adminusers-pact-tag]
           - get: pay-ci
-      # - task: parse-perf-release-tag
-      #   file: pay-ci/ci/tasks/parse-perf-release-tag.yml
-      #   input_mapping:
-      #     ecr-repo: adminusers-ecr-registry-prod
-      - task: parse-perf-release-tag
-        file: pay-ci/ci/tasks/parse-perf-release-tag.yml
-        input_mapping:
-          ecr-repo: adminusers-ecr-registry-prod
-      # - task: parse-release-tag
-      #   file: pay-ci/ci/tasks/parse-release-tag.yml
-      #   input_mapping:
-      #     git-release: pay-adminusers-git-release
-      # - put: products-ecr-registry-test
-      #   params:
-      #     image: products-ecr-registry-prod/image.tar
-      #     additional_tags: parse-perf-release-tag/tag
       - in_parallel:
           steps:
-          # - load_var: release_number
-          #   file: ecr-release-info/release-number
-          - load_var: candidate_image_tag
-            file: tags/candidate-tag
+          - task: parse-ecr-release-tag
+            file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+            input_mapping:
+              ecr-image: adminusers-ecr-registry-test
+          - task: parse-perf-release-tag
+            file: pay-ci/ci/tasks/parse-perf-release-tag.yml
+            input_mapping:
+              ecr-repo: adminusers-ecr-registry-prod
+      - in_parallel:
+          steps:
+          - load_var: release-number
+            file: ecr-release-info/release-number
           - load_var: perf-tag
             file: parse-perf-release-tag/tag
           - task: assume-retag-role
@@ -1617,19 +1619,21 @@ jobs:
             params:
               AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
               AWS_ROLE_SESSION_NAME: retag-ecr-image-as-perf
-      - in_parallel:
-          steps:
-            - load_var: retag-role
-              file: assume-retag-role/assume-role.json
-              format: json
-            - load_var: candidate-image-tag
-              file: tags/candidate-tag
+          - task: generate-docker-creds-config
+            file: pay-ci/ci/tasks/generate-docker-config-file.yml
+            params:
+              USERNAME: ((docker-username))
+              PASSWORD: ((docker-access-token))
+              EMAIL: ((docker-email))
+      - load_var: retag-role
+        file: assume-retag-role/assume-role.json
+        format: json
       - task: retag-candidate-as-perf-in-ecr
         file: pay-ci/ci/tasks/manifest-retag.yml
         params:
           DOCKER_LOGIN_ECR: 1
           AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:candidate-image-tag))"
+          SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:release-number))-candidate"
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers:((.:perf-tag))"
           AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
           AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -16,6 +16,8 @@ params:
   DESTINATION_AWS_SECRET_ACCESS_KEY:
   DESTINATION_AWS_SESSION_TOKEN:
   TAG_LABEL: candidate
+  SOURCE_REGION: eu-west-1
+  DESTINATION_REGION: eu-west-1
 
 run:
   path: bash
@@ -44,7 +46,7 @@ run:
       export AWS_SESSION_TOKEN
 
       echo "Logging in to source ECR"
-      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
+      aws ecr get-login-password --region ${SOURCE_REGION} | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
 
       echo "Pulling images"
       docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &
@@ -66,7 +68,7 @@ run:
       export AWS_SESSION_TOKEN
 
       echo "Logging in to destination ECR"
-      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
+      aws ecr get-login-password --region ${DESTINATION_REGION} | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
 
       echo "Pushing images"
       docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -45,7 +45,7 @@ run:
       export AWS_SESSION_TOKEN
 
       echo "Logging in to source ECR"
-      aws ecr get-login-password --region ${SOURCE_REGION} | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
+      aws ecr get-login-password --region "${SOURCE_REGION}" | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
 
       echo "Pulling images"
       docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
@@ -67,7 +67,7 @@ run:
       export AWS_SESSION_TOKEN
 
       echo "Logging in to destination ECR"
-      aws ecr get-login-password --region ${DESTINATION_REGION} | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
+      aws ecr get-login-password --region "${DESTINATION_REGION}" | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
 
       echo "Pushing images"
       docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -15,7 +15,6 @@ params:
   DESTINATION_AWS_ACCESS_KEY_ID:
   DESTINATION_AWS_SECRET_ACCESS_KEY:
   DESTINATION_AWS_SESSION_TOKEN:
-  TAG_LABEL: candidate
   SOURCE_REGION: eu-west-1
   DESTINATION_REGION: eu-west-1
 
@@ -49,15 +48,15 @@ run:
       aws ecr get-login-password --region ${SOURCE_REGION} | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
 
       echo "Pulling images"
-      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &
-      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
 
       echo "Waiting for pulls to complete"
       wait
 
       echo "Retagging images locally"
-      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8"
-      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
 
       set +x # This is a safety measure to prevent us accidentally leaking AWS secrets in the future
       AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
@@ -71,8 +70,8 @@ run:
       aws ecr get-login-password --region ${DESTINATION_REGION} | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
 
       echo "Pushing images"
-      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &
-      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
 
       echo "Waiting for pushes to complete"
       wait
@@ -80,5 +79,5 @@ run:
       echo "Creating release manifest in destination registry"
       docker buildx imagetools create \
         -t "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-release" \
-        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" \
-        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64"
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" \
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"

--- a/ci/tasks/copy-multiarch-image-to-other-account.yml
+++ b/ci/tasks/copy-multiarch-image-to-other-account.yml
@@ -15,6 +15,7 @@ params:
   DESTINATION_AWS_ACCESS_KEY_ID:
   DESTINATION_AWS_SECRET_ACCESS_KEY:
   DESTINATION_AWS_SESSION_TOKEN:
+  TAG_LABEL: candidate
 
 run:
   path: bash
@@ -46,15 +47,15 @@ run:
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$SOURCE_ECR_REGISTRY"
 
       echo "Pulling images"
-      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
-      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &
+      docker pull --quiet "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" &
 
       echo "Waiting for pulls to complete"
       wait
 
       echo "Retagging images locally"
-      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8"
-      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8"
+      docker tag "${SOURCE_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64"
 
       set +x # This is a safety measure to prevent us accidentally leaking AWS secrets in the future
       AWS_ACCESS_KEY_ID="$DESTINATION_AWS_ACCESS_KEY_ID"
@@ -68,8 +69,8 @@ run:
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$DESTINATION_ECR_REGISTRY"
 
       echo "Pushing images"
-      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" &
-      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" &
+      docker push --quiet "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64" &
 
       echo "Waiting for pushes to complete"
       wait
@@ -77,5 +78,5 @@ run:
       echo "Creating release manifest in destination registry"
       docker buildx imagetools create \
         -t "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-release" \
-        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-armv8" \
-        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-candidate-amd64"
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-armv8" \
+        "${DESTINATION_ECR_REGISTRY}/${ECR_REPO_NAME}:${RELEASE_NUMBER}-${TAG_LABEL}-amd64"

--- a/ci/tasks/manifest-retag.yml
+++ b/ci/tasks/manifest-retag.yml
@@ -13,7 +13,6 @@ params:
   DOCKER_LOGIN_ECR: 0
   AWS_ACCOUNT_ID: 
   DOCKER_CONFIG: docker_creds
-  REGION: 
 
 inputs:
   - name: docker_creds
@@ -24,7 +23,7 @@ run:
   - -ec
   - |
     if [ "$DOCKER_LOGIN_ECR" -eq 1 ]; then
-      aws ecr get-login-password --region ${REGION:-eu-west-1} | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.${REGION:-eu-west-1}.amazonaws.com"
+      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.eu-west-1.amazonaws.com"
     fi
 
     docker buildx imagetools create -t "$NEW_MANIFEST" "$SOURCE_MANIFEST"

--- a/ci/tasks/manifest-retag.yml
+++ b/ci/tasks/manifest-retag.yml
@@ -13,7 +13,7 @@ params:
   DOCKER_LOGIN_ECR: 0
   AWS_ACCOUNT_ID: 
   DOCKER_CONFIG: docker_creds
-  REGION: eu-west-1
+  REGION: 
 
 inputs:
   - name: docker_creds
@@ -24,7 +24,7 @@ run:
   - -ec
   - |
     if [ "$DOCKER_LOGIN_ECR" -eq 1 ]; then
-      aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.${REGION}.amazonaws.com"
+      aws ecr get-login-password --region ${REGION:-eu-west-1} | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.${REGION:-eu-west-1}.amazonaws.com"
     fi
 
     docker buildx imagetools create -t "$NEW_MANIFEST" "$SOURCE_MANIFEST"

--- a/ci/tasks/manifest-retag.yml
+++ b/ci/tasks/manifest-retag.yml
@@ -1,3 +1,4 @@
+---
 platform: linux
 
 image_resource:
@@ -12,6 +13,7 @@ params:
   DOCKER_LOGIN_ECR: 0
   AWS_ACCOUNT_ID: 
   DOCKER_CONFIG: docker_creds
+  REGION: eu-west-1
 
 inputs:
   - name: docker_creds
@@ -22,7 +24,7 @@ run:
   - -ec
   - |
     if [ "$DOCKER_LOGIN_ECR" -eq 1 ]; then
-      aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.eu-west-1.amazonaws.com"
+      aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.${REGION}.amazonaws.com"
     fi
 
     docker buildx imagetools create -t "$NEW_MANIFEST" "$SOURCE_MANIFEST"

--- a/ci/tasks/manifest-retag.yml
+++ b/ci/tasks/manifest-retag.yml
@@ -26,4 +26,7 @@ run:
       aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.eu-west-1.amazonaws.com"
     fi
 
+    echo "source manifest: $SOURCE_MANIFEST"
+    echo "new manifest: $NEW_MANIFEST"
+
     docker buildx imagetools create -t "$NEW_MANIFEST" "$SOURCE_MANIFEST"


### PR DESCRIPTION
Retag the adminusers candidate in the test ECR for test-perf. Requires [this change to pay-infra](https://github.com/alphagov/pay-infra/pull/4728).

Not many adminusers releases require a database migration, and since we only keep a hundred images in our eu-west-1 test ECR, we cannot be certain that the perf-db candidate still exists there. But, we keep everything in our eu-central-1 test ECR, so this change copies the relevant candidate release across regions prior to retagging.

Concourse runs:
* https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-production/jobs/retag-adminusers-image-for-test-perf-db/builds/41
* https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-production/jobs/retag-adminusers-image-for-test-perf/builds/393

[ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/223851549868/govukpay/adminusers?region=eu-west-1)