### PR TITLE
PP-12218: Add grafana-annotation-resource pipeline

### DIFF
--- a/ci/pipelines/grafana-annotation-resource.yml
+++ b/ci/pipelines/grafana-annotation-resource.yml
@@ -1,0 +1,136 @@
+---
+resources:
+  - name: grafana-annotation-resource-pipeline
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+      paths:
+        - ci/pipelines/grafana-annotation-resource.yml
+
+  - name: grafana-annotation-resource-dockerhub
+    type: registry-image
+    icon: docker
+    check_every: 1h
+    source:
+      repository: governmentdigitalservice/pay-grafana-annotation-resource
+      tag: latest
+      username: ((docker-username))
+      password: ((docker-access-token))
+
+  - name: slack-notification
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-notification-secret))
+  
+  - name: grafana-annotation-resource-release
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/paas-grafana-annotation-resource
+      tag_regex: "alpha_release-(.*)"
+      username: alphagov-pay-ci-concourse
+      password: ((github-access-token))
+
+  - name: pay-ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: master
+      username: alphagov-pay-ci-concourse
+      password: ((github-access-token))
+
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+jobs:
+  - name: build-and-push-grafana-annotation-resource
+    plan:
+      - in_parallel:
+          steps:
+          - get: grafana-annotation-resource-release
+            trigger: true
+          - get: pay-ci
+      - in_parallel:
+          steps:
+          - task: parse-release-tag
+            file: pay-ci/ci/tasks/parse-release-tag.yml
+            input_mapping:
+              git-release: grafana-annotation-resource-release
+          - task: generate-docker-creds-config
+            file: pay-ci/ci/tasks/generate-docker-config-file.yml
+            params:
+              USERNAME: ((docker-username))
+              PASSWORD: ((docker-access-token))
+              EMAIL: ((docker-email))
+      - in_parallel:
+          steps:
+          - load_var: release-name
+            file: grafana-annotation-resource-release/.git/ref
+          - load_var: release-tag
+            file: tags/tags
+          - load_var: release-number
+            file: tags/release-number
+          - load_var: release-sha
+            file: tags/release-sha
+          - load_var: date
+            file: tags/date
+      - task: build-grafana-annotation-resource
+        privileged: true
+        params:
+          CONTEXT: grafana-annotation-resource-release
+          DOCKER_CONFIG: docker_creds
+          LABEL_release_number: ((.:release-number))
+          LABEL_release_name: ((.:release-name))
+          LABEL_release_sha: ((.:release-sha))
+          LABEL_build_date: ((.:date))
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: grafana-annotation-resource-release
+            - name: docker_creds
+          outputs:
+            - name: image
+          run:
+            path: build
+      - put: grafana-annotation-resource-dockerhub
+        params:
+          image: image/image.tar
+          additional_tags: tags/tags
+        get_params:
+          skip_download: true
+    on_failure:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-starling"
+        silent: true
+        text: ":red-circle: Failed to build and push pay-grafana-annotation-resource image to dockerhub - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+    on_success:
+      put: slack-notification
+      attempts: 10
+      params:
+        channel: "#govuk-pay-activity"
+        silent: true
+        text: ":green-circle: Built and pushed pay-grafana-annotation-resource image to dockerhub - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+        icon_emoji: ":concourse:"
+        username: pay-concourse
+
+  - name: update-grafana-annotation-resource-pipeline
+    plan:
+      - get: grafana-annotation-resource-pipeline
+        trigger: true
+      - set_pipeline: grafana-annotation-resource
+        file: grafana-annotation-pipeline/ci/pipelines/grafana-annotation.yml


### PR DESCRIPTION
Add pipeline to build and push https://github.com/alphagov/paas-grafana-annotation-resource to dockerhub

Successful build: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/grafana-annotation-resource/jobs/build-and-push-grafana-annotation-resource/builds/1.1

Dockerhub release: https://hub.docker.com/repository/docker/governmentdigitalservice/pay-grafana-annotation-resource/tags?page=1&ordering=last_updated