### PR TITLE
PP-12222: Overriding new default values with the old production-like values

### DIFF
--- a/ci/tasks/endtoend/docker-config/cardid.env
+++ b/ci/tasks/endtoend/docker-config/cardid.env
@@ -2,3 +2,7 @@ PORT=9800
 ADMIN_PORT=9801
 
 AWS_XRAY_DAEMON_ADDRESS=xray:2000
+
+WORLDPAY_DATA_LOCATION=file:///app/data/worldpay/WP_341BIN_V03.CSV
+DISCOVER_DATA_LOCATION=file:///app/data/discover/Merchant_Marketing.csv
+TEST_CARD_DATA_LOCATION=file:///app/data/test-cards/test-card-bin-ranges.csv


### PR DESCRIPTION
The changes in https://github.com/alphagov/pay-cardid/pull/1165 iterate towards a solution where the production bin range files overwrite the local files when a release artefact is prepared.  That means that the local environment can read the files from `src/main/resources` and show sensible defaults, then when we build a release artefact those files will be replaced with production-suitable files.

On our way towards that solution we're improving the local environment by using the newly created demo files but production-like environments need to put the old value back in.

These environment variables will be needed on each production-like environment but I'm testing them first in endtoend.

When remove the git submodule implementation these environment variables will be removed.