### PR TITLE
PP-12272-toolbox-release-metrics

### DIFF
--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -1008,6 +1008,14 @@ jobs:
           - get: pay-ci
       - in_parallel:
           steps:
+          - task: parse-ecr-release-tag
+            file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
+            input_mapping:
+              ecr-image: toolbox-ecr-registry-perf
+          - *parse-adot-ecr-release-tag
+          - *parse-nginx-ecr-release-tag
+      - in_parallel:
+          steps:
           - *load_app_name_from_parse_ecr_release_tag
           - *load_app_release_number_from_parse_ecr_release_tag
           - *load_adot_release_number_from_parse_ecr_release_tag

--- a/ci/pipelines/deploy-to-perf.yml
+++ b/ci/pipelines/deploy-to-perf.yml
@@ -996,20 +996,28 @@ jobs:
   - name: deploy-toolbox-to-perf
     serial: true
     plan:
-      - get: toolbox-ecr-registry-perf
-        trigger: true
-      - get: adot-ecr-registry-perf
-        trigger: true
-      - get: nginx-proxy-ecr-registry-perf
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
-      - load_var: application_image_tag
-        file: toolbox-ecr-registry-perf/tag
-      - load_var: adot_image_tag
-        file: adot-ecr-registry-perf/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-perf/tag
+      - in_parallel:
+          steps:
+          - get: toolbox-ecr-registry-perf
+            trigger: true
+          - get: adot-ecr-registry-perf
+            trigger: true
+          - get: nginx-proxy-ecr-registry-perf
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - *load_adot_release_number_from_parse_ecr_release_tag
+          - *load_nginx_release_number_from_parse_ecr_release_tag
+          - load_var: application_image_tag
+            file: toolbox-ecr-registry-perf/tag
+          - load_var: adot_image_tag
+            file: adot-ecr-registry-perf/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-perf/tag
       - put: slack-notification
         params:
           channel: '#govuk-pay-activity'
@@ -1034,20 +1042,8 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
-    on_success:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-activity'
-        icon_emoji: ":fargate:"
-        username: pay-concourse
-        text: ":green-circle: Deployment of toolbox to perf success - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
-    on_failure:
-      put: slack-notification
-      params:
-        channel: '#govuk-pay-announce'
-        icon_emoji: ":fargate:"
-        username: pay-concourse
-        text: ":red_circle: Deployment of toolbox to perf failed - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: deploy-frontend-to-perf
     serial: true

--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -1431,32 +1431,42 @@ jobs:
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: toolbox-ecr-registry-prod
-        trigger: true
-      - get: adot-ecr-registry-prod
-        trigger: true
-      - get: nginx-proxy-ecr-registry-prod
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
-      - load_var: application_image_tag
-        file: toolbox-ecr-registry-prod/tag
-      - load_var: adot_image_tag
-        file: adot-ecr-registry-prod/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-prod/tag
+      - in_parallel:
+          steps:
+          - get: toolbox-ecr-registry-prod
+            trigger: true
+          - get: adot-ecr-registry-prod
+            trigger: true
+          - get: nginx-proxy-ecr-registry-prod
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
+      - in_parallel:
+          steps:
+          - load_var: application_image_tag
+            file: toolbox-ecr-registry-prod/tag
+          - load_var: adot_image_tag
+            file: adot-ecr-registry-prod/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-prod/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: toolbox
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
-      - load_var: start_snippet
-        file: snippet/start
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
+          - load_var: start_snippet
+            file: snippet/start
       - <<: *put_start_slack_notification
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
@@ -1481,8 +1491,8 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification_announce
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot_announce
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: retag-toolbox-image-for-test-perf
     plan:
@@ -1507,6 +1517,8 @@ jobs:
               ecr-repo: toolbox-ecr-registry-prod
       - in_parallel:
           steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
           - load_var: release-number
             file: ecr-release-info/release-number
           - load_var: perf-tag
@@ -1539,6 +1551,8 @@ jobs:
           <<: *retag_for_perf_test
           NEW_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/toolbox:((.:perf-tag))"
           SOURCE_MANIFEST: "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/toolbox:((.:release-number))-candidate"
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: retag-nginx-proxy-image-for-test-perf
     plan:

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -1332,36 +1332,46 @@ jobs:
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: toolbox-ecr-registry-staging
-        trigger: true
-      - get: adot-ecr-registry-staging
-        trigger: true
-      - get: nginx-proxy-ecr-registry-staging
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
+      - in_parallel:
+          steps:
+          - get: toolbox-ecr-registry-staging
+            trigger: true
+          - get: adot-ecr-registry-staging
+            trigger: true
+          - get: nginx-proxy-ecr-registry-staging
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
       - task: parse-ecr-release-tag
         file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
           ecr-image: toolbox-ecr-registry-staging
-      - load_var: application_image_tag
-        file: toolbox-ecr-registry-staging/tag
-      - load_var: adot_image_tag
-        file: adot-ecr-registry-staging/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-staging/tag
+      - in_parallel:
+          steps:
+          - load_var: application_image_tag
+            file: toolbox-ecr-registry-staging/tag
+          - load_var: adot_image_tag
+            file: adot-ecr-registry-staging/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-staging/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: toolbox
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
-      - load_var: start_snippet
-        file: snippet/start
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
+          - load_var: start_snippet
+            file: snippet/start
       - <<: *put_start_slack_notification
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
@@ -1386,8 +1396,8 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification_announce
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot_announce
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: push-toolbox-to-production-ecr
     plan:
@@ -1404,8 +1414,12 @@ jobs:
         file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
           ecr-image: toolbox-ecr-registry-staging
-      - load_var: release_number
-        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - load_var: release_number
+            file: ecr-release-info/release-number
       - in_parallel:
           steps:
           - *assume_copy_from_staging_ecr_role
@@ -1420,6 +1434,8 @@ jobs:
         params:
           ECR_REPO_NAME: "govukpay/toolbox"
           <<: *copy_ecr_from_staging_to_prod_params
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: deploy-egress-to-staging
     serial: true

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -1454,6 +1454,8 @@ jobs:
         input_mapping:
           git-release: toolbox-git-release
       - in_parallel:
+        - *load_app_name_from_parse_release_tag
+        - *load_app_release_number_from_parse_release_tag
         - load_var: release-number
           file: tags/release-number
         - load_var: release-name
@@ -1554,52 +1556,68 @@ jobs:
                 SOURCE_MANIFEST: "governmentdigitalservice/pay-toolbox:((.:candidate_image_tag))"
                 NEW_MANIFEST: "governmentdigitalservice/pay-toolbox:latest-master"
     on_failure:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-announce'
-        silent: true
-        text: ':red-circle: toolbox image ((.:release-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-announce'
+            silent: true
+            text: ':red-circle: toolbox image ((.:release-tag)) failed to build - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_failure
     on_success:
-      put: slack-notification
-      attempts: 10
-      params:
-        channel: '#govuk-pay-activity'
-        silent: true
-        text: ':hammer: toolbox image ((.:release-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
-        icon_emoji: ":concourse:"
-        username: pay-concourse
+      in_parallel:
+        steps:
+        - put: slack-notification
+          attempts: 10
+          params:
+            channel: '#govuk-pay-activity'
+            silent: true
+            text: ':hammer: toolbox image ((.:release-tag)) built successfully - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>'
+            icon_emoji: ":concourse:"
+            username: pay-concourse
+        - *send_app_release_metric_success
 
   - name: deploy-toolbox
     serial: true
     serial_groups: [deploy-application]
     plan:
-      - get: toolbox-ecr-registry-test
-        trigger: true
-      - get: nginx-proxy-ecr-registry-test
-        trigger: true
-      - get: adot-candidate
-        trigger: true
-      - get: pay-infra
-      - get: pay-ci
-      - load_var: application_image_tag
-        file: toolbox-ecr-registry-test/tag
-      - load_var: adot_image_tag
-        file: adot-candidate/tag
-      - load_var: nginx_image_tag
-        file: nginx-proxy-ecr-registry-test/tag
+      - in_parallel:
+          steps:
+          - get: toolbox-ecr-registry-test
+            trigger: true
+          - get: nginx-proxy-ecr-registry-test
+            trigger: true
+          - get: adot-candidate
+            trigger: true
+          - get: pay-infra
+          - get: pay-ci
+      - in_parallel:
+          steps:
+          - load_var: application_image_tag
+            file: toolbox-ecr-registry-test/tag
+          - load_var: adot_image_tag
+            file: adot-candidate/tag
+          - load_var: nginx_image_tag
+            file: nginx-proxy-ecr-registry-test/tag
       - task: create-notification-snippets
         file: pay-ci/ci/tasks/create-notification-snippets.yml
         params:
           APP_NAME: toolbox
           ACTION_NAME: Deployment
           <<: *snippet_params_all_versions
-      - load_var: success_snippet
-        file: snippet/success
-      - load_var: failure_snippet
-        file: snippet/failure
+      - in_parallel:
+          steps:
+          - *load_app_name
+          - *load_app_release_number
+          - *load_adot_release_number
+          - *load_nginx_release_number
+          - load_var: success_snippet
+            file: snippet/success
+          - load_var: failure_snippet
+            file: snippet/failure
       - task: assume-role
         file: pay-ci/ci/tasks/assume-role.yml
         params:
@@ -1623,8 +1641,8 @@ jobs:
         params:
           APP_NAME: toolbox
           <<: *wait_for_deploy_params
-    <<: *put_success_slack_notification
-    <<: *put_failure_slack_notification
+    <<: *put_success_slack_and_metric_notification_with_nginx_and_adot
+    <<: *put_failure_slack_and_metric_notification_with_nginx_and_adot
 
   - name: push-toolbox-to-staging-ecr
     plan:
@@ -1641,8 +1659,12 @@ jobs:
         file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
         input_mapping:
           ecr-image: toolbox-ecr-registry-test
-      - load_var: release_number
-        file: ecr-release-info/release-number
+      - in_parallel:
+          steps:
+          - *load_app_name_from_parse_ecr_release_tag
+          - *load_app_release_number_from_parse_ecr_release_tag
+          - load_var: release_number
+            file: ecr-release-info/release-number
       - in_parallel:
           steps:
           - *assume_copy_from_test_ecr_role
@@ -1657,6 +1679,8 @@ jobs:
         params:
           ECR_REPO_NAME: "govukpay/toolbox"
           <<: *copy_ecr_from_test_to_staging_params
+    <<: *put_success_metric
+    <<: *put_failure_metric
 
   - name: build-and-push-egress-candidate
     plan:


### PR DESCRIPTION
Send release metrics for toolbox. 

[Here they are in Grafana](https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk/goto/vOTmReAIR?orgId=1). Note that toolbox doesn't do pact tagging or smoke-testing.