### PR TITLE
BAU: Add prometheus-pushgateway pipeline self update

### DIFF
--- a/ci/pipelines/prometheus-pushgateway.yml
+++ b/ci/pipelines/prometheus-pushgateway.yml
@@ -17,6 +17,15 @@ definitions:
     aws_region: eu-west-1
 
 resources:
+  - name: prometheus-pushgateway-pipeline
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+      paths:
+        - ci/pipelines/prometheus-pushgateway.yml
+
   - name: prometheus-pushgateway
     type: registry-image
     icon: docker
@@ -196,3 +205,10 @@ jobs:
           additional_tags: tags/tags
         get_params:
           skip_download: true
+
+  - name: update-prometheus-pushgateway-pipeline
+    plan:
+      - get: prometheus-pushgateway-pipeline
+        trigger: true
+      - set_pipeline: prometheus-pushgateway
+        file: prometheus-pushgateway-pipeline/ci/pipelines/prometheus-pushgateway.yml


### PR DESCRIPTION
After merging my previous PR for this pipeline I noticed it doesn't have the self-update job. So this PR adds a pipeline self-update from master in pay-ci.

I set the pipeline with this job and you can see it successfully run: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/prometheus-pushgateway/jobs/update-prometheus-pushgateway-pipeline/builds/1