### PR TITLE
PP-12123: There's another mediatype which is an image list

### DIFF
--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -59,7 +59,7 @@ jobs:
             IMAGE_TAG=$(cut -f 2 -d ":" <<<"$IMAGE")
 
             MEDIATYPE=$(docker buildx imagetools inspect "$BASE_CONTAINER_DEFINITION" --raw 2>&1 | jq --raw-output .mediaType)
-            if [[ "$MEDIATYPE" != "application/vnd.docker.distribution.manifest.list.v2+json" ]] ; then
+            if [[ "$MEDIATYPE" != "application/vnd.docker.distribution.manifest.list.v2+json" ]] && [[ "$MEDIATYPE" != "application/vnd.oci.image.index.v1+json" ]]; then
               echo "ERROR! The image specified by '$BASE_CONTAINER_DEFINITION' does not refer to a manifest"
               echo
               echo "All image sha pins must point to the image manifest, not to one of the architecture specific images"


### PR DESCRIPTION
ADOT images use a different manifest list mediatype than all the others we have, but it is a valid image list type so we should be ok with this too.

See https://github.com/alphagov/pay-adot/actions/runs/7871038916/job/21473486399 for the failure using the manifest verification on master.