### PR TITLE
PP-12268-publicauth-release-metrics

### DIFF
--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -1302,22 +1302,38 @@ jobs:
   - name: deploy-publicauth-to-perf
     serial: true
     plan:
-      - get: publicauth-ecr-registry-perf
-        trigger: true
-      - get: publicauth-db-ecr-registry-perf
-        trigger: true
-      - get: nginx-proxy-ecr-registry-perf
-        trigger: true
-      - get: adot-ecr-registry-perf
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
-      - load_var: application_image_tag
-        file: publicauth-ecr-registry-perf/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-perf/tag
-      - load_var: adot_image_tag
-        file: adot-ecr-registry-perf/tag
+      - in_parallel:
+          steps:
+          - get: publicauth-ecr-registry-perf
+            trigger: true
+          - get: publicauth-db-ecr-registry-perf
+            trigger: true
+          - get: nginx-proxy-ecr-registry-perf
+            trigger: true
+          - get: adot-ecr-registry-perf
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
+      - in_parallel:
+          steps:
+          - task: parse-ecr-release-tag
+            file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+            input_mapping:
+              ecr-image: publicauth-ecr-registry-perf
+          - *parse-adot-ecr-release-tag
+          - *parse-nginx-ecr-release-tag
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - *load_adot_release_number_from_parse_ecr_release_tag
+          - *load_nginx_release_number_from_parse_ecr_release_tag
+          - load_var: application_image_tag
+            file: publicauth-ecr-registry-perf/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-perf/tag
+          - load_var: adot_image_tag
+            file: adot-ecr-registry-perf/tag
       - put: slack-notification
         params:
           channel: '#govuk-pay-activity'
@@ -1342,39 +1358,31 @@ jobs:
         params:
           APP_NAME: publicauth
           <<: *wait_for_deploy_params
-    on_success:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-activity'
-        icon_emoji: ":fargate:"
-        username: pay-concourse
-        text: ":green-circle: Deployment of publicauth to perf success - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-    on_failure:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-announce'
-        icon_emoji: ":fargate:"
-        username: pay-concourse
-        text: ":red_circle: Deployment of publicauth to perf failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: publicauth-db-migration-perf
     plan:
-      - get: pay-ci
-      - get: publicauth-db-ecr-registry-perf
-        params:
-          format: oci
-        trigger: true
-        passed: [deploy-publicauth-to-perf]
-      - task: assume-role
-        file: pay-ci/ci/tasks/assume-role.yml
-        params:
-          AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
-          AWS_ROLE_SESSION_NAME: db-migration-perf-test-assume-role
-      - load_var: role
-        file: assume-role/assume-role.json
-        format: json
-      - load_var: application_image_tag
-        file: publicauth-db-ecr-registry-perf/tag
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: publicauth-db-ecr-registry-perf
+            params:
+              format: oci
+            trigger: true
+            passed: [deploy-publicauth-to-perf]
+          - task: assume-role
+            file: pay-ci/ci/tasks/assume-role.yml
+            params:
+              AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
+              AWS_ROLE_SESSION_NAME: db-migration-perf-test-assume-role
+      - in_parallel:
+          steps:
+          - load_var: role
+            file: assume-role/assume-role.json
+            format: json
+          - load_var: application_image_tag
+            file: publicauth-db-ecr-registry-perf/tag
       - task: start-publicauth-db
         file: pay-ci/ci/tasks/start-rds-instance.yml
         params:

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -2771,6 +2771,10 @@ jobs:
           <<: *snippet_params_all_versions
       - in_parallel:
           steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
           - load_var: success_snippet
             file: snippet/success
           - load_var: failure_snippet

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -2745,32 +2745,38 @@ jobs:
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: publicauth-ecr-registry-prod
-        trigger: true
-      - get: nginx-proxy-ecr-registry-prod
-        trigger: true
-      - get: adot-ecr-registry-prod
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
-      - load_var: application_image_tag
-        file: publicauth-ecr-registry-prod/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-prod/tag
-      - load_var: adot_image_tag
-        file: adot-ecr-registry-prod/tag
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: pay-infra
+          - get: publicauth-ecr-registry-prod
+            trigger: true
+          - get: nginx-proxy-ecr-registry-prod
+            trigger: true
+          - get: adot-ecr-registry-prod
+            trigger: true
+      - in_parallel:
+          steps:
+          - load_var: application_image_tag
+            file: publicauth-ecr-registry-prod/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-prod/tag
+          - load_var: adot_image_tag
+            file: adot-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: publicauth
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
-      - load_var: start_snippet
-        file: snippet/start
+      - in_parallel:
+          steps:
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
+          - load_var: start_snippet
+            file: snippet/start
       - <<: *put_start_slack_notification
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
@@ -2795,27 +2801,31 @@ jobs:
         params:
           APP_NAME: publicauth
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification_announce
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot_announce
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: publicauth-db-migration-prod
     plan:
-      - get: pay-ci
-      - get: publicauth-ecr-registry-prod
-        params:
-          format: oci
-        trigger: false
-        passed: [deploy-publicauth-to-prod]
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: publicauth-ecr-registry-prod
+            params:
+              format: oci
+            trigger: false
+            passed: [deploy-publicauth-to-prod]
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
           AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
           AWS_ROLE_SESSION_NAME: terraform-prod-assume-role
-      - load_var: role
-        file: assume-role/assume-role.json
-        format: json
-      - load_var: application_image_tag
-        file: publicauth-ecr-registry-prod/tag
+      - in_parallel:
+          steps:
+          - load_var: role
+            file: assume-role/assume-role.json
+            format: json
+          - load_var: application_image_tag
+            file: publicauth-ecr-registry-prod/tag
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -2902,10 +2912,12 @@ jobs:
   - name: smoke-test-publicauth-on-prod
     serial_groups: [smoke-test]
     plan:
-      - get: publicauth-ecr-registry-prod
-        trigger: true
-        passed: [deploy-publicauth-to-prod]
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: publicauth-ecr-registry-prod
+            trigger: true
+            passed: [deploy-publicauth-to-prod]
+          - get: pay-ci
       - load_var: application_image_tag
         file: publicauth-ecr-registry-prod/tag
       - task: create-notification-snippets
@@ -2914,10 +2926,14 @@ jobs:
           APP_NAME: publicauth
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2928,8 +2944,8 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-production
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: retag-publicauth-image-for-test-perf
     plan:
@@ -2954,6 +2970,8 @@ jobs:
               ecr-repo: publicauth-ecr-registry-prod
       - in_parallel:
           steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
           - load_var: release-number
             file: ecr-release-info/release-number
           - load_var: perf-tag
@@ -2986,6 +3004,8 @@ jobs:
           <<: *retag_for_perf_test
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/publicauth:((.:perf-tag))"
           SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/publicauth:((.:release-number))-candidate"
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: deploy-cardid-to-prod
     serial: true

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -2625,6 +2625,8 @@ jobs:
           steps:
           - *load_app_name
           - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
           - load_var: success_snippet
             file: snippet/success
           - load_var: failure_snippet
@@ -2655,8 +2657,8 @@ jobs:
         params:
           APP_NAME: publicauth
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_and_metric_notification_announce
-    <<: *put_failure_slack_and_metric_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot_announce
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: smoke-test-publicauth-on-staging
     serial_groups: [smoke-test]
@@ -2677,6 +2679,8 @@ jobs:
           <<: *snippet_params_app_version
       - in_parallel:
           steps:
+          - *load_app_name
+          - *load_app_release_number
           - load_var: success_snippet
             file: snippet/success
           - load_var: failure_snippet

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -2597,32 +2597,40 @@ jobs:
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: publicauth-ecr-registry-staging
-        trigger: true
-      - get: nginx-proxy-ecr-registry-staging
-        trigger: true
-      - get: adot-ecr-registry-staging
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
-      - load_var: application_image_tag
-        file: publicauth-ecr-registry-staging/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-staging/tag
-      - load_var: adot_image_tag
-        file: adot-ecr-registry-staging/tag
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: pay-infra
+          - get: publicauth-ecr-registry-staging
+            trigger: true
+          - get: nginx-proxy-ecr-registry-staging
+            trigger: true
+          - get: adot-ecr-registry-staging
+            trigger: true
+      - in_parallel:
+          steps:
+          - load_var: application_image_tag
+            file: publicauth-ecr-registry-staging/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-staging/tag
+          - load_var: adot_image_tag
+            file: adot-ecr-registry-staging/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: publicauth
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
-      - load_var: start_snippet
-        file: snippet/start
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
+          - load_var: start_snippet
+            file: snippet/start
       - <<: *put_start_slack_notification
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
@@ -2647,16 +2655,18 @@ jobs:
         params:
           APP_NAME: publicauth
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification_announce
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_announce
+    <<: *put_failure_slack_and_metric_notification
 
   - name: smoke-test-publicauth-on-staging
     serial_groups: [smoke-test]
     plan:
-      - get: publicauth-ecr-registry-staging
-        trigger: true
-        passed: [deploy-publicauth-to-staging]
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: publicauth-ecr-registry-staging
+            trigger: true
+            passed: [deploy-publicauth-to-staging]
       - load_var: application_image_tag
         file: publicauth-ecr-registry-staging/tag
       - task: create-notification-snippets
@@ -2665,10 +2675,12 @@ jobs:
           APP_NAME: publicauth
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -2679,27 +2691,31 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-staging
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: publicauth-db-migration-staging
     plan:
-      - get: pay-ci
-      - get: publicauth-ecr-registry-staging
-        params:
-          format: oci
-        trigger: false
-        passed: [deploy-publicauth-to-staging]
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: publicauth-ecr-registry-staging
+            params:
+              format: oci
+            trigger: false
+            passed: [deploy-publicauth-to-staging]
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
           AWS_ROLE_ARN: arn:aws:iam::((pay_aws_staging_account_id)):role/concourse
           AWS_ROLE_SESSION_NAME: terraform-staging-assume-role
-      - load_var: role
-        file: assume-role/assume-role.json
-        format: json
-      - load_var: application_image_tag
-        file: publicauth-ecr-registry-staging/tag
+      - in_parallel:
+          steps:
+          - load_var: role
+            file: assume-role/assume-role.json
+            format: json
+          - load_var: application_image_tag
+            file: publicauth-ecr-registry-staging/tag
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -2750,6 +2766,8 @@ jobs:
           - *assume_write_to_prod_ecr_role
       - in_parallel:
           steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
           - *load_copy_from_staging_ecr_role
           - *load_write_to_prod_ecr_role
       - task: copy-images-to-prod
@@ -2758,6 +2776,8 @@ jobs:
         params:
           ECR_REPO_NAME: "govukpay/publicauth"
           <<: *copy_ecr_from_staging_to_prod_params
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: deploy-cardid-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -4995,21 +4995,24 @@ jobs:
         input_mapping:
           git-release: publicauth-git-release
       - in_parallel:
-        - load_var: release-number
-          file: tags/release-number
-        - load_var: release-name
-          file: publicauth-git-release/.git/ref
-        - load_var: release-sha
-          file: tags/release-sha
-        - load_var: candidate-image-tag
-          file: tags/candidate-tag
-        - load_var: date
-          file: tags/date
-        - task: assume-role
-          file: pay-ci/ci/tasks/assume-role.yml
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
-            AWS_ROLE_SESSION_NAME: codebuild-assume-role
+          steps:
+          - *load_app_name_from_parse_release_tag
+          - *load_app_release_number_from_parse_release_tag
+          - load_var: release-number
+            file: tags/release-number
+          - load_var: release-name
+            file: publicauth-git-release/.git/ref
+          - load_var: release-sha
+            file: tags/release-sha
+          - load_var: candidate-image-tag
+            file: tags/candidate-tag
+          - load_var: date
+            file: tags/date
+          - task: assume-role
+            file: pay-ci/ci/tasks/assume-role.yml
+            params:
+              AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-builder-test-12
+              AWS_ROLE_SESSION_NAME: codebuild-assume-role
       - load_var: role
         file: assume-role/assume-role.json
         format: json
@@ -5031,6 +5034,7 @@ jobs:
           PASSWORD: ((docker-access-token))
           EMAIL: ((docker-email))
       - in_parallel:
+          steps:
           - task: run-codebuild-publicauth-amd64
             attempts: 3
             file: pay-ci/ci/tasks/run-codebuild.yml
@@ -5056,23 +5060,29 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
           AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
     on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: publicauth candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-announce'
+            silent: true
+            text: ':red-circle: publicauth candidate image ((.:candidate-image-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_failure
     on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':hammer: publicauth candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-activity'
+            silent: true
+            text: ':hammer: publicauth candidate image ((.:candidate-image-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_success
 
   - name: run-publicauth-e2e
     plan:
@@ -5118,6 +5128,8 @@ jobs:
               format: json
             - load_var: release_image_tag
               file: parse-candidate-tag/release-tag
+            - *load_app_name_from_parse_candidate_tag
+            - *load_app_release_number_from_parse_candidate_tag
       - task: prepare-codebuild
         file: pay-ci/ci/tasks/prepare-e2e-codebuild.yml
         params:
@@ -5170,52 +5182,68 @@ jobs:
                 SOURCE_MANIFEST: "governmentdigitalservice/pay-publicauth:((.:candidate_image_tag))"
                 NEW_MANIFEST: "governmentdigitalservice/pay-publicauth:latest-master"
     on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: publicauth candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-announce'
+            silent: true
+            text: ':red-circle: publicauth candidate image ((.:candidate_image_tag)) failed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_failure
     on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':green-circle: publicauth candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-activity'
+            silent: true
+            text: ':green-circle: publicauth candidate image ((.:candidate_image_tag)) passed post-merge end to end tests - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_success
 
   - name: deploy-publicauth
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: publicauth-ecr-registry-test
-        trigger: true
-      - get: nginx-proxy-ecr-registry-test
-        trigger: true
-      - get: adot-ecr-registry-test
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
-      - load_var: application_image_tag
-        file: publicauth-ecr-registry-test/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-test/tag
-      - load_var: adot_image_tag
-        file: adot-ecr-registry-test/tag
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: pay-infra
+          - get: publicauth-ecr-registry-test
+            trigger: true
+          - get: nginx-proxy-ecr-registry-test
+            trigger: true
+          - get: adot-ecr-registry-test
+            trigger: true
+      - in_parallel:
+          steps:
+          - load_var: application_image_tag
+            file: publicauth-ecr-registry-test/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-test/tag
+          - load_var: adot_image_tag
+            file: adot-ecr-registry-test/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: publicauth
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -5239,27 +5267,31 @@ jobs:
         params:
           APP_NAME: publicauth
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: publicauth-db-migration
     plan:
-      - get: pay-ci
-      - get: publicauth-ecr-registry-test
-        params:
-          format: oci
-        trigger: false
-        passed: [deploy-publicauth]
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: publicauth-ecr-registry-test
+            params:
+              format: oci
+            trigger: false
+            passed: [deploy-publicauth]
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
           AWS_ROLE_ARN: arn:aws:iam::((pay_aws_test_account_id)):role/concourse
           AWS_ROLE_SESSION_NAME: terraform-test-assume-role
-      - load_var: role
-        file: assume-role/assume-role.json
-        format: json
-      - load_var: application_image_tag
-        file: publicauth-ecr-registry-test/tag
+      - in_parallel:
+          steps:
+          - load_var: role
+            file: assume-role/assume-role.json
+            format: json
+          - load_var: application_image_tag
+            file: publicauth-ecr-registry-test/tag
       - <<: *put_db_migration_slack_notification
       - task: run-db-migration
         config:
@@ -5290,10 +5322,12 @@ jobs:
   - name: smoke-test-publicauth
     serial_groups: [smoke-test]
     plan:
-      - get: publicauth-ecr-registry-test
-        trigger: true
-        passed: [deploy-publicauth]
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: pay-ci
+          - get: publicauth-ecr-registry-test
+            trigger: true
+            passed: [deploy-publicauth]
       - load_var: application_image_tag
         file: publicauth-ecr-registry-test/tag
       - task: create-notification-snippets
@@ -5302,10 +5336,14 @@ jobs:
           APP_NAME: publicauth
           ACTION_NAME: Smoke test
           <<: *snippet_params_app_version
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -5316,8 +5354,8 @@ jobs:
         format: json
       - in_parallel:
           <<: *smoke-test-run-all-on-test
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification
+    <<: *put_failure_slack_and_metric_notification
 
   - name: push-publicauth-to-staging-ecr
     plan:
@@ -5334,8 +5372,12 @@ jobs:
         file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
           ecr-image: publicauth-ecr-registry-test
-      - load_var: release_number
-        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - load_var: release_number
+            file: ecr-release-info/release-number
       - in_parallel:
           steps:
           - *assume_copy_from_test_ecr_role
@@ -5350,6 +5392,8 @@ jobs:
         params:
           ECR_REPO_NAME: "govukpay/publicauth"
           <<: *copy_ecr_from_test_to_staging_params
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: build-and-push-selfservice-candidate
     plan:


### PR DESCRIPTION
Send deployment metrics for all relevant publicauth tasks across all pipelines.

[See in Grafana](https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk/goto/bqAHb9ASg?orgId=1).