### PR TITLE
PP-12421: Remove redundant resource types

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -621,11 +621,6 @@ resources:
       <<: *aws_prod_config
 
 resource_types:
-  - name: registry-image
-    type: registry-image
-    source:
-      repository: concourse/registry-image-resource
-      tag: "1.4.1"
   - name: slack-notification
     type: docker-image
     source:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -636,11 +636,6 @@ resources:
       url: https://hooks.slack.com/services/((slack-notification-secret))
 
 resource_types:
-  - name: registry-image
-    type: registry-image
-    source:
-      repository: concourse/registry-image-resource
-      tag: "1.4.1"
   - name: slack-notification
     type: docker-image
     source:

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -896,11 +896,6 @@ resources:
       url: https://hooks.slack.com/services/((slack-notification-secret))
 
 resource_types:
-  - name: registry-image
-    type: registry-image
-    source:
-      repository: concourse/registry-image-resource
-      tag: "1.4.1"
   - name: slack-notification
     type: docker-image
     source:

--- a/ci/pipelines/perf-tests.yml
+++ b/ci/pipelines/perf-tests.yml
@@ -122,11 +122,6 @@ resource_types:
       repository: cfcommunity/slack-notification-resource
       tag: latest
 
-  - name: cf-cli
-    type: registry-image
-    source:
-      repository: nulldriver/cf-cli-resource
-
   - name: pull-request
     type: registry-image
     source:


### PR DESCRIPTION
We are defining the registry-image resource type in some pipelines, but its now bundled with concourse and we don't need to custom define it.

We also don't use cloudfoundry anymore so removing the cf-cli resource type from the perf-tests pipeline.

I've not removed it from deploy-to-perf since @kbottla is currently converting it to pkl