### PR TITLE
PP-12343: Example of adding a new templated deployment

### DIFF
--- a/ci/pkl-pipelines/pay-js.pkl
+++ b/ci/pkl-pipelines/pay-js.pkl
@@ -17,6 +17,10 @@ local payJsLibraries: Listing<PayJsLibraryPipeline> = new {
         name = "metrics"
         source_branch = "main"
     }
+    new {
+        name = "logging-pipeline"
+        source_branch = "main"
+    }
 }
 
 resources = new {
@@ -79,3 +83,4 @@ jobs = new {
         }
     }
 }    
+


### PR DESCRIPTION
This PR is a demonstation of how templated pipelines can drastically help us going forward.

It demonstrates the work involved in adding a new js library for deployment to get the new deployment running.

From this PR a diff of the YML produced:

```diff
$ diff -U 5 before.yml after.yml
--- before.yml	2024-03-05 14:22:02
+++ after.yml	2024-03-05 14:22:15
@@ -47,10 +47,23 @@
       BASE: main
       REPO: alphagov/pay-js-metrics
       GITHUB_TOKEN: ((github-access-token))
     input_mapping:
       src: js-metrics-git-release
+- name: version-and-push-js-logging
+  plan:
+  - in_parallel:
+    - get: js-logging-git-release
+    - get: pay-ci
+  - task: npm-version-and-create-pr
+    file: pay-ci/ci/tasks/npm-version-and-create-pr.yml
+    params:
+      BASE: main
+      REPO: alphagov/pay-js-logging
+      GITHUB_TOKEN: ((github-access-token))
+    input_mapping:
+      src: js-logging-git-release
 resources:
 - name: pipeline-source
   type: git
   source:
     uri: https://github.com/alphagov/pay-ci
@@ -81,15 +94,27 @@
     branch: main
     commit_filter:
       exclude:
       - \[automated release\]
   icon: github
+- name: js-logging-git-release
+  type: git
+  source:
+    uri: https://github.com/alphagov/pay-js-logging
+    branch: main
+    commit_filter:
+      exclude:
+      - \[automated release\]
+  icon: github
 groups:
 - name: update-pipeline
   jobs:
   - update-pipeline
 - name: js-commons
   jobs:
   - version-and-push-js-commons
 - name: js-metrics
   jobs:
   - version-and-push-js-metrics
+- name: js-logging
+  jobs:
+  - version-and-push-js-logging
```