### PR TITLE
PP-12343: Pay-js is in pay-deploy subfolder, also don't apply pipelines with -test suffix

### DIFF
--- a/ci/pkl-pipelines/common/pipeline_self_update.pkl
+++ b/ci/pkl-pipelines/common/pipeline_self_update.pkl
@@ -53,7 +53,7 @@ function PayPipelineSelfUpdateJob(pkl_pipeline_file: String): Pipeline.Job = new
       }
     }
     new Pipeline.SetPipelineStep {
-      set_pipeline = "\(pipeline_name)-test"
+      set_pipeline = pipeline_name
       file = "pipeline-source/ci/pkl-pipelines/\(yml_pipeline_file)"
     }
   }

--- a/ci/pkl-pipelines/pay-deploy/pay-js.pkl
+++ b/ci/pkl-pipelines/pay-deploy/pay-js.pkl
@@ -20,7 +20,7 @@ local payJsLibraries: Listing<PayJsLibraryPipeline> = new {
 }
 
 resources = new {
-  pipeline_self_update.PayPipelineSelfUpdateResource("pay-js.pkl", "master")
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/pay-js.pkl", "master")
   shared_resources.payCiGitHubResource
   for (jsLibrary in payJsLibraries) {
     (shared_resources.payGithubResourceWithBranch("js-\(jsLibrary.name)-git-release", "pay-js-\(jsLibrary.name)", jsLibrary.source_branch)) {


### PR DESCRIPTION
Oops, left -test in the name of the pipelines that get set with the self update, and also pay-js is in the pay-deploy subfolder