### PR TITLE
BAU: Tidy pipeline anchors

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -298,6 +298,87 @@ definitions:
     ENV: test-12
     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
 
+  # Separate tasks for each combination of scenario/environment
+  smoke-test-run-all-on-test: &smoke-test-run-all-on-test
+    limit: 8
+    steps:
+      - task: run_create_card_payment_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_sandbox_test"
+      - task: run_recurring_card_payment_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "rec_card_sandbox_test"
+      - task: run_create_card_payment_worldpay_with_3ds2-test
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2_test"
+      - task: run_create_card_payment_worldpay_with_3ds2_exemption-test
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_3ds2ex_test"
+      - task: run_create_card_payment_worldpay_without_3ds-test
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_wpay_test"
+      - task: run_recurring_card_payment_worldpay-test
+        attempts: 10
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "reccard_worldpay_test"
+      - task: run_cancel_card_payment_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "cancel_sandbox_test"
+      - task: run_use_payment_link_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "pymntlnk_sandbox_test"
+      - task: run_create_card_payment_stripe-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_test"
+      - task: run_create_card_payment_stripe_3ds-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "card_stripe_3ds_test"
+      - task: run_recurring_card_payment_stripe-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "rec_card_stripe_test"
+      - task: run_notifications_sandbox-test
+        file: pay-ci/ci/tasks/run-smoke-test.yml
+        params:
+          <<: *aws_assumed_role_creds
+          AWS_REGION: "eu-west-1"
+          SMOKE_TEST_NAME: "notifcatns_sndbx_test"
+
 
 resources:
   - name: prometheus-pushgateway
@@ -920,87 +1001,6 @@ groups:
     jobs:
       - update-deploy-to-test-pipeline
 
-definitions:
-  # Separate tasks for each combination of scenario/environment
-  - &smoke-test-run-all-on-test
-    limit: 8
-    steps:
-      - task: run_create_card_payment_sandbox-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_sandbox_test"
-      - task: run_recurring_card_payment_sandbox-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "rec_card_sandbox_test"
-      - task: run_create_card_payment_worldpay_with_3ds2-test
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds2_test"
-      - task: run_create_card_payment_worldpay_with_3ds2_exemption-test
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_3ds2ex_test"
-      - task: run_create_card_payment_worldpay_without_3ds-test
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_wpay_test"
-      - task: run_recurring_card_payment_worldpay-test
-        attempts: 10
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "reccard_worldpay_test"
-      - task: run_cancel_card_payment_sandbox-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "cancel_sandbox_test"
-      - task: run_use_payment_link_sandbox-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "pymntlnk_sandbox_test"
-      - task: run_create_card_payment_stripe-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_stripe_test"
-      - task: run_create_card_payment_stripe_3ds-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "card_stripe_3ds_test"
-      - task: run_recurring_card_payment_stripe-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "rec_card_stripe_test"
-      - task: run_notifications_sandbox-test
-        file: pay-ci/ci/tasks/run-smoke-test.yml
-        params:
-          <<: *aws_assumed_role_creds
-          AWS_REGION: "eu-west-1"
-          SMOKE_TEST_NAME: "notifcatns_sndbx_test"
 
 docker_credentials: &docker_credentials
   DOCKER_USERNAME: ((docker-username))

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1,61 +1,62 @@
 definitions:
-  - &load_app_name
-    load_var: app_name
-    file: snippet/app_name
-  - &load_app_name_from_parse_release_tag
-    load_var: app_name
-    file: tags/app_name
-  - &load_app_name_from_parse_ecr_release_tag
-    load_var: app_name
-    file: ecr-release-info/app_name
-  - &load_app_name_from_parse_candidate_tag
-    load_var: app_name
-    file: parse-candidate-tag/app_name
-  - &load_app_release_number
-    load_var: app_release_number
-    file: snippet/app_release_number
-  - &load_app_release_number_from_parse_release_tag
-    load_var: app_release_number
-    file: tags/release-number
-  - &load_app_release_number_from_parse_ecr_release_tag
-    load_var: app_release_number
-    file: ecr-release-info/release-number
-  - &load_app_release_number_from_parse_candidate_tag
-    load_var: app_release_number
-    file: parse-candidate-tag/release-number
-  - &load_adot_release_number
-    load_var: adot_release_number
-    file: snippet/adot_release_number
-  - &load_nginx_release_number
-    load_var: nginx_release_number
-    file: snippet/nginx_release_number
-  - &load_nginx_forward_proxy_release_number
-    load_var: nginx_forward_proxy_release_number
-    file: snippet/nginx_forward_proxy_release_number
-  - &assume_copy_from_test_ecr_role
-    task: assume-copy-from-ecr-test-role
-    file: pay-ci/ci/tasks/assume-role.yml
-    output_mapping:
-      assume-role: assume-copy-from-ecr-test-role
-    params:
-      AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-      AWS_ROLE_SESSION_NAME: copy-from-ecr-in-test
-  - &assume_write_to_staging_ecr_role
-    task: assume-write-to-ecr-staging-role
-    file: pay-ci/ci/tasks/assume-role.yml
-    output_mapping:
-      assume-role: assume-write-to-ecr-staging-role
-    params:
-      AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
-      AWS_ROLE_SESSION_NAME: copy-to-ecr-in-staging
-  - &load_copy_from_test_ecr_role
-    load_var: copy-from-test-ecr-role
-    file: assume-copy-from-ecr-test-role/assume-role.json
-    format: json
-  - &load_write_to_staging_ecr_role
-    load_var: write-to-staging-ecr-role
-    file: assume-write-to-ecr-staging-role/assume-role.json
-    format: json
+  array_anchors:
+    - &load_app_name
+      load_var: app_name
+      file: snippet/app_name
+    - &load_app_name_from_parse_release_tag
+      load_var: app_name
+      file: tags/app_name
+    - &load_app_name_from_parse_ecr_release_tag
+      load_var: app_name
+      file: ecr-release-info/app_name
+    - &load_app_name_from_parse_candidate_tag
+      load_var: app_name
+      file: parse-candidate-tag/app_name
+    - &load_app_release_number
+      load_var: app_release_number
+      file: snippet/app_release_number
+    - &load_app_release_number_from_parse_release_tag
+      load_var: app_release_number
+      file: tags/release-number
+    - &load_app_release_number_from_parse_ecr_release_tag
+      load_var: app_release_number
+      file: ecr-release-info/release-number
+    - &load_app_release_number_from_parse_candidate_tag
+      load_var: app_release_number
+      file: parse-candidate-tag/release-number
+    - &load_adot_release_number
+      load_var: adot_release_number
+      file: snippet/adot_release_number
+    - &load_nginx_release_number
+      load_var: nginx_release_number
+      file: snippet/nginx_release_number
+    - &load_nginx_forward_proxy_release_number
+      load_var: nginx_forward_proxy_release_number
+      file: snippet/nginx_forward_proxy_release_number
+    - &assume_copy_from_test_ecr_role
+      task: assume-copy-from-ecr-test-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      output_mapping:
+        assume-role: assume-copy-from-ecr-test-role
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: copy-from-ecr-in-test
+    - &assume_write_to_staging_ecr_role
+      task: assume-write-to-ecr-staging-role
+      file: pay-ci/ci/tasks/assume-role.yml
+      output_mapping:
+        assume-role: assume-write-to-ecr-staging-role
+      params:
+        AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+        AWS_ROLE_SESSION_NAME: copy-to-ecr-in-staging
+    - &load_copy_from_test_ecr_role
+      load_var: copy-from-test-ecr-role
+      file: assume-copy-from-ecr-test-role/assume-role.json
+      format: json
+    - &load_write_to_staging_ecr_role
+      load_var: write-to-staging-ecr-role
+      file: assume-write-to-ecr-staging-role/assume-role.json
+      format: json
 
 copy_ecr_from_test_to_staging_params: &copy_ecr_from_test_to_staging_params
   RELEASE_NUMBER:  ((.:release_number))
@@ -224,7 +225,7 @@ put_success_slack_and_metric_notification_with_nginx_and_adot: &put_success_slac
         - *slack_notification_success
         - *send_app_release_metric_success
         - *send_nginx_release_metric_success
-        - *send_adot_release_metric_success 
+        - *send_adot_release_metric_success
 
 put_failure_slack_and_metric_notification_with_nginx_and_adot: &put_failure_slack_and_metric_notification_with_nginx_and_adot
   on_failure:
@@ -4274,7 +4275,7 @@ jobs:
         params:
           ECR_REPO_NAME: "govukpay/products-ui"
           <<: *copy_ecr_from_test_to_staging_params
-  
+
   - name: build-and-push-publicapi-candidate
     plan:
       - in_parallel:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -58,245 +58,245 @@ definitions:
       file: assume-write-to-ecr-staging-role/assume-role.json
       format: json
 
-copy_ecr_from_test_to_staging_params: &copy_ecr_from_test_to_staging_params
-  RELEASE_NUMBER:  ((.:release_number))
-  SOURCE_ECR_REGISTRY: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
-  DESTINATION_ECR_REGISTRY: "((pay_aws_staging_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
-  SOURCE_AWS_ACCESS_KEY_ID: ((.:copy-from-test-ecr-role.AWS_ACCESS_KEY_ID))
-  SOURCE_AWS_SECRET_ACCESS_KEY: ((.:copy-from-test-ecr-role.AWS_SECRET_ACCESS_KEY))
-  SOURCE_AWS_SESSION_TOKEN: ((.:copy-from-test-ecr-role.AWS_SESSION_TOKEN))
-  DESTINATION_AWS_ACCESS_KEY_ID: ((.:write-to-staging-ecr-role.AWS_ACCESS_KEY_ID))
-  DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:write-to-staging-ecr-role.AWS_SECRET_ACCESS_KEY))
-  DESTINATION_AWS_SESSION_TOKEN: ((.:write-to-staging-ecr-role.AWS_SESSION_TOKEN))
+  copy_ecr_from_test_to_staging_params: &copy_ecr_from_test_to_staging_params
+    RELEASE_NUMBER:  ((.:release_number))
+    SOURCE_ECR_REGISTRY: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+    DESTINATION_ECR_REGISTRY: "((pay_aws_staging_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+    SOURCE_AWS_ACCESS_KEY_ID: ((.:copy-from-test-ecr-role.AWS_ACCESS_KEY_ID))
+    SOURCE_AWS_SECRET_ACCESS_KEY: ((.:copy-from-test-ecr-role.AWS_SECRET_ACCESS_KEY))
+    SOURCE_AWS_SESSION_TOKEN: ((.:copy-from-test-ecr-role.AWS_SESSION_TOKEN))
+    DESTINATION_AWS_ACCESS_KEY_ID: ((.:write-to-staging-ecr-role.AWS_ACCESS_KEY_ID))
+    DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:write-to-staging-ecr-role.AWS_SECRET_ACCESS_KEY))
+    DESTINATION_AWS_SESSION_TOKEN: ((.:write-to-staging-ecr-role.AWS_SESSION_TOKEN))
 
 
-aws_test_config: &aws_test_config
-  aws_access_key_id: ((readonly_access_key_id))
-  aws_secret_access_key: ((readonly_secret_access_key))
-  aws_session_token: ((readonly_session_token))
-  # Need to create the role for the concourse user to assume in the test account
-  aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-  # Hardcode the test account registry ID for now. Needs to be a string, not a number
-  aws_ecr_registry_id: "((pay_aws_test_account_id))"
-  aws_region: eu-west-1
+  aws_test_config: &aws_test_config
+    aws_access_key_id: ((readonly_access_key_id))
+    aws_secret_access_key: ((readonly_secret_access_key))
+    aws_session_token: ((readonly_session_token))
+    # Need to create the role for the concourse user to assume in the test account
+    aws_role_arn: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+    # Hardcode the test account registry ID for now. Needs to be a string, not a number
+    aws_ecr_registry_id: "((pay_aws_test_account_id))"
+    aws_region: eu-west-1
 
-aws_staging_config: &aws_staging_config
-  aws_access_key_id: ((readonly_access_key_id))
-  aws_secret_access_key: ((readonly_secret_access_key))
-  aws_session_token: ((readonly_session_token))
-  aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
-  aws_ecr_registry_id: "((pay_aws_staging_account_id))"
-  aws_region: eu-west-1
+  aws_staging_config: &aws_staging_config
+    aws_access_key_id: ((readonly_access_key_id))
+    aws_secret_access_key: ((readonly_secret_access_key))
+    aws_session_token: ((readonly_session_token))
+    aws_role_arn: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
+    aws_ecr_registry_id: "((pay_aws_staging_account_id))"
+    aws_region: eu-west-1
 
-aws_assumed_role_creds: &aws_assumed_role_creds
-  AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-  AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-  AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
+  aws_assumed_role_creds: &aws_assumed_role_creds
+    AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
+    AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
+    AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
-slack-notification-success: &slack_notification_success
-  put: slack-notification
-  params:
-    channel: '#govuk-pay-activity'
-    icon_emoji: ":fargate:"
-    username: pay-concourse
-    text: "((.:success_snippet)) |
-          <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-
-put_success_slack_notification: &put_success_slack_notification
-  on_success:
-    *slack_notification_success
-
-slack-notification-failure: &slack_notification_failure
-  put: slack-notification
-  params:
-    channel: '#govuk-pay-announce'
-    icon_emoji: ":fargate:"
-    username: pay-concourse
-    text: "((.:failure_snippet)) \n
-          - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-
-put_failure_slack_notification: &put_failure_slack_notification
-  on_failure:
-    *slack_notification_failure
-
-pushgateway_default_labels: &pushgateway_default_labels
-  pipeline: "$BUILD_PIPELINE_NAME"
-  conocurse_job: "$BUILD_JOB_NAME"
-  app: "((.:app_name))"
-  environment: test-12
-  instance: "concourse"
-
-send_app_release_metric_success: &send_app_release_metric_success
-  put: send-app-release-number-metric
-  resource: prometheus-pushgateway
-  params:
-    metric: deployment_pipeline_app_release_number
-    value: "((.:app_release_number))"
-    job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/success"
-    labels:
-      <<: *pushgateway_default_labels
-      outcome: success
-
-send_nginx_release_metric_success: &send_nginx_release_metric_success
-  put: send-nginx-release-number-metric
-  resource: prometheus-pushgateway
-  params:
-    metric: deployment_pipeline_sidecar_release_number
-    value: "((.:nginx_release_number))"
-    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/success"
-    labels:
-      <<: *pushgateway_default_labels
-      outcome: success
-      sidecar: nginx
-
-send_adot_release_metric_success: &send_adot_release_metric_success
-  put: send-adot-release-number-metric
-  resource: prometheus-pushgateway
-  params:
-    metric: deployment_pipeline_sidecar_release_number
-    value: "((.:adot_release_number))"
-    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/success"
-    labels:
-      <<: *pushgateway_default_labels
-      outcome: success
-      sidecar: adot
-
-send_app_release_metric_failure: &send_app_release_metric_failure
-  put: send-app-release-number-metric
-  resource: prometheus-pushgateway
-  params:
-    metric: deployment_pipeline_app_release_number
-    value: "((.:app_release_number))"
-    job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/failure"
-    labels:
-      <<: *pushgateway_default_labels
-      outcome: failure
-
-send_nginx_release_metric_failure: &send_nginx_release_metric_failure
-  put: send-nginx-release-number-metric
-  resource: prometheus-pushgateway
-  params:
-    metric: deployment_pipeline_sidecar_release_number
-    value: "((.:nginx_release_number))"
-    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/failure"
-    labels:
-      <<: *pushgateway_default_labels
-      outcome: failure
-      sidecar: nginx
-
-send_adot_release_metric_failure: &send_adot_release_metric_failure
-  put: send-adot-release-number-metric
-  resource: prometheus-pushgateway
-  params:
-    metric: deployment_pipeline_sidecar_release_number
-    value: "((.:adot_release_number))"
-    job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/failure"
-    labels:
-      <<: *pushgateway_default_labels
-      outcome: failure
-      sidecar: adot
-
-put_success_metric: &put_success_metric
-  on_success:
-    *send_app_release_metric_success
-
-put_failure_metric: &put_failure_metric
-  on_failure:
-    *send_app_release_metric_failure
-
-put_success_slack_and_metric_notification: &put_success_slack_and_metric_notification
-  on_success:
-    in_parallel:
-        steps:
-        - *slack_notification_success
-        - *send_app_release_metric_success
-
-put_failure_slack_and_metric_notification: &put_failure_slack_and_metric_notification
-  on_failure:
-    in_parallel:
-        steps:
-        - *slack_notification_failure
-        - *send_app_release_metric_failure
-
-put_success_slack_and_metric_notification_with_nginx_and_adot: &put_success_slack_and_metric_notification_with_nginx_and_adot
-  on_success:
-    in_parallel:
-        steps:
-        - *slack_notification_success
-        - *send_app_release_metric_success
-        - *send_nginx_release_metric_success
-        - *send_adot_release_metric_success
-
-put_failure_slack_and_metric_notification_with_nginx_and_adot: &put_failure_slack_and_metric_notification_with_nginx_and_adot
-  on_failure:
-    in_parallel:
-        steps:
-        - *slack_notification_failure
-        - *send_app_release_metric_failure
-        - *send_nginx_release_metric_failure
-        - *send_adot_release_metric_failure
-
-put_db_migration_slack_notification: &put_db_migration_slack_notification
-  put: slack-notification
-  params:
-    channel: '#govuk-pay-announce'
-    icon_emoji: ":postgres:"
-    username: pay-concourse
-    text: ":postgres: starting $BUILD_JOB_NAME on test-12\n
-          - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-
-put_db_migration_success_slack_notification: &put_db_migration_success_slack_notification
-  on_success:
+  slack-notification-success: &slack_notification_success
     put: slack-notification
     params:
       channel: '#govuk-pay-activity'
-      icon_emoji: ":postgres:"
+      icon_emoji: ":fargate:"
       username: pay-concourse
-      text: ":green-circle: $BUILD_JOB_NAME completed successfully on test-12\n
+      text: "((.:success_snippet)) |
+            <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
+  put_success_slack_notification: &put_success_slack_notification
+    on_success:
+      *slack_notification_success
+
+  slack-notification-failure: &slack_notification_failure
+    put: slack-notification
+    params:
+      channel: '#govuk-pay-announce'
+      icon_emoji: ":fargate:"
+      username: pay-concourse
+      text: "((.:failure_snippet)) \n
             - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-put_db_migration_failure_slack_notification: &put_db_migration_failure_slack_notification
-  on_failure:
+  put_failure_slack_notification: &put_failure_slack_notification
+    on_failure:
+      *slack_notification_failure
+
+  pushgateway_default_labels: &pushgateway_default_labels
+    pipeline: "$BUILD_PIPELINE_NAME"
+    conocurse_job: "$BUILD_JOB_NAME"
+    app: "((.:app_name))"
+    environment: test-12
+    instance: "concourse"
+
+  send_app_release_metric_success: &send_app_release_metric_success
+    put: send-app-release-number-metric
+    resource: prometheus-pushgateway
+    params:
+      metric: deployment_pipeline_app_release_number
+      value: "((.:app_release_number))"
+      job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/success"
+      labels:
+        <<: *pushgateway_default_labels
+        outcome: success
+
+  send_nginx_release_metric_success: &send_nginx_release_metric_success
+    put: send-nginx-release-number-metric
+    resource: prometheus-pushgateway
+    params:
+      metric: deployment_pipeline_sidecar_release_number
+      value: "((.:nginx_release_number))"
+      job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/success"
+      labels:
+        <<: *pushgateway_default_labels
+        outcome: success
+        sidecar: nginx
+
+  send_adot_release_metric_success: &send_adot_release_metric_success
+    put: send-adot-release-number-metric
+    resource: prometheus-pushgateway
+    params:
+      metric: deployment_pipeline_sidecar_release_number
+      value: "((.:adot_release_number))"
+      job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/success"
+      labels:
+        <<: *pushgateway_default_labels
+        outcome: success
+        sidecar: adot
+
+  send_app_release_metric_failure: &send_app_release_metric_failure
+    put: send-app-release-number-metric
+    resource: prometheus-pushgateway
+    params:
+      metric: deployment_pipeline_app_release_number
+      value: "((.:app_release_number))"
+      job: "deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/failure"
+      labels:
+        <<: *pushgateway_default_labels
+        outcome: failure
+
+  send_nginx_release_metric_failure: &send_nginx_release_metric_failure
+    put: send-nginx-release-number-metric
+    resource: prometheus-pushgateway
+    params:
+      metric: deployment_pipeline_sidecar_release_number
+      value: "((.:nginx_release_number))"
+      job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/failure"
+      labels:
+        <<: *pushgateway_default_labels
+        outcome: failure
+        sidecar: nginx
+
+  send_adot_release_metric_failure: &send_adot_release_metric_failure
+    put: send-adot-release-number-metric
+    resource: prometheus-pushgateway
+    params:
+      metric: deployment_pipeline_sidecar_release_number
+      value: "((.:adot_release_number))"
+      job: "deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/failure"
+      labels:
+        <<: *pushgateway_default_labels
+        outcome: failure
+        sidecar: adot
+
+  put_success_metric: &put_success_metric
+    on_success:
+      *send_app_release_metric_success
+
+  put_failure_metric: &put_failure_metric
+    on_failure:
+      *send_app_release_metric_failure
+
+  put_success_slack_and_metric_notification: &put_success_slack_and_metric_notification
+    on_success:
+      in_parallel:
+          steps:
+          - *slack_notification_success
+          - *send_app_release_metric_success
+
+  put_failure_slack_and_metric_notification: &put_failure_slack_and_metric_notification
+    on_failure:
+      in_parallel:
+          steps:
+          - *slack_notification_failure
+          - *send_app_release_metric_failure
+
+  put_success_slack_and_metric_notification_with_nginx_and_adot: &put_success_slack_and_metric_notification_with_nginx_and_adot
+    on_success:
+      in_parallel:
+          steps:
+          - *slack_notification_success
+          - *send_app_release_metric_success
+          - *send_nginx_release_metric_success
+          - *send_adot_release_metric_success
+
+  put_failure_slack_and_metric_notification_with_nginx_and_adot: &put_failure_slack_and_metric_notification_with_nginx_and_adot
+    on_failure:
+      in_parallel:
+          steps:
+          - *slack_notification_failure
+          - *send_app_release_metric_failure
+          - *send_nginx_release_metric_failure
+          - *send_adot_release_metric_failure
+
+  put_db_migration_slack_notification: &put_db_migration_slack_notification
     put: slack-notification
     params:
       channel: '#govuk-pay-announce'
       icon_emoji: ":postgres:"
       username: pay-concourse
-      text: ":red-circle: $BUILD_JOB_NAME failed on test-12\n
+      text: ":postgres: starting $BUILD_JOB_NAME on test-12\n
             - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-wait_for_deploy_params: &wait_for_deploy_params
-  <<: *aws_assumed_role_creds
-  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
-  ADOT_IMAGE_TAG: ((.:adot_image_tag))
-  ENVIRONMENT: test-12
+  put_db_migration_success_slack_notification: &put_db_migration_success_slack_notification
+    on_success:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-activity'
+        icon_emoji: ":postgres:"
+        username: pay-concourse
+        text: ":green-circle: $BUILD_JOB_NAME completed successfully on test-12\n
+              - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-deploy_params: &deploy_params
-  <<: *aws_assumed_role_creds
-  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
-  ADOT_IMAGE_TAG: ((.:adot_image_tag))
-  ACCOUNT: test
-  ENVIRONMENT: test-12
+  put_db_migration_failure_slack_notification: &put_db_migration_failure_slack_notification
+    on_failure:
+      put: slack-notification
+      params:
+        channel: '#govuk-pay-announce'
+        icon_emoji: ":postgres:"
+        username: pay-concourse
+        text: ":red-circle: $BUILD_JOB_NAME failed on test-12\n
+              - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
-check_release_versions_params: &check_release_versions_params
-  <<: *aws_assumed_role_creds
-  AWS_REGION: "eu-west-1"
-  CLUSTER_NAME: "test-12-fargate"
-  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-  ADOT_IMAGE_TAG: ((.:adot_image_tag))
-  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+  wait_for_deploy_params: &wait_for_deploy_params
+    <<: *aws_assumed_role_creds
+    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
+    ENVIRONMENT: test-12
 
-snippet_params_all_versions: &snippet_params_all_versions
-  ENV: test-12
-  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-  ADOT_IMAGE_TAG: ((.:adot_image_tag))
-  NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+  deploy_params: &deploy_params
+    <<: *aws_assumed_role_creds
+    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
+    ACCOUNT: test
+    ENVIRONMENT: test-12
 
-snippet_params_app_version: &snippet_params_app_version
-  ENV: test-12
-  APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+  check_release_versions_params: &check_release_versions_params
+    <<: *aws_assumed_role_creds
+    AWS_REGION: "eu-west-1"
+    CLUSTER_NAME: "test-12-fargate"
+    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
+    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+
+  snippet_params_all_versions: &snippet_params_all_versions
+    ENV: test-12
+    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+    ADOT_IMAGE_TAG: ((.:adot_image_tag))
+    NGINX_IMAGE_TAG: ((.:nginx_image_tag))
+
+  snippet_params_app_version: &snippet_params_app_version
+    ENV: test-12
+    APPLICATION_IMAGE_TAG: ((.:application_image_tag))
 
 
 resources:


### PR DESCRIPTION
The `deploy-to-test.yml` pipeline file contained a duplicate `definitions` block introduced in [this commit](https://github.com/alphagov/pay-ci/commit/a80b8d46429af621e113e25e1ea4785a7a12f5d2).

Tidy up the file by:
*  Nesting the array type anchors under a new mapping `array_anchors`. 
* Moving the map type anchors under the first `definitions`.
* Converting the array type anchor in the second `definitions` block to a map type and moving it to the first `definitions` block, and removing teh now empty second block.

These changes are seperate commits that at no point change the actual pipeline.