### PR TITLE
PP-12385: Use different test names from concourse regular ci test

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/pkl_pipeline_changes.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/pkl_pipeline_changes.pkl
@@ -36,7 +36,7 @@ jobs = new {
           new GetStep { get = "pay-ci" }
         }
       }
-      shared_resources.putPRTestPendingStatus("pkl-pipeline-pr")
+      shared_resources.putPRTestPendingStatus("pkl-pipeline-pr", "pipeline-yaml-changes")
       new TaskStep {
         task = "comment-on-pr-with-yml-and-concourse-diffs"
         file = "pay-ci/ci/tasks/comment-on-pr-with-pkl-pipeline-diffs.yml"
@@ -45,8 +45,8 @@ jobs = new {
           ["CONCOURSE_TEAM"] = concourseTeamName
           ["FLY_PASSWORD"] = "((readonly_local_user_password))"
         }
-        on_success = shared_resources.putPRTestSuccessStatus("pkl-pipeline-pr")
-        on_failure = shared_resources.putPRTestFailedStatus("pkl-pipeline-pr")
+        on_success = shared_resources.putPRTestSuccessStatus("pkl-pipeline-pr", "pipeline-yaml-changes")
+        on_failure = shared_resources.putPRTestFailedStatus("pkl-pipeline-pr", "pipeline-yaml-changes")
       }
     }
   }

--- a/ci/pkl-pipelines/common/shared_pipelines/pkl_pipeline_changes.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/pkl_pipeline_changes.pkl
@@ -36,7 +36,7 @@ jobs = new {
           new GetStep { get = "pay-ci" }
         }
       }
-      shared_resources.putPRTestPendingStatus("pkl-pipeline-pr", "pipeline-yaml-changes")
+      shared_resources.putPRTestPendingStatus("pkl-pipeline-pr", "pipeline-yaml-changes-\(concourseTeamName)")
       new TaskStep {
         task = "comment-on-pr-with-yml-and-concourse-diffs"
         file = "pay-ci/ci/tasks/comment-on-pr-with-pkl-pipeline-diffs.yml"
@@ -45,8 +45,8 @@ jobs = new {
           ["CONCOURSE_TEAM"] = concourseTeamName
           ["FLY_PASSWORD"] = "((readonly_local_user_password))"
         }
-        on_success = shared_resources.putPRTestSuccessStatus("pkl-pipeline-pr", "pipeline-yaml-changes")
-        on_failure = shared_resources.putPRTestFailedStatus("pkl-pipeline-pr", "pipeline-yaml-changes")
+        on_success = shared_resources.putPRTestSuccessStatus("pkl-pipeline-pr", "pipeline-yaml-changes-\(concourseTeamName)")
+        on_failure = shared_resources.putPRTestFailedStatus("pkl-pipeline-pr", "pipeline-yaml-changes-\(concourseTeamName)")
       }
     }
   }

--- a/ci/pkl-pipelines/common/shared_resources.pkl
+++ b/ci/pkl-pipelines/common/shared_resources.pkl
@@ -130,16 +130,16 @@ function payGithubPullRequestResource(_name: String, alphagovRepo: String): Pipe
   }
 }
 
-function putPRTestPendingStatus(resourceName: String): Pipeline.PutStep = new {
+function putPRTestPendingStatus(resourceName: String, test_name: String): Pipeline.PutStep = new {
   put = resourceName
   params {
     ["path"] = resourceName
     ["status"] = "pending"
-    ["context"] = "test"
+    ["context"] = test_name
   }
 }
 
-function putPRTestSuccessStatus(resourceName: String): Pipeline.PutStep = new {
+function putPRTestSuccessStatus(resourceName: String, test_name: String): Pipeline.PutStep = new {
   put = resourceName
   get_params {
     ["skip_download"] = true
@@ -147,11 +147,11 @@ function putPRTestSuccessStatus(resourceName: String): Pipeline.PutStep = new {
   params {
     ["path"] = resourceName
     ["status"] = "success"
-    ["context"] = "test"
+    ["context"] = test_name
   }
 }
 
-function putPRTestFailedStatus(resourceName: String): Pipeline.PutStep = new {
+function putPRTestFailedStatus(resourceName: String, test_name: String): Pipeline.PutStep = new {
   put = resourceName
   get_params {
     ["skip_download"] = true
@@ -159,6 +159,6 @@ function putPRTestFailedStatus(resourceName: String): Pipeline.PutStep = new {
   params {
     ["path"] = resourceName
     ["status"] = "failure"
-    ["context"] = "test"
+    ["context"] = test_name
   }
 }


### PR DESCRIPTION
I realised, the actual concourse ci tests (running pipecleaner etc) and my tests all post the same test name to concourse, so they overwrite each other for the test status.

This PR allows the test name to be set in the shared resource, and updates the pkl-pipeline-changes pipelines to use a new name.

Hopefully this PR should _also_ demo the whole process works 