### PR TITLE
PP-12262: Send Release Metrics for CardID

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -2843,14 +2843,16 @@ jobs:
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: cardid-ecr-registry-prod
-        trigger: true
-      - get: nginx-proxy-ecr-registry-prod
-        trigger: true
-      - get: adot-ecr-registry-prod
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-prod
+            trigger: true
+          - get: nginx-proxy-ecr-registry-prod
+            trigger: true
+          - get: adot-ecr-registry-prod
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
       - load_var: application_image_tag
         file: cardid-ecr-registry-prod/tag
       - load_var: nginx_image_tag
@@ -2863,12 +2865,18 @@ jobs:
           APP_NAME: cardid
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
-      - load_var: start_snippet
-        file: snippet/start
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
+          - load_var: start_snippet
+            file: snippet/start
       - <<: *put_start_slack_notification
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
@@ -2907,16 +2915,18 @@ jobs:
         params:
           APP_NAME: cardid
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification_announce
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot_announce
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: smoke-test-cardid-on-prod
     serial_groups: [smoke-test]
     plan:
-      - get: cardid-ecr-registry-prod
-        trigger: true
-        passed: [deploy-cardid-to-prod]
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-prod
+            trigger: true
+            passed: [deploy-cardid-to-prod]
+          - get: pay-ci
       - load_var: application_image_tag
         file: cardid-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -2925,10 +2935,14 @@ jobs:
           APP_NAME: cardid
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2939,43 +2953,8 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-production
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
-
-  - name: cardid-pact-tag
-    plan:
-      - get: cardid-ecr-registry-prod
-        passed: [smoke-test-cardid-on-prod]
-        trigger: true
-      - load_var: application_image_tag
-        file: cardid-ecr-registry-prod/tag
-      - get: pay-ci
-      - task: create-notification-snippets
-        file: pay-ci/ci/tasks/create-notification-snippets.yml
-        params:
-          APP_NAME: cardid
-          ACTION_NAME: Pact tag
-          <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
-      - task: get-git-sha-for-release-tag
-        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
-        params:
-          APP_NAME: cardid
-          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-          GITHUB_TOKEN: ((github-access-token))
-      - load_var: git-sha
-        file: git-sha/git-sha
-      - task: tag-pact
-        file: pay-ci/ci/tasks/pact-tag.yml
-        params:
-          GIT_SHA: ((.:git-sha))
-          APP_NAME: cardid
-          PACT_TAG: production-fargate
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: retag-cardid-image-for-test-perf
     plan:
@@ -3000,6 +2979,8 @@ jobs:
               ecr-repo: cardid-ecr-registry-prod
       - in_parallel:
           steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
           - load_var: release-number
             file: ecr-release-info/release-number
           - load_var: perf-tag
@@ -3032,6 +3013,49 @@ jobs:
           <<: *retag_for_perf_test
           SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:release-number))-candidate"
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:perf-tag))"
+    <<: *put_success_metric
+    <<: *put_failure_metric
+
+  - name: cardid-pact-tag
+    plan:
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-prod
+            passed: [smoke-test-cardid-on-prod]
+            trigger: true
+          - get: pay-ci
+      - load_var: application_image_tag
+        file: cardid-ecr-registry-prod/tag
+      - task: create-notification-snippets
+        file: pay-ci/ci/tasks/create-notification-snippets.yml
+        params:
+          APP_NAME: cardid
+          ACTION_NAME: Pact tag
+          <<: *snippet_params_app_version
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
+      - task: get-git-sha-for-release-tag
+        file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
+        params:
+          APP_NAME: cardid
+          APPLICATION_IMAGE_TAG: ((.:application_image_tag))
+          GITHUB_TOKEN: ((github-access-token))
+      - load_var: git-sha
+        file: git-sha/git-sha
+      - task: tag-pact
+        file: pay-ci/ci/tasks/pact-tag.yml
+        params:
+          GIT_SHA: ((.:git-sha))
+          APP_NAME: cardid
+          PACT_TAG: production-fargate
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: deploy-publicapi-to-prod
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -2593,14 +2593,20 @@ jobs:
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: cardid-ecr-registry-staging
-        trigger: true
-      - get: nginx-proxy-ecr-registry-staging
-        trigger: true
-      - get: adot-ecr-registry-staging
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-staging
+            trigger: true
+          - get: nginx-proxy-ecr-registry-staging
+            trigger: true
+          - get: adot-ecr-registry-staging
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: cardid-ecr-registry-staging
       - load_var: application_image_tag
         file: cardid-ecr-registry-staging/tag
       - load_var: nginx_image_tag
@@ -2613,12 +2619,18 @@ jobs:
           APP_NAME: cardid
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
-      - load_var: start_snippet
-        file: snippet/start
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
+          - load_var: start_snippet
+            file: snippet/start
       - <<: *put_start_slack_notification
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
@@ -2657,16 +2669,22 @@ jobs:
         params:
           APP_NAME: cardid
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification_announce
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot_announce
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: smoke-test-cardid-on-staging
     serial_groups: [smoke-test]
     plan:
-      - get: cardid-ecr-registry-staging
-        trigger: true
-        passed: [deploy-cardid-to-staging]
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-staging
+            trigger: true
+            passed: [deploy-cardid-to-staging]
+          - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: cardid-ecr-registry-staging
       - load_var: application_image_tag
         file: cardid-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -2675,10 +2693,14 @@ jobs:
           APP_NAME: cardid
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2689,27 +2711,37 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-staging
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: cardid-pact-tag
     plan:
-      - get: cardid-ecr-registry-staging
-        passed: [smoke-test-cardid-on-staging]
-        trigger: true
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-staging
+            passed: [smoke-test-cardid-on-staging]
+            trigger: true
+          - get: pay-ci
       - load_var: application_image_tag
         file: cardid-ecr-registry-staging/tag
-      - get: pay-ci
+      - task: parse-ecr-release-tag
+        file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+        input_mapping:
+          ecr-image: cardid-ecr-registry-staging
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: cardid
           ACTION_NAME: Pact tag
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -2724,8 +2756,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: cardid
           PACT_TAG: staging-fargate
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: push-cardid-to-production-ecr
     plan:
@@ -2742,8 +2774,12 @@ jobs:
         file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
           ecr-image: cardid-ecr-registry-staging
-      - load_var: release_number
-        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - load_var: release_number
+            file: ecr-release-info/release-number
       - in_parallel:
           steps:
           - *assume_copy_from_staging_ecr_role
@@ -2756,8 +2792,10 @@ jobs:
         file: pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml
         privileged: true
         params:
-         ECR_REPO_NAME: "govukpay/cardid"
-         <<: *copy_ecr_from_staging_to_prod_params
+          ECR_REPO_NAME: "govukpay/cardid"
+          <<: *copy_ecr_from_staging_to_prod_params
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: deploy-publicapi-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -5428,6 +5428,8 @@ jobs:
         input_mapping:
           git-release: cardid-git-release
       - in_parallel:
+        - *load_app_name_from_parse_release_tag
+        - *load_app_release_number_from_parse_release_tag
         - load_var: release-number
           file: tags/release-number
         - load_var: release-name
@@ -5489,31 +5491,37 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: cardid candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-announce'
+            silent: true
+            text: ':red-circle: cardid candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_failure
     on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':hammer: cardid candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-activity'
+            silent: true
+            text: ':hammer: cardid candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_success
 
   - name: run-cardid-e2e
     plan:
       - in_parallel:
         - get: cardid-candidate
-          trigger: true
           params:
             format: oci
+          trigger: true
         - get: pay-ci
       - in_parallel:
           steps:
@@ -5543,14 +5551,16 @@ jobs:
               AWS_ROLE_SESSION_NAME: retag-ecr-image-as-release
       - in_parallel:
           steps:
-            - load_var: role
-              file: assume-role/assume-role.json
-              format: json
-            - load_var: retag-role
-              file: assume-retag-role/assume-role.json
-              format: json
-            - load_var: release_image_tag
-              file: parse-candidate-tag/release-tag
+          - load_var: role
+            file: assume-role/assume-role.json
+            format: json
+          - load_var: retag-role
+            file: assume-retag-role/assume-role.json
+            format: json
+          - load_var: release_image_tag
+            file: parse-candidate-tag/release-tag
+          - *load_app_name_from_parse_candidate_tag
+          - *load_app_release_number_from_parse_candidate_tag
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
@@ -5577,62 +5587,70 @@ jobs:
             AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
       - in_parallel:
           steps:
-            - task: retag-candidate-as-release-in-ecr
-              file: pay-ci/ci/tasks/manifest-retag.yml
-              params:
-                DOCKER_LOGIN_ECR: 1
-                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:candidate_image_tag))"
-                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:release_image_tag))"
-                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
-                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
-                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
-            - task: retag-candidate-as-latest-in-ecr
-              file: pay-ci/ci/tasks/manifest-retag.yml
-              params:
-                DOCKER_LOGIN_ECR: 1
-                AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
-                SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:candidate_image_tag))"
-                NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:latest"
-                AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
-                AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
-                AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
-            - task: retag-candidate-as-release-in-dockerhub
-              file: pay-ci/ci/tasks/manifest-retag.yml
-              params:
-                SOURCE_MANIFEST: "governmentdigitalservice/pay-cardid:((.:candidate_image_tag))"
-                NEW_MANIFEST: "governmentdigitalservice/pay-cardid:latest-master"
+          - task: retag-candidate-as-release-in-ecr
+            file: pay-ci/ci/tasks/manifest-retag.yml
+            params:
+              DOCKER_LOGIN_ECR: 1
+              AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+              SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:candidate_image_tag))"
+              NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:release_image_tag))"
+              AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+              AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+              AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+          - task: retag-candidate-as-latest-in-ecr
+            file: pay-ci/ci/tasks/manifest-retag.yml
+            params:
+              DOCKER_LOGIN_ECR: 1
+              AWS_ACCOUNT_ID: "((pay_aws_test_account_id))"
+              SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:((.:candidate_image_tag))"
+              NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/cardid:latest"
+              AWS_ACCESS_KEY_ID: ((.:retag-role.AWS_ACCESS_KEY_ID))
+              AWS_SECRET_ACCESS_KEY: ((.:retag-role.AWS_SECRET_ACCESS_KEY))
+              AWS_SESSION_TOKEN: ((.:retag-role.AWS_SESSION_TOKEN))
+          - task: retag-candidate-as-release-in-dockerhub
+            file: pay-ci/ci/tasks/manifest-retag.yml
+            params:
+              SOURCE_MANIFEST: "governmentdigitalservice/pay-cardid:((.:candidate_image_tag))"
+              NEW_MANIFEST: "governmentdigitalservice/pay-cardid:latest-master"
     on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: cardid candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+          - put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-announce'
+              silent: true
+              text: ':red-circle: cardid candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
+          - *send_app_release_metric_failure
     on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: cardid candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+          - put: slack-notification
+            attempts: 10
+            params:
+              channel: '#govuk-pay-activity'
+              silent: true
+              text: ':green-circle: cardid candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+              icon_emoji: ":concourse:"
+              username: pay-concourse
+          - *send_app_release_metric_success
 
   - name: deploy-cardid
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: cardid-ecr-registry-test
-        trigger: true
-      - get: adot-ecr-registry-test
-        trigger: true
-      - get: nginx-proxy-ecr-registry-test
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-test
+            trigger: true
+          - get: nginx-proxy-ecr-registry-test
+            trigger: true
+          - get: adot-ecr-registry-test
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
       - load_var: application_image_tag
         file: cardid-ecr-registry-test/tag
       - load_var: nginx_image_tag
@@ -5645,10 +5663,16 @@ jobs:
           APP_NAME: cardid
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -5686,16 +5710,18 @@ jobs:
         params:
           APP_NAME: cardid
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: smoke-test-cardid
     serial_groups: [smoke-test]
     plan:
-      - get: cardid-ecr-registry-test
-        trigger: true
-        passed: [deploy-cardid]
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-test
+            trigger: true
+            passed: [deploy-cardid]
+          - get: pay-ci
       - load_var: application_image_tag
         file: cardid-ecr-registry-test/tag
       - task: create-notification-snippets
@@ -5704,10 +5730,14 @@ jobs:
           APP_NAME: cardid
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -5718,27 +5748,33 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: cardid-pact-tag
     plan:
-      - get: cardid-ecr-registry-test
-        passed: [smoke-test-cardid]
-        trigger: true
+      - in_parallel:
+          steps:
+          - get: cardid-ecr-registry-test
+            passed: [smoke-test-cardid]
+            trigger: true
+          - get: pay-ci
       - load_var: application_image_tag
         file: cardid-ecr-registry-test/tag
-      - get: pay-ci
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: cardid
           ACTION_NAME: Pact tag
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: get-git-sha-for-release-tag
         file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
         params:
@@ -5753,8 +5789,8 @@ jobs:
           GIT_SHA: ((.:git-sha))
           APP_NAME: cardid
           PACT_TAG: test-fargate
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: push-cardid-to-staging-ecr
     plan:
@@ -5771,8 +5807,12 @@ jobs:
         file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
           ecr-image: cardid-ecr-registry-test
-      - load_var: release_number
-        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - load_var: release_number
+            file: ecr-release-info/release-number
       - in_parallel:
           steps:
           - *assume_copy_from_test_ecr_role
@@ -5787,7 +5827,8 @@ jobs:
         params:
           ECR_REPO_NAME: "govukpay/cardid"
           <<: *copy_ecr_from_test_to_staging_params
-
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: build-webhooks
     plan:


### PR DESCRIPTION
Update `deploy-to-test`, `deploy-to-perf`, `deploy-to-staging`, and `deploy-to-production` to send release metrics for the cardid app.

This is a fairly mechanical copy of the changes made to the jobs for adminusers in these pipelines. Some reordering was done to add consistency with the structure of the adminusers jobs.

