### PR TITLE
PP-12139: Re-enable stripe 3ds test

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -203,6 +203,12 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_prod"
+      - task: run_create_card_payment_stripe_3ds-production
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_3ds_prod"
       - task: run_recurring_card_payment_stripe-production
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -219,6 +219,12 @@ smoke-test-run-all-on-staging: &smoke-test-run-all-on-staging
         <<: *aws_assumed_role_creds
         AWS_REGION: "eu-west-1"
         SMOKE_TEST_NAME: "card_stripe_stag"
+    - task: run_create_card_payment_stripe_3ds-staging
+      file: pay-ci/ci/tasks/run-smoke-test.yml
+      params:
+        <<: *aws_assumed_role_creds
+        AWS_REGION: "eu-west-1"
+        SMOKE_TEST_NAME: "card_stripe_3ds_stag"
     - task: run_recurring_card_payment_stripe-staging
       file: pay-ci/ci/tasks/run-smoke-test.yml
       params:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -815,6 +815,12 @@ definitions:
           <<: *aws_assumed_role_creds
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "card_stripe_test"
+      - task: run_create_card_payment_stripe_3ds-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_3ds_test"
       - task: run_recurring_card_payment_stripe-test
         file: pay-ci/ci/tasks/run-smoke-test.yml
         params:


### PR DESCRIPTION
This was fixed in https://github.com/alphagov/pay-smoke-tests/pull/227, let's hope it works for real.