### PR TITLE
PP-12343: Refactor to reduce duplicated common shared code

### DIFF
--- a/ci/pkl-pipelines/common/pipeline_self_update.pkl
+++ b/ci/pkl-pipelines/common/pipeline_self_update.pkl
@@ -20,7 +20,10 @@ payPipelineSelfUpdateGroup: Pipeline.Group = new {
 
 function PayPipelineSelfUpdateJob(pkl_pipeline_file: String): Pipeline.Job = new {
   local yml_pipeline_file = pkl_pipeline_file.replaceLast(".pkl", ".yaml")
-  local pipeline_name = pkl_pipeline_file.replaceLast(".pkl", "").replaceLast("pay-deploy/", "")
+  local pipeline_name = pkl_pipeline_file.
+    replaceLast(".pkl", "").
+    replaceLast("pay-deploy/", "").
+    replaceLast("pay-dev/", "")
 
   name = "update-pipeline"
   plan = new {

--- a/ci/pkl-pipelines/common/pipeline_self_update.pkl
+++ b/ci/pkl-pipelines/common/pipeline_self_update.pkl
@@ -2,16 +2,13 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "./shared_resources.pkl"
 
-function PayPipelineSelfUpdateResource(pkl_pipeline_file: String, branch: String): shared_resources.PayGitHubResource = new {
-  name = "pipeline-source"
-  source = new Mapping {
-    ["uri"] = "https://github.com/alphagov/pay-ci"
-    ["branch"] = branch
-    ["paths"] = new Listing<String> {
-      "ci/pkl-pipelines/\(pkl_pipeline_file)"
-      "ci/pkl-pipelines/common/**"
+function PayPipelineSelfUpdateResource(pkl_pipeline_file: String, branch: String) = (shared_resources.payGithubResourceWithBranch("pipeline-source", "pay-ci", branch)) {
+    source {
+      ["paths"] = new Listing<String> {
+        "ci/pkl-pipelines/\(pkl_pipeline_file)"
+        "ci/pkl-pipelines/common/**"
+      }
     }
-  }
 }
 
 payPipelineSelfUpdateGroup: Pipeline.Group = new {

--- a/ci/pkl-pipelines/common/shared_resources.pkl
+++ b/ci/pkl-pipelines/common/shared_resources.pkl
@@ -1,11 +1,6 @@
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/Pipeline.pkl"
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/TaskConfig.pkl"
 
-class PayGitHubResource extends Pipeline.Resource {
-  type = "git"
-  icon = "github"
-}
-
 anonymousConcourseRunnerResource = new TaskConfig.AnonymousResource {
   type = "registry-image"
   source = new {
@@ -14,15 +9,7 @@ anonymousConcourseRunnerResource = new TaskConfig.AnonymousResource {
   }
 }
 
-payCiGitHubResource: PayGitHubResource = new {
-  name = "pay-ci"
-  source = new Mapping {
-    ["uri"] = "https://github.com/alphagov/pay-ci"
-    ["branch"] = "master"
-    ["username"] = "alphagov-pay-ci-concourse"
-    ["password"] = "((github-access-token))"
-  }
-}
+payCiGitHubResource = payGithubResourceWithBranch("pay-ci", "pay-ci", "master")
 
 function payDockerHubResource(resource_name: String, repo: String, tag: String): Pipeline.Resource = new {
   name = resource_name

--- a/ci/pkl-pipelines/pay-deploy/detect-secrets.pkl
+++ b/ci/pkl-pipelines/pay-deploy/detect-secrets.pkl
@@ -6,16 +6,10 @@ import "../common/shared_resources.pkl"
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("detect-secrets.pkl", "master")
   shared_resources.payCiGitHubResource
-  new shared_resources.PayGitHubResource {
-    name = "detect-secrets-src"
-    source = new {
-      ["uri"] = "https://github.com/alphagov/pay-ci"
-      ["branch"] = "master"
-      ["paths"] = new Listing<String> {
-        "ci/docker/detect-secrets/*"
-      }
+  (shared_resources.payGithubResourceWithBranch("detect-secrets-src", "pay-ci", "master")) {
+    source {
+      ["paths"] = new Listing<String> { "ci/docker/detect-secrets/*" }
     }
-
   }
   shared_resources.payDockerHubResource("detect-secrets-registry-image", "governmentdigitalservice/pay-detect-secrets", "latest")
 }

--- a/ci/pkl-pipelines/pay-deploy/pay-js.pkl
+++ b/ci/pkl-pipelines/pay-deploy/pay-js.pkl
@@ -23,13 +23,10 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-js.pkl", "master")
   shared_resources.payCiGitHubResource
   for (jsLibrary in payJsLibraries) {
-    new shared_resources.PayGitHubResource {
-      name = "js-\(jsLibrary.name)-git-release"
-      source = new Mapping {
-        ["uri"] = "https://github.com/alphagov/pay-js-\(jsLibrary.name)"
-        ["branch"] = jsLibrary.source_branch
-        ["commit_filter"] = new {
-          exclude = new Listing {
+    (shared_resources.payGithubResourceWithBranch("js-\(jsLibrary.name)-git-release", "pay-js-\(jsLibrary.name)", jsLibrary.source_branch)) {
+      source {
+        ["commit_filter"] = new Mapping<String, Listing<String>> {
+          ["exclude"] = new Listing {
             "\\[automated release\\]"
           }
         }
@@ -49,7 +46,7 @@ groups = new {
 }
 
 jobs = new {
-  pipeline_self_update.PayPipelineSelfUpdateJob("pay-js.pkl")
+  pipeline_self_update.PayPipelineSelfUpdateJob("pay-deploy/pay-js.pkl")
   for (jsLibrary in payJsLibraries) {
     new {
       name = "version-and-push-\(jsLibrary.name)"


### PR DESCRIPTION
Between my changes and the changes of @kbottla we ended up with some duplicated, but different, shared code. This PR removes that duplication and reuses the newer code @kbottla wrote.

I've also added the pipeline self update to strip pay-dev team name as well as pay-deploy

There are no set-pipeline differences between this PR and the ones we already merged.