### PR TITLE
PP-12123: try sending metrics from deploy-adminusers

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1,4 +1,19 @@
 definitions:
+  - &load_app_name
+    load_var: app_name
+    file: snippet/app_name
+  - &load_app_release_number
+    load_var: app_release_number
+    file: snippet/app_release_number
+  - &load_adot_release_number
+    load_var: adot_release_number
+    file: snippet/adot_release_number
+  - &load_nginx_release_number
+    load_var: nginx_release_number
+    file: snippet/nginx_release_number
+  - &load_nginx_forward_proxy_release_number
+    load_var: nginx_forward_proxy_release_number
+    file: snippet/nginx_forward_proxy_release_number
   - &assume_copy_from_test_ecr_role
     task: assume-copy-from-ecr-test-role
     file: pay-ci/ci/tasks/assume-role.yml
@@ -35,6 +50,7 @@ copy_ecr_from_test_to_staging_params: &copy_ecr_from_test_to_staging_params
   DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:write-to-staging-ecr-role.AWS_SECRET_ACCESS_KEY))
   DESTINATION_AWS_SESSION_TOKEN: ((.:write-to-staging-ecr-role.AWS_SESSION_TOKEN))
 
+
 aws_test_config: &aws_test_config
   aws_access_key_id: ((readonly_access_key_id))
   aws_secret_access_key: ((readonly_secret_access_key))
@@ -67,6 +83,52 @@ put_success_slack_notification: &put_success_slack_notification
       username: pay-concourse
       text: "((.:success_snippet)) |
             <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+put_success_slack_and_metric_notification_with_nginx: &put_success_slack_and_metric_notification
+  on_success:
+    in_parallel:
+        steps:
+        - put: slack-notification
+          params:
+            channel: '#govuk-pay-activity'
+            icon_emoji: ":fargate:"
+            username: pay-concourse
+            text: "((.:success_snippet)) |
+                  <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        - put: send-app-release-number-metric
+          resource: prometheus-pushgateway
+          params:
+            metric: deployment_pipeline_app_release_number_gauge
+            value: "((.:app_release_number))"
+            labels:
+              pipeline: "$BUILD_PIPELINE_NAME"
+              conocurse_job: "$BUILD_JOB_NAME"
+              app: "((.:app_name))"
+              outcome: success
+        - put: send-nginx-release-number-metric
+          resource: prometheus-pushgateway
+          params:
+            metric: deployment_pipeline_sidecar_release_number_gauge
+            value: "((.:nginx_release_number))"
+            labels:
+              pipeline: "$BUILD_PIPELINE_NAME"
+              conocurse_job: "$BUILD_JOB_NAME"
+              app: "((.:app_name))"
+              outcome: success
+              sidecar: nginx
+        - put: send-adot-release-number-metric
+          resource: prometheus-pushgateway
+          params:
+            metric: deployment_pipeline_sidecar_release_number_gauge
+            value: "((.:nginx_release_number))"
+            labels:
+              pipeline: "$BUILD_PIPELINE_NAME"
+              conocurse_job: "$BUILD_JOB_NAME"
+              app: "((.:app_name))"
+              outcome: success
+              sidecar: nginx
+
+
 
 put_failure_slack_notification: &put_failure_slack_notification
   on_failure:
@@ -142,6 +204,11 @@ snippet_params_app_version: &snippet_params_app_version
 
 
 resources:
+  - name: prometheus-pushgateway
+    type: prometheus-pushgateway
+    source:
+      url: https://prometheus-pushgateway.deploy.payments.service.gov.uk
+      job: concourse_deploy_metric
   - name: deploy-to-test-pipeline-definition
     type: git
     icon: github
@@ -157,7 +224,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: master
+      branch: pp-12123/send-release-metric-for-adminusers-deploy
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
   - name: adot-git-release
@@ -601,6 +668,11 @@ resource_types:
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest
+  - name: prometheus-pushgateway
+    type: docker-image
+    source:
+      repository: governmentdigitalservice/pay-prometheus-pushgateway-resource
+      tag: latest-master
 
 groups:
   - name: adminusers
@@ -2288,10 +2360,16 @@ jobs:
           APP_NAME: adminusers
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -2329,7 +2407,7 @@ jobs:
         params:
           APP_NAME: adminusers
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification
+    <<: *put_success_slack_and_metric_notification
     <<: *put_failure_slack_notification
 
   - name: adminusers-db-migration

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -84,6 +84,13 @@ put_success_slack_notification: &put_success_slack_notification
       text: "((.:success_snippet)) |
             <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
+pushgateway_default_labels: &pushgateway_default_labels
+  pipeline: "$BUILD_PIPELINE_NAME"
+  conocurse_job: "$BUILD_JOB_NAME"
+  app: "((.:app_name))"
+  environment: test-12
+  instance: "concourse"
+
 put_success_slack_and_metric_notification_with_nginx: &put_success_slack_and_metric_notification
   on_success:
     in_parallel:
@@ -98,37 +105,73 @@ put_success_slack_and_metric_notification_with_nginx: &put_success_slack_and_met
         - put: send-app-release-number-metric
           resource: prometheus-pushgateway
           params:
-            metric: deployment_pipeline_app_release_number_gauge
+            metric: deployment_pipeline_app_release_number
             value: "((.:app_release_number))"
+            job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/success"
             labels:
-              pipeline: "$BUILD_PIPELINE_NAME"
-              conocurse_job: "$BUILD_JOB_NAME"
-              app: "((.:app_name))"
+              <<: *pushgateway_default_labels
               outcome: success
         - put: send-nginx-release-number-metric
           resource: prometheus-pushgateway
           params:
-            metric: deployment_pipeline_sidecar_release_number_gauge
+            metric: deployment_pipeline_sidecar_release_number
             value: "((.:nginx_release_number))"
+            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/success"
             labels:
-              pipeline: "$BUILD_PIPELINE_NAME"
-              conocurse_job: "$BUILD_JOB_NAME"
-              app: "((.:app_name))"
+              <<: *pushgateway_default_labels
               outcome: success
               sidecar: nginx
         - put: send-adot-release-number-metric
           resource: prometheus-pushgateway
           params:
-            metric: deployment_pipeline_sidecar_release_number_gauge
-            value: "((.:nginx_release_number))"
+            metric: deployment_pipeline_sidecar_release_number
+            value: "((.:adot_release_number))"
+            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/success"
             labels:
-              pipeline: "$BUILD_PIPELINE_NAME"
-              conocurse_job: "$BUILD_JOB_NAME"
-              app: "((.:app_name))"
+              <<: *pushgateway_default_labels
               outcome: success
+              sidecar: adot
+
+put_failure_slack_and_metric_notification_with_nginx: &put_failure_slack_and_metric_notification
+  on_failure:
+    in_parallel:
+        steps:
+        - put: slack-notification
+          params:
+            channel: '#govuk-pay-announce'
+            icon_emoji: ":fargate:"
+            username: pay-concourse
+            text: "((.:failure_snippet)) \n
+                  - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        - put: send-app-release-number-metric
+          resource: prometheus-pushgateway
+          params:
+            metric: deployment_pipeline_app_release_number
+            value: "((.:app_release_number))"
+            job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/failure"
+            labels:
+              <<: *pushgateway_default_labels
+              outcome: failure
+        - put: send-nginx-release-number-metric
+          resource: prometheus-pushgateway
+          params:
+            metric: deployment_pipeline_sidecar_release_number
+            value: "((.:nginx_release_number))"
+            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/failure"
+            labels:
+              <<: *pushgateway_default_labels
+              outcome: failure
               sidecar: nginx
-
-
+        - put: send-adot-release-number-metric
+          resource: prometheus-pushgateway
+          params:
+            metric: deployment_pipeline_sidecar_release_number
+            value: "((.:adot_release_number))"
+            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/failure"
+            labels:
+              <<: *pushgateway_default_labels
+              outcome: failure
+              sidecar: adot
 
 put_failure_slack_notification: &put_failure_slack_notification
   on_failure:
@@ -208,7 +251,7 @@ resources:
     type: prometheus-pushgateway
     source:
       url: https://prometheus-pushgateway.deploy.payments.service.gov.uk
-      job: concourse_deploy_metric
+      job: deployment_pipeline_release_number
   - name: deploy-to-test-pipeline-definition
     type: git
     icon: github
@@ -2340,14 +2383,16 @@ jobs:
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: adminusers-ecr-registry-test
-        trigger: true
-      - get: nginx-proxy-ecr-registry-test
-        trigger: true
-      - get: adot-ecr-registry-test
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-test
+            trigger: true
+          - get: nginx-proxy-ecr-registry-test
+            trigger: true
+          - get: adot-ecr-registry-test
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
       - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
       - load_var: nginx_image_tag
@@ -2408,7 +2453,7 @@ jobs:
           APP_NAME: adminusers
           <<: *wait_for_deploy_params
     <<: *put_success_slack_and_metric_notification
-    <<: *put_failure_slack_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: adminusers-db-migration
     plan:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -2,6 +2,9 @@ definitions:
   - &load_app_name
     load_var: app_name
     file: snippet/app_name
+  - &load_app_name_from_parse_release_tag
+    load_var: app_name
+    file: tags/app_name
   - &load_app_name_from_parse_ecr_release_tag
     load_var: app_name
     file: ecr-release-info/app_name
@@ -11,6 +14,9 @@ definitions:
   - &load_app_release_number
     load_var: app_release_number
     file: snippet/app_release_number
+  - &load_app_release_number_from_parse_release_tag
+    load_var: app_release_number
+    file: tags/release-number
   - &load_app_release_number_from_parse_ecr_release_tag
     load_var: app_release_number
     file: ecr-release-info/release-number
@@ -2240,6 +2246,8 @@ jobs:
         input_mapping:
           git-release: adminusers-git-release
       - in_parallel:
+        - *load_app_name_from_parse_release_tag
+        - *load_app_release_number_from_parse_release_tag
         - load_var: release-number
           file: tags/release-number
         - load_var: release-name
@@ -2301,23 +2309,29 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: adminusers candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-announce'
+            silent: true
+            text: ':red-circle: adminusers candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_failure
     on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':hammer: adminusers candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-activity'
+            silent: true
+            text: ':hammer: adminusers candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_success
 
   - name: run-adminusers-e2e
     plan:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -5,12 +5,18 @@ definitions:
   - &load_app_name_from_parse_ecr_release_tag
     load_var: app_name
     file: ecr-release-info/app_name
+  - &load_app_name_from_parse_candidate_tag
+    load_var: app_name
+    file: parse-candidate-tag/app_name
   - &load_app_release_number
     load_var: app_release_number
     file: snippet/app_release_number
   - &load_app_release_number_from_parse_ecr_release_tag
     load_var: app_release_number
     file: ecr-release-info/release-number
+  - &load_app_release_number_from_parse_candidate_tag
+    load_var: app_release_number
+    file: parse-candidate-tag/release-number
   - &load_adot_release_number
     load_var: adot_release_number
     file: snippet/adot_release_number
@@ -2357,6 +2363,8 @@ jobs:
               format: json
             - load_var: release_image_tag
               file: parse-candidate-tag/release-tag
+            - *load_app_name_from_parse_candidate_tag
+            - *load_app_release_number_from_parse_candidate_tag
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
@@ -2401,23 +2409,29 @@ jobs:
                 SOURCE_MANIFEST: "governmentdigitalservice/pay-adminusers:((.:candidate_image_tag))"
                 NEW_MANIFEST: "governmentdigitalservice/pay-adminusers:latest-master"
     on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: adminusers candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-announce'
+            silent: true
+            text: ':red-circle: adminusers candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_failure
     on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: adminusers candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-activity'
+            silent: true
+            text: ':green-circle: adminusers candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_success
 
   - name: deploy-adminusers
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -2,9 +2,15 @@ definitions:
   - &load_app_name
     load_var: app_name
     file: snippet/app_name
+  - &load_app_name_from_parse_ecr_release_tag
+    load_var: app_name
+    file: ecr-release-info/app_name
   - &load_app_release_number
     load_var: app_release_number
     file: snippet/app_release_number
+  - &load_app_release_number_from_parse_ecr_release_tag
+    load_var: app_release_number
+    file: ecr-release-info/release-number
   - &load_adot_release_number
     load_var: adot_release_number
     file: snippet/adot_release_number
@@ -2628,8 +2634,12 @@ jobs:
         file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
           ecr-image: adminusers-ecr-registry-test
-      - load_var: release_number
-        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - load_var: release_number
+            file: ecr-release-info/release-number
       - in_parallel:
           steps:
           - *assume_copy_from_test_ecr_role
@@ -2644,6 +2654,8 @@ jobs:
         params:
           ECR_REPO_NAME: "govukpay/adminusers"
           <<: *copy_ecr_from_test_to_staging_params
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: build-and-push-connector-candidate
     plan:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -319,7 +319,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: pp-12123/send-release-metric-for-adminusers-deploy
+      branch: master
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
   - name: adot-git-release

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -74,15 +74,31 @@ aws_assumed_role_creds: &aws_assumed_role_creds
   AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
   AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
+slack-notification-success: &slack_notification_success
+  put: slack-notification
+  params:
+    channel: '#govuk-pay-activity'
+    icon_emoji: ":fargate:"
+    username: pay-concourse
+    text: "((.:success_snippet)) |
+          <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
 put_success_slack_notification: &put_success_slack_notification
   on_success:
-    put: slack-notification
-    params:
-      channel: '#govuk-pay-activity'
-      icon_emoji: ":fargate:"
-      username: pay-concourse
-      text: "((.:success_snippet)) |
-            <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    *slack_notification_success
+
+slack-notification-failure: &slack_notification_failure
+  put: slack-notification
+  params:
+    channel: '#govuk-pay-announce'
+    icon_emoji: ":fargate:"
+    username: pay-concourse
+    text: "((.:failure_snippet)) \n
+          - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+put_failure_slack_notification: &put_failure_slack_notification
+  on_failure:
+    *slack_notification_failure
 
 pushgateway_default_labels: &pushgateway_default_labels
   pipeline: "$BUILD_PIPELINE_NAME"
@@ -91,97 +107,115 @@ pushgateway_default_labels: &pushgateway_default_labels
   environment: test-12
   instance: "concourse"
 
-put_success_slack_and_metric_notification_with_nginx: &put_success_slack_and_metric_notification
+send_app_release_metric_success: &send_app_release_metric_success
+  put: send-app-release-number-metric
+  resource: prometheus-pushgateway
+  params:
+    metric: deployment_pipeline_app_release_number
+    value: "((.:app_release_number))"
+    job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/success"
+    labels:
+      <<: *pushgateway_default_labels
+      outcome: success
+
+send_nginx_release_metric_success: &send_nginx_release_metric_success
+  put: send-nginx-release-number-metric
+  resource: prometheus-pushgateway
+  params:
+    metric: deployment_pipeline_sidecar_release_number
+    value: "((.:nginx_release_number))"
+    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/success"
+    labels:
+      <<: *pushgateway_default_labels
+      outcome: success
+      sidecar: nginx
+
+send_adot_release_metric_success: &send_adot_release_metric_success
+  put: send-adot-release-number-metric
+  resource: prometheus-pushgateway
+  params:
+    metric: deployment_pipeline_sidecar_release_number
+    value: "((.:adot_release_number))"
+    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/success"
+    labels:
+      <<: *pushgateway_default_labels
+      outcome: success
+      sidecar: adot
+
+send_app_release_metric_failure: &send_app_release_metric_failure
+  put: send-app-release-number-metric
+  resource: prometheus-pushgateway
+  params:
+    metric: deployment_pipeline_app_release_number
+    value: "((.:app_release_number))"
+    job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/failure"
+    labels:
+      <<: *pushgateway_default_labels
+      outcome: failure
+
+send_nginx_release_metric_failure: &send_nginx_release_metric_failure
+  put: send-nginx-release-number-metric
+  resource: prometheus-pushgateway
+  params:
+    metric: deployment_pipeline_sidecar_release_number
+    value: "((.:nginx_release_number))"
+    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/failure"
+    labels:
+      <<: *pushgateway_default_labels
+      outcome: failure
+      sidecar: nginx
+
+send_adot_release_metric_failure: &send_adot_release_metric_failure
+  put: send-adot-release-number-metric
+  resource: prometheus-pushgateway
+  params:
+    metric: deployment_pipeline_sidecar_release_number
+    value: "((.:adot_release_number))"
+    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/failure"
+    labels:
+      <<: *pushgateway_default_labels
+      outcome: failure
+      sidecar: adot
+
+put_success_metric: &put_success_metric
+  on_success:
+    *send_app_release_metric_success
+
+put_failure_metric: &put_failure_metric
+  on_failure:
+    *send_app_release_metric_failure
+
+put_success_slack_and_metric_notification: &put_success_slack_and_metric_notification
   on_success:
     in_parallel:
         steps:
-        - put: slack-notification
-          params:
-            channel: '#govuk-pay-activity'
-            icon_emoji: ":fargate:"
-            username: pay-concourse
-            text: "((.:success_snippet)) |
-                  <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        - put: send-app-release-number-metric
-          resource: prometheus-pushgateway
-          params:
-            metric: deployment_pipeline_app_release_number
-            value: "((.:app_release_number))"
-            job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/success"
-            labels:
-              <<: *pushgateway_default_labels
-              outcome: success
-        - put: send-nginx-release-number-metric
-          resource: prometheus-pushgateway
-          params:
-            metric: deployment_pipeline_sidecar_release_number
-            value: "((.:nginx_release_number))"
-            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/success"
-            labels:
-              <<: *pushgateway_default_labels
-              outcome: success
-              sidecar: nginx
-        - put: send-adot-release-number-metric
-          resource: prometheus-pushgateway
-          params:
-            metric: deployment_pipeline_sidecar_release_number
-            value: "((.:adot_release_number))"
-            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/success"
-            labels:
-              <<: *pushgateway_default_labels
-              outcome: success
-              sidecar: adot
+        - *slack_notification_success
+        - *send_app_release_metric_success
 
-put_failure_slack_and_metric_notification_with_nginx: &put_failure_slack_and_metric_notification
+put_failure_slack_and_metric_notification: &put_failure_slack_and_metric_notification
   on_failure:
     in_parallel:
         steps:
-        - put: slack-notification
-          params:
-            channel: '#govuk-pay-announce'
-            icon_emoji: ":fargate:"
-            username: pay-concourse
-            text: "((.:failure_snippet)) \n
-                  - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-        - put: send-app-release-number-metric
-          resource: prometheus-pushgateway
-          params:
-            metric: deployment_pipeline_app_release_number
-            value: "((.:app_release_number))"
-            job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/failure"
-            labels:
-              <<: *pushgateway_default_labels
-              outcome: failure
-        - put: send-nginx-release-number-metric
-          resource: prometheus-pushgateway
-          params:
-            metric: deployment_pipeline_sidecar_release_number
-            value: "((.:nginx_release_number))"
-            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/failure"
-            labels:
-              <<: *pushgateway_default_labels
-              outcome: failure
-              sidecar: nginx
-        - put: send-adot-release-number-metric
-          resource: prometheus-pushgateway
-          params:
-            metric: deployment_pipeline_sidecar_release_number
-            value: "((.:adot_release_number))"
-            job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/failure"
-            labels:
-              <<: *pushgateway_default_labels
-              outcome: failure
-              sidecar: adot
+        - *slack_notification_failure
+        - *send_app_release_metric_failure
 
-put_failure_slack_notification: &put_failure_slack_notification
+put_success_slack_and_metric_notification_with_nginx_and_adot: &put_success_slack_and_metric_notification_with_nginx_and_adot
+  on_success:
+    in_parallel:
+        steps:
+        - *slack_notification_success
+        - *send_app_release_metric_success
+        - *send_nginx_release_metric_success
+        - *send_adot_release_metric_success 
+
+put_failure_slack_and_metric_notification_with_nginx_and_adot: &put_failure_slack_and_metric_notification_with_nginx_and_adot
   on_failure:
-    put: slack-notification
-    params:
-      channel: '#govuk-pay-announce'
-      icon_emoji: ":fargate:"
-      username: pay-concourse
-      text: "((.:failure_snippet)) \n
-            - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    in_parallel:
+        steps:
+        - *slack_notification_failure
+        - *send_app_release_metric_failure
+        - *send_nginx_release_metric_failure
+        - *send_adot_release_metric_failure
 
 put_db_migration_slack_notification: &put_db_migration_slack_notification
   put: slack-notification
@@ -2452,8 +2486,8 @@ jobs:
         params:
           APP_NAME: adminusers
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_and_metric_notification
-    <<: *put_failure_slack_and_metric_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: adminusers-db-migration
     plan:
@@ -2503,10 +2537,12 @@ jobs:
   - name: smoke-test-adminusers
     serial_groups: [smoke-test]
     plan:
-      - get: adminusers-ecr-registry-test
-        trigger: true
-        passed: [deploy-adminusers]
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-test
+            trigger: true
+            passed: [deploy-adminusers]
+          - get: pay-ci
       - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
       - task: create-notification-snippets
@@ -2515,10 +2551,14 @@ jobs:
           APP_NAME: adminusers
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2529,27 +2569,33 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: adminusers-pact-tag
     plan:
-      - get: adminusers-ecr-registry-test
-        passed: [smoke-test-adminusers]
-        trigger: true
+      - in_parallel:
+          steps:
+          - get: adminusers-ecr-registry-test
+            passed: [smoke-test-adminusers]
+            trigger: true
+          - get: pay-ci
       - load_var: application_image_tag
         file: adminusers-ecr-registry-test/tag
-      - get: pay-ci
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: adminusers
           ACTION_NAME: Pact tag
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -2564,8 +2610,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: adminusers
           PACT_TAG: test-fargate
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: push-adminusers-to-staging-ecr
     plan:

--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -16,7 +16,7 @@ params:
 outputs:
   - name: snippet
 run:
-  path: sh
+  path: ash
   args:
     - -c
     - |

--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -22,6 +22,9 @@ run:
     - |
       APP_RELEASE_NUMBER=$(echo "${APPLICATION_IMAGE_TAG}" | sed 's/-release//')
 
+      echo -n "${APP_NAME}" | tee -a snippet/app_name
+      echo -n "${APP_RELEASE_NUMBER}" | tee -a snippet/app_release_number
+
       cat <<EOT >> snippet/start
       :rocket: ${ACTION_NAME} of <https://github.com/alphagov/pay-${APP_NAME}/releases/tag/alpha_release-${APP_RELEASE_NUMBER}|${APP_NAME} ${APP_RELEASE_NUMBER}-release> on ${ENV} is beginning
       EOT
@@ -38,6 +41,7 @@ run:
       # shellcheck disable=SC2015
       [ -n "${NGINX_IMAGE_TAG}" ] && \
       NGINX_RELEASE_NUMBER=$(echo "${NGINX_IMAGE_TAG}" | sed 's/-release//') && \
+      echo -n "${NGINX_RELEASE_NUMBER}" | tee -a snippet/nginx_release_number && \
       echo "- <https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}|nginx-proxy v${NGINX_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
 
@@ -45,11 +49,14 @@ run:
       # shellcheck disable=SC2015
       [ -n "${ADOT_IMAGE_TAG}" ] && \
       ADOT_RELEASE_NUMBER=$(echo "${ADOT_IMAGE_TAG}" | sed 's/-release//') && \
+      echo -n "${ADOT_RELEASE_NUMBER}" | tee -a snippet/adot_release_number && \
       echo "- <https://github.com/alphagov/pay-adot/releases/tag/alpha_release-${ADOT_RELEASE_NUMBER}|adot v${ADOT_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
 
       # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
+      NGINX_FORWARD_PROXY_RELEASE_NUMBER=$(echo "${NGINX_FORWARD_PROXY_IMAGE_TAG}" | sed 's/-release//') && \
+      echo -n "${NGINX_FORWARD_PROXY_RELEASE_NUMBER}" | tee -a snippet/nginx_forward_proxy_release_number && \
       echo "- <https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}|nginx-forward-proxy v${NGINX_FORWARD_PROXY_IMAGE_TAG}>" | \
       tee -a snippet/failure || true

--- a/ci/tasks/parse-candidate-tag.yml
+++ b/ci/tasks/parse-candidate-tag.yml
@@ -22,3 +22,10 @@ run:
       RELEASE_NUMBER=$(cut -f 1 -d "-" < ecr-repo/tag)
       echo "${RELEASE_NUMBER}-release" | tee parse-candidate-tag/release-tag
       echo "$RELEASE_NUMBER" > parse-candidate-tag/release-number
+
+      # ecr-repo/respository looks like '223851549868.dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers'
+      # in awk FS is the field separator and NF is the number of fields, meaning we separate on / and print the last field
+      APP_NAME=$(awk 'BEGIN { FS="/" } { print $NF }' < ecr-repo/repository)
+      echo -n "APP name: "
+      echo "${APP_NAME}" | tee parse-candidate-tag/app_name
+      echo

--- a/ci/tasks/parse-candidate-tag.yml
+++ b/ci/tasks/parse-candidate-tag.yml
@@ -15,7 +15,7 @@ inputs:
 outputs:
   - name: parse-candidate-tag
 run:
-  path: sh
+  path: ash
   args:
     - -ec
     - |

--- a/ci/tasks/parse-ecr-release-tag.yml
+++ b/ci/tasks/parse-ecr-release-tag.yml
@@ -15,7 +15,16 @@ run:
     - |
       echo -n "ECR Image Tag: "
       cat ecr-image/tag
+      echo
       RELEASE_NUMBER=$(cut -f 1 -d "-" < ecr-image/tag)
       echo -n "Release number: "
       echo "${RELEASE_NUMBER}" | tee ecr-release-info/release-number
+      echo
+
+      # ecr-image/respository looks like '223851549868.dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers'
+      # in awk FS is the field separator and NF is the number of fields, meaning we separate on / and print the last field
+      APP_NAME=(awk 'BEGIN { FS="/" } { print $NF }' < ecr-image/repository)
+      echo -n "APP name: "
+      echo "${APP_NAME}" | tee ecr-release-info/app_name
+      echo
 

--- a/ci/tasks/parse-ecr-release-tag.yml
+++ b/ci/tasks/parse-ecr-release-tag.yml
@@ -23,7 +23,7 @@ run:
 
       # ecr-image/respository looks like '223851549868.dkr.ecr.eu-west-1.amazonaws.com/govukpay/adminusers'
       # in awk FS is the field separator and NF is the number of fields, meaning we separate on / and print the last field
-      APP_NAME=(awk 'BEGIN { FS="/" } { print $NF }' < ecr-image/repository)
+      APP_NAME=$(awk 'BEGIN { FS="/" } { print $NF }' < ecr-image/repository)
       echo -n "APP name: "
       echo "${APP_NAME}" | tee ecr-release-info/app_name
       echo

--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -24,6 +24,12 @@ run:
       cat tags/date >> tags/all-release-tags
       echo -n "${RELEASE_NUMBER}-candidate " >> tags/all-candidate-tags
       cat tags/date >> tags/all-candidate-tags
+
+      # in awk FS is the field separator and NF is the number of fields, meaning we separate on / and print the last field
+      APP_NAME=$(cat git-release/.git/config | grep 'url = ' | awk '{ print $3 }' | awk 'BEGIN { FS="/" } { print $NF }' | sed -E 's/^pay-//')
+      echo -n "APP name: "
+      echo "${APP_NAME}" | tee tags/app_name
+      echo
       
       cd git-release
       git rev-parse HEAD | tee ../tags/release-sha

--- a/ci/tasks/parse-release-tag.yml
+++ b/ci/tasks/parse-release-tag.yml
@@ -26,7 +26,7 @@ run:
       cat tags/date >> tags/all-candidate-tags
 
       # in awk FS is the field separator and NF is the number of fields, meaning we separate on / and print the last field
-      APP_NAME=$(cat git-release/.git/config | grep 'url = ' | awk '{ print $3 }' | awk 'BEGIN { FS="/" } { print $NF }' | sed -E 's/^pay-//')
+      APP_NAME=$(grep 'url = ' < git-release/.git/config | awk '{ print $3 }' | awk 'BEGIN { FS="/" } { print $NF }' | sed -E 's/^pay-//')
       echo -n "APP name: "
       echo "${APP_NAME}" | tee tags/app_name
       echo


### PR DESCRIPTION
Considering we have hundreds of places to send the metrics I've put a lot of effort in deploy-to-test to be able to parse all the different kinds of inputs and generate app names and release numbers, and to use yaml anchors and loaded variables so we can not have to repeat literally thousands of lines of code.

I've run all the jobs and have created a simple grafana dashboard which shows the release number sent at each step:

https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk/d/e5000e04-deef-4ac7-8ffc-b7364c241dd1/release-pipeline-releases?orgId=1
![Screenshot 2024-02-16 at 17 29 28](https://github.com/alphagov/pay-ci/assets/2170030/3bd03fa5-766c-43dc-aaa3-a97f7f8b393b)


