### PR TITLE
PP-12219-deployment-events-for-adminusers

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -93,6 +93,15 @@ definitions:
     AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   slack-notification-success: &slack_notification_success
+slack-notification-success: &slack_notification_success
+  put: slack-notification
+  params:
+    channel: '#govuk-pay-activity'
+    icon_emoji: ":fargate:"
+    username: pay-concourse
+    text: "((.:success_snippet)) |
+          <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+
     put: slack-notification
     params:
       channel: '#govuk-pay-activity'
@@ -386,7 +395,6 @@ definitions:
           AWS_REGION: "eu-west-1"
           SMOKE_TEST_NAME: "notifcatns_sndbx_test"
 
-
 resources:
   - name: prometheus-pushgateway
     type: prometheus-pushgateway
@@ -437,6 +445,7 @@ resources:
       password: ((grafana-annotations-password))
       tags:
         - test-12
+        - release
 
   # Github Releases
   - name: stream-s3-sqs-git-release
@@ -2543,7 +2552,6 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
     <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
-    <<: *put_release_annotation
 
   - name: adminusers-db-migration
     plan:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -93,15 +93,6 @@ definitions:
     AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
 
   slack-notification-success: &slack_notification_success
-slack-notification-success: &slack_notification_success
-  put: slack-notification
-  params:
-    channel: '#govuk-pay-activity'
-    icon_emoji: ":fargate:"
-    username: pay-concourse
-    text: "((.:success_snippet)) |
-          <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-
     put: slack-notification
     params:
       channel: '#govuk-pay-activity'
@@ -126,6 +117,13 @@ slack-notification-success: &slack_notification_success
   put_failure_slack_notification: &put_failure_slack_notification
     on_failure:
       *slack_notification_failure
+
+  send_app_release_annotation: &send_app_release_annotation
+    put: grafana-annotation
+    params:
+      tags:
+        - ((.:app_name))
+      template:  "released ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} release ((.:app_release_number)) (build ${BUILD_ID})"
 
   pushgateway_default_labels: &pushgateway_default_labels
     pipeline: "$BUILD_PIPELINE_NAME"
@@ -234,6 +232,8 @@ slack-notification-success: &slack_notification_success
           - *send_app_release_metric_success
           - *send_nginx_release_metric_success
           - *send_adot_release_metric_success
+          - *send_app_release_annotation
+
 
   put_failure_slack_and_metric_notification_with_nginx_and_adot: &put_failure_slack_and_metric_notification_with_nginx_and_adot
     on_failure:
@@ -262,14 +262,6 @@ slack-notification-success: &slack_notification_success
         username: pay-concourse
         text: ":green-circle: $BUILD_JOB_NAME completed successfully on test-12\n
               - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-
-  put_release_annotation: &put_release_annotation
-    on_success:
-      put: grafana-annotation
-      params:
-        tags:
-          - complete
-        template:  "released build ${BUILD_ID}"
 
   put_db_migration_failure_slack_notification: &put_db_migration_failure_slack_notification
     on_failure:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -69,7 +69,6 @@ definitions:
     DESTINATION_AWS_SECRET_ACCESS_KEY: ((.:write-to-staging-ecr-role.AWS_SECRET_ACCESS_KEY))
     DESTINATION_AWS_SESSION_TOKEN: ((.:write-to-staging-ecr-role.AWS_SESSION_TOKEN))
 
-
   aws_test_config: &aws_test_config
     aws_access_key_id: ((readonly_access_key_id))
     aws_secret_access_key: ((readonly_secret_access_key))
@@ -255,6 +254,14 @@ definitions:
         text: ":green-circle: $BUILD_JOB_NAME completed successfully on test-12\n
               - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
 
+  put_release_annotation: &put_release_annotation
+    on_success:
+      put: grafana-annotation
+      params:
+        tags:
+          - complete
+        template:  "released build ${BUILD_ID}"
+
   put_db_migration_failure_slack_notification: &put_db_migration_failure_slack_notification
     on_failure:
       put: slack-notification
@@ -422,6 +429,14 @@ resources:
       tag_regex: "alpha_release-(.*)"
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
+  - name: grafana-annotation
+    type: grafana-annotation
+    source:
+      url: "https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk"
+      username: pay_cd
+      password: ((grafana-annotations-password))
+      tags:
+        - test-12
 
   # Github Releases
   - name: stream-s3-sqs-git-release
@@ -850,6 +865,11 @@ resource_types:
     source:
       repository: governmentdigitalservice/pay-prometheus-pushgateway-resource
       tag: latest-master
+  - name: grafana-annotation
+    type: docker-image
+    source:
+      repository: governmentdigitalservice/pay-grafana-annotation-resource
+      tag: latest
 
 groups:
   - name: adminusers
@@ -2523,6 +2543,7 @@ jobs:
           <<: *wait_for_deploy_params
     <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
     <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
+    <<: *put_release_annotation
 
   - name: adminusers-db-migration
     plan:


### PR DESCRIPTION
Puts an annotation in Grafana when an adminusers release succeeds.

We already have logic to report success to Slack and Prometheus, so I chose to piggyback off that. 

Tags are the application name, the target environment, and the fixed string `release`. What is released is encoded in the annotation description. I am happy to discuss and/or alter this choice, because I flip-flopped many times on what should or should not be a tag.

You can see an annotation [here](https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk/goto/qdZQ7ETSR?orgId=1).