### PR TITLE
PP-12420 Convert deploy-to-perf pipeline to pkl

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_slack_notifications.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_slack_notifications.pkl
@@ -17,6 +17,20 @@ slackNotificationResourceType = new Pipeline.ResourceType {
   }
 }
 
+function paySlackNotificationForAppDeployment(channelName: String, isASuccess: Boolean, message: String): Pipeline.PutStep = new Pipeline.PutStep {
+  put = "slack-notification"
+  params = new Mapping {
+    ["channel"] = channelName
+    when (isASuccess) {
+      ["text"] = ":green-circle: \(message) - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    } else {
+      ["text"] = ":red_circle: \(message) - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+    }
+    ["icon_emoji"] = ":fargate:"
+    ["username"] = "pay-concourse"
+  }
+}
+
 function paySlackNotificationForFail(channel_name: String, message: String): Pipeline.PutStep = new Pipeline.PutStep {
   put = "slack-notification"
   attempts = 10

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -94,6 +94,7 @@ groups {
       }
     }
   }
+  pipeline_self_update.payPipelineSelfUpdateGroup
 }
 
 jobs {

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -1,0 +1,424 @@
+amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/Pipeline.pkl"
+
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/TaskConfig.pkl"
+
+import "../common/pipeline_self_update.pkl"
+import "../common/shared_resources.pkl"
+import "../common/shared_resources_for_metrics.pkl"
+import "../common/shared_resources_for_slack_notifications.pkl"
+
+local class PayApp {
+  name: String
+  has_db: Boolean = false
+  is_a_helper_or_sidecar_app: Boolean = false
+  override_app_to_deploy: String?
+  override_ecr_repo: String?
+  rds_identifier_suffix: Int? = 0
+  use_app_specific_deploy_task: Boolean = false
+}
+
+local payApplicationsWithDB: Listing<PayApp> = new {
+  new { name = "adminusers"; has_db = true }
+  new { name = "connector"; has_db = true }
+  new { name = "ledger"; has_db = true }
+  new { name = "products"; has_db = true }
+  new { name = "publicauth"; has_db = true;  rds_identifier_suffix = 1 }
+  new { name = "webhooks"; has_db = true }
+}
+
+local payApplicationsWithOutDB: Listing<PayApp> = new {
+  new { name = "cardid" }
+  new { name = "frontend"; use_app_specific_deploy_task = true }
+  new { name = "products-ui" }
+  new { name = "publicapi" }
+  new { name = "selfservice" }
+  new { name = "toolbox" }
+}
+
+// sidecars or other helpers
+local payHelpers: Listing<PayApp> = new {
+  new { name = "alpine"; override_app_to_deploy = "scheduled-tasks"; is_a_helper_or_sidecar_app = true }
+  new { name = "egress"; is_a_helper_or_sidecar_app = true; use_app_specific_deploy_task = true }
+  new { name = "nginx-forward-proxy"; override_app_to_deploy = "frontend"; is_a_helper_or_sidecar_app = true }
+  new { name = "nginx-proxy"; override_ecr_repo = "docker-nginx-proxy"; override_app_to_deploy = "toolbox"; is_a_helper_or_sidecar_app = true }
+  new { name = "notifications"; is_a_helper_or_sidecar_app = true }
+  new { name = "stream-s3-sqs"; override_app_to_deploy = "scheduled-tasks";  is_a_helper_or_sidecar_app = true }
+  new { name = "webhooks-egress"; is_a_helper_or_sidecar_app = true; use_app_specific_deploy_task = true }
+}
+
+local allPayApps: Listing<PayApp> = new {
+  ...payApplicationsWithDB
+  ...payApplicationsWithOutDB
+  ...payHelpers
+}
+
+resource_types {
+  shared_resources_for_slack_notifications.slackNotificationResourceType
+  shared_resources_for_metrics.prometheusPushgatewayResourceType
+}
+
+resources = new {
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/deploy-to-perf.pkl", "master")
+  shared_resources_for_metrics.prometheusPushgatewayResource
+  (shared_resources.payGithubResourceWithBranch("deploy-to-perf-pipeline-definition", "pay-ci", "master")) {
+    source { ["paths"] = new Listing<String> { "ci/pipelines/deploy-to-perf.yml" } }
+  }
+  shared_resources.payCiGitHubResource
+  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+
+  shared_resources.payECRResourceWithVariant("adot-ecr-registry-perf", "govukpay/adot", "pay_aws_test_account_id", "perf")
+  for (app in allPayApps) {
+    shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-perf", "govukpay/\(if (app.override_ecr_repo == null) app.name else app.override_ecr_repo)", "pay_aws_test_account_id", "perf")
+    when (app.has_db) {
+      shared_resources.payECRResourceWithVariant("\(app.name)-db-ecr-registry-perf", "govukpay/\(app.name)", "pay_aws_test_account_id", "perf-db")
+    }
+  }
+  shared_resources_for_slack_notifications.slackNotificationResource
+}
+
+groups {
+  for (app in allPayApps) {
+    new {
+      name = app.name
+      jobs = new Listing {
+        when (app.override_app_to_deploy != null) {
+          when (app.override_app_to_deploy == "scheduled-tasks") {
+            "deploy-\(app.override_app_to_deploy)"
+          } else {
+            "deploy-\(app.override_app_to_deploy)-to-perf"
+          }
+        } else {
+          "deploy-\(app.name)-to-perf"
+        }
+        when (app.has_db) {
+          "\(app.name)-db-migration-perf"
+        }
+      }
+    }
+  }
+}
+
+jobs {
+  pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/deploy-to-perf.pkl")
+  for (app in allPayApps) {
+    when (app.override_app_to_deploy == null) {
+      new {
+        name = "deploy-\(app.name)-to-perf"
+        serial = true
+        plan {
+          new InParallelStep { in_parallel = getResourcesToDeployApp(app) }
+          new InParallelStep { in_parallel = parseReleaseTagsToDeployApp(app) }
+          new InParallelStep { in_parallel = loadVariablesToDeployApp(app) }
+          new PutStep {
+            put = "slack-notification"
+            params = new Mapping {
+              ["channel"] = "#govuk-pay-activity"
+              ["text"] = ":rocket: Starting \(app.name) deployment to perf - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+              ["icon_emoji"] = ":fargate:"
+              ["username"] = "pay-concourse"
+            }
+          }
+          assumeRole("terraform-test-assume-role")
+          (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
+          deployToPerf(app)
+          waitForDeploy(app)
+        }
+        on_success = sendSlackNoticationAndPutMetrics(app, true)
+        on_failure = sendSlackNoticationAndPutMetrics(app, false)
+      }
+    }
+  }
+  for (app in payApplicationsWithDB) {
+    new {
+      name = "\(app.name)-db-migration-perf"
+      plan {
+        new InParallelStep { in_parallel = getResourcesAndAssumeRoleToRunDbMigrations(app) }
+        new InParallelStep {
+          in_parallel = new Listing {
+            (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
+            loadVar("application_image_tag", "publicauth-db-ecr-registry-perf/tag")
+          }
+        }
+        startDatabase(app)
+        shared_resources_for_slack_notifications.paySlackNotificationForDBMigration("#govuk-pay-activity", "test-perf-1")
+        runDBMigrations(app)
+      }
+      on_success = shared_resources_for_slack_notifications.paySlackNotificationForDBMigrationStatus("#govuk-pay-activity", true, "test-perf-1")
+      on_failure = shared_resources_for_slack_notifications.paySlackNotificationForDBMigrationStatus("#govuk-pay-announce", false, "test-perf-1")
+      ensure = stopDatabase(app)
+    }
+  }
+  new {
+    name = "deploy-scheduled-tasks"
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          getStep("alpine-ecr-registry-perf", true)
+          getStep("stream-s3-sqs-ecr-registry-perf", true)
+          getStep("pay-ci", false)
+          getStep("pay-infra", false)
+        }
+      }
+      new InParallelStep {
+        in_parallel = new Listing {
+          loadVar("alpine_image_tag", "alpine-ecr-registry-perf/tag")
+          loadVar("stream_s3_sqs_image_tag", "stream-s3-sqs-ecr-registry-perf/tag")
+          assumeRole("terraform-test-assume-role")
+        }
+      }
+      (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
+      deployToPerf(new PayApp { name = "scheduled-tasks"; use_app_specific_deploy_task = true })
+    }
+    on_failure = shared_resources_for_slack_notifications.paySlackNotificationForFail("#govuk-pay-announce", "Scheduled tasks failed to deploy alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag))")
+    on_success = shared_resources_for_slack_notifications.paySlackNotificationForSuccess("#govuk-pay-activity", "Scheduled tasks deployed alpine image ((.:alpine_image_tag)) and stream-s3-sqs image ((.:stream_s3_sqs_image_tag)) successfully")
+  }
+}
+
+local function getResourcesToDeployApp(app: PayApp): Listing<Step> = new Listing<Step> {
+  getStep("\(app.name)-ecr-registry-perf", true)
+
+  when (app.has_db) {
+    getStep("\(app.name)-db-ecr-registry-perf", true)
+  }
+
+  when (app.name == "frontend") {
+    getStep("nginx-forward-proxy-ecr-registry-perf", true)
+  }
+
+  when (!app.is_a_helper_or_sidecar_app) {
+    getStep("nginx-proxy-ecr-registry-perf", true)
+    getStep("adot-ecr-registry-perf", true)
+  }
+
+  getStep("pay-infra", false)
+  getStep("pay-ci", false)
+}
+
+local function loadVariablesToDeployApp(app: PayApp): Listing<Step> = new Listing<Step> {
+  loadVar("app_name", "ecr-release-info/app_name")
+  loadVar("app_release_number", "ecr-release-info/release-number")
+  loadVar("application_image_tag", "\(app.name)-ecr-registry-perf/tag")
+
+  when (app.is_a_helper_or_sidecar_app == false) {
+    loadVar("adot_image_tag", "adot-ecr-registry-perf/tag")
+    loadVar("adot_release_number", "adot-release-info/release-number")
+    loadVar("nginx_image_tag", "nginx-proxy-ecr-registry-perf/tag")
+    loadVar("nginx_release_number", "nginx-release-info/release-number")
+  }
+
+  when (app.name == "frontend") {
+    loadVar("nginx_forward_proxy_release_number", "nginx-forward-proxy-release-info/release-number")
+  }
+}
+
+local function parseReleaseTag(appName: String, includeOutputMapping: Boolean) = new TaskStep {
+  task = "parse-\(appName)-ecr-release-tag"
+  file = "pay-ci/ci/tasks/parse-ecr-release-tag.yml"
+  input_mapping = new {
+    ["ecr-image"] = "\(appName)-ecr-registry-perf"
+  }
+  when (includeOutputMapping) {
+    output_mapping = new {
+      ["ecr-release-info"] = "\(appName)-release-info"
+    }
+  }
+}
+
+local function parseReleaseTagsToDeployApp(app: PayApp): Listing<Step> = new Listing<Step> {
+  parseReleaseTag(app.name, false)
+
+  when (app.is_a_helper_or_sidecar_app == false) {
+    parseReleaseTag("adot", true)
+    parseReleaseTag("nginx", true)
+  }
+
+  when (app.name == "frontend") {
+    parseReleaseTag("nginx-forward-proxy", true)
+  }
+}
+
+local function deployToPerf(app: PayApp) = new TaskStep {
+  task = "deploy-to-perf"
+
+  when (app.use_app_specific_deploy_task) {
+    when (app.name == "frontend") {
+      file = "pay-ci/ci/tasks/deploy-\(app.name)-with-adot.yml"
+    } else {
+      file = "pay-ci/ci/tasks/deploy-\(app.name).yml"
+    }
+  } else {
+    file = "pay-ci/ci/tasks/deploy-app-with-adot.yml"
+  }
+
+  params {
+    ["APP_NAME"] = app.name
+    when (app.name == "scheduled-tasks") {
+      ["ALPINE_IMAGE_TAG"] = "((.:alpine_image_tag))"
+      ["STREAM_S3_SQS_IMAGE_TAG"] = "((.:stream_s3_sqs_image_tag))"
+    } else {
+      ["APPLICATION_IMAGE_TAG"] = "((.:application_image_tag))"
+    }
+    ["ACCOUNT"] = "test"
+    ["ENVIRONMENT"] = "test-perf-1"
+    when (app.name == "frontend") {
+      ["NGINX_FORWARD_PROXY_IMAGE_TAG"] = "((.:nginx_forward_proxy_image_tag))"
+    }
+    when (app.is_a_helper_or_sidecar_app == false && app.name != "scheduled-tasks") {
+      ["NGINX_IMAGE_TAG"] = "((.:nginx_image_tag))"
+      ["ADOT_IMAGE_TAG"] = "((.:adot_image_tag))"
+    }
+    ...getAWSAssumeRoleCreds()
+  }
+
+  when (app.name == "notifications") {
+    config = getAdditionalConfigForNotifications(app)
+  }
+}
+
+local function waitForDeploy(app: PayApp) = new TaskStep {
+  task = "wait-for-deploy"
+  file = "pay-ci/ci/tasks/wait-for-deploy.yml"
+  params {
+    ["APP_NAME"] = app.name
+    ["APPLICATION_IMAGE_TAG"] = "((.:application_image_tag))"
+    ["ENVIRONMENT"] = "test-perf-1"
+    when (app.is_a_helper_or_sidecar_app == false) {
+      ["NGINX_IMAGE_TAG"] = "((.:nginx_image_tag))"
+      ["ADOT_IMAGE_TAG"] = "((.:adot_image_tag))"
+    }
+    when (app.name == "frontend") {
+      ["NGINX_FORWARD_PROXY_IMAGE_TAG"] = "((.:nginx_forward_proxy_image_tag))"
+    }
+    ...getAWSAssumeRoleCreds()
+  }
+}
+
+local function startDatabase(app: PayApp) = new TaskStep {
+  task = "start-\(app.name)-db"
+  file = "pay-ci/ci/tasks/start-rds-instance.yml"
+  params {
+    ["RDS_INSTANCE_NAME"] = "test-perf-1-\(app.name)-rds-\(app.rds_identifier_suffix)"
+    ...getAWSAssumeRoleCreds()
+  }
+}
+
+local function stopDatabase(app: PayApp) = new TaskStep {
+  task = "stop-\(app.name)-db"
+  file = "pay-ci/ci/tasks/stop-rds-instance.yml"
+  params {
+    ["RDS_INSTANCE_NAME"] = "test-perf-1-\(app.name)-rds-\(app.rds_identifier_suffix)"
+    ...getAWSAssumeRoleCreds()
+  }
+}
+
+local function runDBMigrations(app: PayApp) = new TaskStep {
+  task = "run-db-migration"
+  config {
+    platform = "linux"
+    image_resource {
+      type = "registry-image"
+      source {
+        ["repository"] = "governmentdigitalservice/pay-node-runner"
+        ["tag"] = "node16"
+      }
+    }
+    inputs = new Listing<TaskConfig.Input> {
+      new TaskConfig.Input { name = "pay-ci" }
+    }
+    params = new {
+      ...getAWSAssumeRoleCreds()
+      ["AWS_PAGER"] = ""
+      ["AWS_REGION"] = "eu-west-1"
+      ["CLUSTER_NAME"] = "test-perf-1-fargate"
+      ["APP_NAME"] = app.name
+      ["APPLICATION_IMAGE_TAG"] = "((.:application_image_tag))"
+    }
+    run {
+      path = "node"
+      args {
+        "pay-ci/ci/scripts/run-ecs-db-migration.js"
+      }
+    }
+  }
+}
+
+local function sendSlackNoticationAndPutMetrics(app: PayApp, isASuccess: Boolean) = new InParallelStep {
+  in_parallel = new InParallelConfig {
+    steps = new Listing<Step> {
+      when (isASuccess == true) {
+        shared_resources_for_slack_notifications.paySlackNotificationForAppDeployment("#govuk-pay-activity", true, "Deployment of ((.:app_name)) to perf success")
+      }
+      else {
+        shared_resources_for_slack_notifications.paySlackNotificationForAppDeployment("#govuk-pay-announce", false, "Deployment of ((.:app_name)) to perf failed")
+      }
+      shared_resources_for_metrics.paySendAppReleaseMetric(isASuccess, "test-perf-1")
+      when (app.is_a_helper_or_sidecar_app == false) {
+        shared_resources_for_metrics.paySendNginxReleaseMetric(isASuccess, "test-perf-1")
+        shared_resources_for_metrics.paySendAdotReleaseMetric(isASuccess, "test-perf-1")
+      }
+      when (app.name == "frontend") {
+        shared_resources_for_metrics.paySendNginxForwardProxyReleaseMetric(isASuccess, "test-perf-1")
+      }
+    }
+  }
+}
+
+local function getResourcesAndAssumeRoleToRunDbMigrations(app: PayApp): Listing<Step> = new Listing<Step> {
+  getStep("pay-ci", false)
+  (getStep("\(app.name)-db-ecr-registry-perf", true)) {
+    passed = new Listing<Identifier> {
+      "deploy-\(app.name)-to-perf"
+    }
+    params {
+      ["format"] = "oci"
+    }
+  }
+  assumeRole("db-migration-perf-test-assume-role")
+}
+
+local function assumeRole(awsRoleSessionName: String) = new TaskStep {
+  task = "assume-role"
+  file = "pay-ci/ci/tasks/assume-role.yml"
+  params {
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/concourse"
+    ["AWS_ROLE_SESSION_NAME"] = awsRoleSessionName
+  }
+}
+
+local function getAdditionalConfigForNotifications(app: PayApp) = new TaskConfig {
+  platform = "linux"
+  inputs {
+    new TaskConfig.Input { name = "pay-infra" }
+  }
+  image_resource {
+    type = "registry-image"
+    source {
+      ["repository"] = "hashicorp/terraform"
+      ["tag"] = "1.3.7"
+    }
+  }
+  run = new TaskConfig.Run {
+    path = "/bin/bash"
+    args {
+      "pay-ci/ci/scripts/deploy-notifications"
+    }
+  }
+}
+
+local function getAWSAssumeRoleCreds() = new Mapping<String, String> {
+  ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+  ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+  ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+}
+
+local function loadVar(variable: String, fileName: String): LoadVarStep = new LoadVarStep {
+  load_var = variable
+  file = fileName
+}
+
+local function getStep(name: String, shouldTrigger: Boolean): GetStep = new GetStep {
+  get = name
+  when (shouldTrigger == true) {
+    trigger = shouldTrigger
+  }
+}

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -10,47 +10,45 @@ import "../common/shared_resources_for_slack_notifications.pkl"
 local class PayApp {
   name: String
   has_db: Boolean = false
-  is_a_helper_or_sidecar_app: Boolean = false
+  include_nginx_and_adot_sidecar: Boolean = true
   override_app_to_deploy: String?
   override_ecr_repo: String?
-  rds_identifier_suffix: Int? = 0
+  rds_identifier_suffix: Int = 0
   use_app_specific_deploy_task: Boolean = false
 }
 
-local payApplicationsWithDB: Listing<PayApp> = new {
+local payApps: Listing<PayApp> = new Listing<PayApp> {
   new { name = "adminusers"; has_db = true }
-  new { name = "connector"; has_db = true }
-  new { name = "ledger"; has_db = true }
-  new { name = "products"; has_db = true }
-  new { name = "publicauth"; has_db = true;  rds_identifier_suffix = 1 }
-  new { name = "webhooks"; has_db = true }
-}
-
-local payApplicationsWithOutDB: Listing<PayApp> = new {
   new { name = "cardid" }
+  new { name = "connector"; has_db = true }
+  new { name = "egress"; include_nginx_and_adot_sidecar = false; use_app_specific_deploy_task = true }
   new { name = "frontend"; use_app_specific_deploy_task = true }
+  new { name = "ledger"; has_db = true }
+  new { name = "notifications"; include_nginx_and_adot_sidecar = false }
+  new { name = "products"; has_db = true }
   new { name = "products-ui" }
   new { name = "publicapi" }
+  new { name = "publicauth"; has_db = true;  rds_identifier_suffix = 1 }
   new { name = "selfservice" }
   new { name = "toolbox" }
-}
+  new { name = "webhooks"; has_db = true }
+  new { name = "webhooks-egress"; include_nginx_and_adot_sidecar = false; use_app_specific_deploy_task = true }
+}.toList().sortBy((app) -> app.name).toListing()
 
 // sidecars or other helpers
-local payHelpers: Listing<PayApp> = new {
-  new { name = "alpine"; override_app_to_deploy = "scheduled-tasks"; is_a_helper_or_sidecar_app = true }
-  new { name = "egress"; is_a_helper_or_sidecar_app = true; use_app_specific_deploy_task = true }
-  new { name = "nginx-forward-proxy"; override_app_to_deploy = "frontend"; is_a_helper_or_sidecar_app = true }
-  new { name = "nginx-proxy"; override_ecr_repo = "docker-nginx-proxy"; override_app_to_deploy = "toolbox"; is_a_helper_or_sidecar_app = true }
-  new { name = "notifications"; is_a_helper_or_sidecar_app = true }
-  new { name = "stream-s3-sqs"; override_app_to_deploy = "scheduled-tasks";  is_a_helper_or_sidecar_app = true }
-  new { name = "webhooks-egress"; is_a_helper_or_sidecar_app = true; use_app_specific_deploy_task = true }
-}
+local payHelpers: Listing<PayApp> = new Listing<PayApp> {
+  new { name = "alpine"; override_app_to_deploy = "scheduled-tasks"; include_nginx_and_adot_sidecar = false }
+  new { name = "nginx-forward-proxy"; override_app_to_deploy = "frontend"; include_nginx_and_adot_sidecar = false }
+  new { name = "nginx-proxy"; override_ecr_repo = "docker-nginx-proxy"; override_app_to_deploy = "toolbox"; include_nginx_and_adot_sidecar = false }
+  new { name = "stream-s3-sqs"; override_app_to_deploy = "scheduled-tasks";  include_nginx_and_adot_sidecar = false }
+}.toList().sortBy((app) -> app.name).toListing()
 
 local allPayApps: Listing<PayApp> = new {
-  ...payApplicationsWithDB
-  ...payApplicationsWithOutDB
+  ...payApps
   ...payHelpers
 }
+
+local payApplicationsWithDB = payApps.toList().filter((app) -> app.has_db).toListing()
 
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
@@ -185,7 +183,7 @@ local function getResourcesToDeployApp(app: PayApp): Listing<Step> = new Listing
     getStep("nginx-forward-proxy-ecr-registry-perf", true)
   }
 
-  when (!app.is_a_helper_or_sidecar_app) {
+  when (app.include_nginx_and_adot_sidecar) {
     getStep("nginx-proxy-ecr-registry-perf", true)
     getStep("adot-ecr-registry-perf", true)
   }
@@ -199,7 +197,7 @@ local function loadVariablesToDeployApp(app: PayApp): Listing<Step> = new Listin
   loadVar("app_release_number", "ecr-release-info/release-number")
   loadVar("application_image_tag", "\(app.name)-ecr-registry-perf/tag")
 
-  when (app.is_a_helper_or_sidecar_app == false) {
+  when (app.include_nginx_and_adot_sidecar == true) {
     loadVar("adot_image_tag", "adot-ecr-registry-perf/tag")
     loadVar("adot_release_number", "adot-release-info/release-number")
     loadVar("nginx_image_tag", "nginx-proxy-ecr-registry-perf/tag")
@@ -218,8 +216,9 @@ local function parseReleaseTag(appName: String, includeOutputMapping: Boolean) =
     ["ecr-image"] = "\(appName)-ecr-registry-perf"
   }
   when (includeOutputMapping) {
+    local releaseInfoPrefix = if (appName == "nginx-proxy") "nginx" else appName
     output_mapping = new {
-      ["ecr-release-info"] = "\(appName)-release-info"
+      ["ecr-release-info"] = "\(releaseInfoPrefix)-release-info"
     }
   }
 }
@@ -227,9 +226,9 @@ local function parseReleaseTag(appName: String, includeOutputMapping: Boolean) =
 local function parseReleaseTagsToDeployApp(app: PayApp): Listing<Step> = new Listing<Step> {
   parseReleaseTag(app.name, false)
 
-  when (app.is_a_helper_or_sidecar_app == false) {
+  when (app.include_nginx_and_adot_sidecar == true) {
     parseReleaseTag("adot", true)
-    parseReleaseTag("nginx", true)
+    parseReleaseTag("nginx-proxy", true)
   }
 
   when (app.name == "frontend") {
@@ -263,7 +262,7 @@ local function deployToPerf(app: PayApp) = new TaskStep {
     when (app.name == "frontend") {
       ["NGINX_FORWARD_PROXY_IMAGE_TAG"] = "((.:nginx_forward_proxy_image_tag))"
     }
-    when (app.is_a_helper_or_sidecar_app == false && app.name != "scheduled-tasks") {
+    when (app.include_nginx_and_adot_sidecar == true) {
       ["NGINX_IMAGE_TAG"] = "((.:nginx_image_tag))"
       ["ADOT_IMAGE_TAG"] = "((.:adot_image_tag))"
     }
@@ -282,7 +281,7 @@ local function waitForDeploy(app: PayApp) = new TaskStep {
     ["APP_NAME"] = app.name
     ["APPLICATION_IMAGE_TAG"] = "((.:application_image_tag))"
     ["ENVIRONMENT"] = "test-perf-1"
-    when (app.is_a_helper_or_sidecar_app == false) {
+    when (app.include_nginx_and_adot_sidecar == true) {
       ["NGINX_IMAGE_TAG"] = "((.:nginx_image_tag))"
       ["ADOT_IMAGE_TAG"] = "((.:adot_image_tag))"
     }
@@ -352,7 +351,7 @@ local function sendSlackNoticationAndPutMetrics(app: PayApp, isASuccess: Boolean
         shared_resources_for_slack_notifications.paySlackNotificationForAppDeployment("#govuk-pay-announce", false, "Deployment of ((.:app_name)) to perf failed")
       }
       shared_resources_for_metrics.paySendAppReleaseMetric(isASuccess, "test-perf-1")
-      when (app.is_a_helper_or_sidecar_app == false) {
+      when (app.include_nginx_and_adot_sidecar == true) {
         shared_resources_for_metrics.paySendNginxReleaseMetric(isASuccess, "test-perf-1")
         shared_resources_for_metrics.paySendAdotReleaseMetric(isASuccess, "test-perf-1")
       }

--- a/ci/scripts/deploy-notifications.sh
+++ b/ci/scripts/deploy-notifications.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd pay-infra/provisioning/terraform/deployments/${ACCOUNT}/${ENVIRONMENT}/microservices_v2/notifications
+
+terraform init
+
+terraform apply \
+  -var notifications_image_tag=${APPLICATION_IMAGE_TAG} \
+  -auto-approve


### PR DESCRIPTION
## WHAT
- Added deploy-to-perf pkl module
- Some apps show additional changes for Slack notifications as `sending metrics` yaml is being added for apps not done yet
- `adot` is not added to list of apps as test-perf doesn't have `adot` group. Will add it separately 

Diff is in concourse due to size. Can use the terminal using below which shows diffs in color

`cd ci/pkl-pipelines/pay-dev`

`fly -t pay-dev set-pipeline -c ./deploy-to-perf.yml -p deploy-to-perf --dry-run | zmore`


![image](https://github.com/alphagov/pay-ci/assets/40598480/48d0ad95-830b-4b94-847c-c5c8eb387b99)
