### PR TITLE
PP-12156: Replace docker manifest inspect with docker buildx imagetools inspect

### DIFF
--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -58,7 +58,8 @@ jobs:
             IMAGE_NAME=$(cut -f 1 -d ":" <<<"$IMAGE")
             IMAGE_TAG=$(cut -f 2 -d ":" <<<"$IMAGE")
 
-            if ! docker manifest inspect "$BASE_CONTAINER_DEFINITION" >> /dev/null 2>&1; then
+            MEDIATYPE=$(docker buildx imagetools inspect "$BASE_CONTAINER_DEFINITION" --raw 2>&1 | jq --raw-output .mediaType)
+            if [[ "$MEDIATYPE" != "application/vnd.docker.distribution.manifest.list.v2+json" ]] ; then
               echo "ERROR! The image specified by '$BASE_CONTAINER_DEFINITION' does not refer to a manifest"
               echo
               echo "All image sha pins must point to the image manifest, not to one of the architecture specific images"


### PR DESCRIPTION
Our unit test to make sure all docker base images are manifests, not raw images, uses docker manifest inspect (which is listed as experimental). It seems that if a new manifest gets pushed with the same tag (which probably leaves the old manifest untagged) docker manifest inspect fails, even when referencing a manifest by a sha pin.

We can instead use docker buildx imagetools inspect which seems to always work