### PR TITLE
PP-12386-convert-e2e-helpers-to-pkl

### DIFF
--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -120,7 +120,7 @@ jobs = new {
       }
 
       shared_resources.generateDockerCredsConfigStep
-      shared_resources.parseReleaseTag("endtoend-git-release")
+      parseReleaseTag("endtoend-git-release")
       new LoadVarStep { load_var = "release_number_tag" file = "tags/release-number" }
 
       new InParallelStep {  // One step in parallel, but that's what the original does
@@ -156,7 +156,7 @@ jobs = new {
         }
       }
 
-      shared_resources.parseCandidateTag("endtoend-candidate-ecr-registry-test")
+      parseCandidateTag("endtoend-candidate-ecr-registry-test")
 
       new LoadVarStep { 
         load_var = "candidate_number_tag" 
@@ -179,23 +179,19 @@ jobs = new {
         }
       }
 
-      shared_resources.prepareCodeBuild(
-        "endtoend", 
-        "prepare-e2e-codebuild.yml", 
-        "((.:candidate_image_tag))"
-      )
+      prepareCodeBuild("endtoend", "prepare-e2e-codebuild.yml", "((.:candidate_image_tag))")
 
       new InParallelStep {
         in_parallel = new Listing {
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
             3
           )
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
             1
           )
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json",
             1
           )
@@ -239,7 +235,7 @@ jobs = new {
         }
       }
 
-      shared_resources.parseReleaseTag("reverse-proxy-git-release")
+      parseReleaseTag("reverse-proxy-git-release")
 
       new InParallelStep {
         in_parallel = new Listing<Step> {
@@ -253,10 +249,10 @@ jobs = new {
       }
 
       new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
-      shared_resources.prepareCodeBuildMultiarch("reverse-proxy")
+      prepareCodeBuildMultiarch("reverse-proxy")
       shared_resources.generateDockerCredsConfigStep
-      shared_resources.runCodeBuildMultiarch("reverse-proxy", 3)
-      shared_resources.runCodeBuild(
+      runCodeBuildMultiarch("reverse-proxy", 3)
+      runCodeBuild(
         "run-codebuild-reverse-proxy-manifest",
         "../../../../run-codebuild-configuration/reverse-proxy-manifest.json",
         3
@@ -286,7 +282,7 @@ jobs = new {
         }
       }
 
-      shared_resources.parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
+      parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
 
       new LoadVarStep { 
         load_var = "candidate_number_tag"
@@ -309,7 +305,7 @@ jobs = new {
         }
       }
 
-      shared_resources.prepareCodeBuild(
+      prepareCodeBuild(
         "reverse-proxy", 
         "prepare-e2e-codebuild.yml", 
         "((.:candidate_image_tag))"
@@ -317,15 +313,15 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
             3
           )
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
             1
           )
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json",
             1
           )
@@ -335,7 +331,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_resources.generateDockerCredsConfigStep
-          shared_resources.parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
+          parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
           assumeCodeBuildRole("executor", "e2e-test-assume-role")
           assumeRetagRole
          }
@@ -394,7 +390,7 @@ jobs = new {
         }
       }
 
-      shared_resources.parseReleaseTag("stubs-git-release")
+      parseReleaseTag("stubs-git-release")
 
       new InParallelStep {
         in_parallel = new Listing<Step> {
@@ -406,9 +402,9 @@ jobs = new {
         }
       }
 
-      shared_resources.prepareCodeBuildMultiarch("stubs")
-      shared_resources.runCodeBuildMultiarch("stubs", 1)
-      shared_resources.runCodeBuild(
+      prepareCodeBuildMultiarch("stubs")
+      runCodeBuildMultiarch("stubs", 1)
+      runCodeBuild(
         "run-codebuild-stubs-manifest",
         "../../../../run-codebuild-configuration/stubs-manifest.json",
         1
@@ -441,7 +437,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_resources.generateDockerCredsConfigStep
-          shared_resources.parseCandidateTag("stubs-candidate-ecr-registry-test")
+          parseCandidateTag("stubs-candidate-ecr-registry-test")
           assumeCodeBuildRole("executor", "e2e-test-assume-role")
           assumeRetagRole
           assumeWriteToDeployRole
@@ -480,19 +476,15 @@ jobs = new {
         }
       }
 
-      shared_resources.prepareCodeBuild(
-        "stubs", 
-        "prepare-e2e-codebuild.yml", 
-        "((.:candidate_image_tag))"
-      )
+      prepareCodeBuild("stubs", "prepare-e2e-codebuild.yml", "((.:candidate_image_tag))")
 
       new InParallelStep {
         in_parallel = new Listing {
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
             3
           )
-          shared_resources.runCodeBuild(
+          runCodeBuild(
             "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
             1
           )
@@ -683,4 +675,76 @@ local function copyImageToEcr(image: String, displayName: String): Job = new {
     "#govuk-pay-activity",
     "Copied \(displayName) image from Docker Hub to ECR"
   )
+}
+
+local function parseReleaseTag(gitRelease: String): TaskStep = new {
+  task = "parse-release-tag"
+  file = "pay-ci/ci/tasks/parse-release-tag.yml"
+  input_mapping {
+    ["git-release"] = gitRelease
+  }
+}
+
+local function parseCandidateTag(ecrRepo: String): TaskStep = new {
+  task = "parse-candidate-tag"
+  file = "pay-ci/ci/tasks/parse-candidate-tag.yml"
+  input_mapping {
+    ["ecr-repo"] = ecrRepo
+  }
+}
+
+local function prepareCodeBuild(project: String, taskFile: String, tag: String): TaskStep = new {
+  task = "prepare-codebuild"
+  file = "pay-ci/ci/tasks/\(taskFile)"
+  params = new {
+    ["PROJECT_UNDER_TEST"] = project
+    ["RELEASE_TAG_UNDER_TEST"] = tag
+    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+  }
+}
+
+local function prepareCodeBuildMultiarch(project: String): TaskStep = new {
+  task = "prepare-codebuild"
+  file = "pay-ci/ci/tasks/prepare-codebuild-multiarch.yml"
+  params = new {
+    ["PROJECT_TO_BUILD"] = project
+    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+    ["RELEASE_NUMBER"] = "((.:release-number))"
+    ["RELEASE_NAME"] = "((.:release-name))"
+    ["RELEASE_SHA"] = "((.:release-sha))"
+    ["BUILD_DATE"] = "((.:date))"
+  }
+}
+
+local function runCodeBuild(taskName: String, pathToConfig: String, attemptCount: Int): TaskStep = new {
+  task = taskName
+  file = "pay-ci/ci/tasks/run-codebuild.yml"
+  when (attemptCount != 1) {
+    attempts = attemptCount
+  }
+  params = new {
+    ["PATH_TO_CONFIG"] = pathToConfig
+    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+  }
+}
+
+local function runCodeBuildMultiarch(project: String, attempts: Int): InParallelStep= new {
+  in_parallel = new Listing {
+    runCodeBuild(
+      "run-codebuild-\(project)-amd64",
+      "../../../../run-codebuild-configuration/\(project)-amd64.json",
+      attempts
+    )
+    runCodeBuild(
+      "run-codebuild-\(project)-armv8",
+      "../../../../run-codebuild-configuration/\(project)-armv8.json",
+      attempts
+    )
+  }
 }

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -6,98 +6,65 @@ import "../common/shared_resources.pkl"
 
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
-
   shared_resources.payCiGitHubResource
 
   (shared_resources.payGithubResourceWithBranch("e2e-helpers-pipeline", "pay-ci", "master")) {
     source { ["paths"] = new Listing<String> { "ci/pipelines/e2e-helpers.yml" } }
   }
 
-  (shared_resources.payGithubResourceWithBranch("endtoend-git-release", "pay-endtoend", "master")) {
-    source { ["tag_regex"] = "alpha_release-(.*)" }
-  }
+  shared_resources.payGithubResourceWithBranch("endtoend-git-release", "pay-endtoend", "master")
+    |>withTagRegex("alpha_release-(.*)")
+  
+  shared_resources.payGithubResourceWithBranch("stubs-git-release", "pay-stubs", "master") 
+    |>withTagRegex("alpha_release-(.*)")
 
-  (shared_resources.payGithubResourceWithBranch("stubs-git-release", "pay-stubs", "master")) {
-    source { ["tag_regex"] = "alpha_release-(.*)" }
-  }
+  shared_resources.payGithubResourceWithBranch("reverse-proxy-git-release", "pay-scripts", "master")
+    |>withTagRegex("reverse_proxy_alpha_release-(.*)")
 
-  (shared_resources.payGithubResourceWithBranch(
-    "reverse-proxy-git-release", "pay-scripts", "master")
-  ) {
-    source { ["tag_regex"] = "reverse_proxy_alpha_release-(.*)" }
-  }
+  shared_resources.payECRResource(
+    "endtoend-ecr-registry-test", "govukpay/endtoend", "pay_aws_test_account_id"
+  ) |>withTag("latest")
 
-  (shared_resources.payECRResource(
-    "endtoend-ecr-registry-test", "govukpay/endtoend", "pay_aws_test_account_id")
-  ) {
-    source { ["tag"] = "latest" }
-  }
+  shared_resources.payECRResourceWithVariant(
+    "endtoend-candidate-ecr-registry-test", "govukpay/endtoend", "pay_aws_test_account_id", "candidate"
+  )
 
-  (shared_resources.payECRResourceWithVariant(
-    "endtoend-candidate-ecr-registry-test",
-    "govukpay/endtoend",
-    "pay_aws_test_account_id",
-    "candidate"))
-
-  (shared_resources.payECRResourceWithVariant(
+  shared_resources.payECRResourceWithVariant(
     "reverse-proxy-candidate-ecr-registry-test",
     "govukpay/reverse-proxy",
     "pay_aws_test_account_id",
-    "candidate"))
+    "candidate")
 
-  (shared_resources.payECRResourceWithVariant(
+  shared_resources.payECRResourceWithVariant(
     "stubs-candidate-ecr-registry-test",
     "govukpay/stubs",
     "pay_aws_test_account_id",
-    "candidate"))
+    "candidate")
 
   shared_resources.payDockerHubResource(
-    "endtoend-dockerhub", 
-    "governmentdigitalservice/pay-endtoend", 
-    "latest-master")
+    "endtoend-dockerhub", "governmentdigitalservice/pay-endtoend", "latest-master"
+  )
 
-  (shared_resources.payDockerHubResource("postgres-15-alpine", "postgres", "15-alpine")) {
-    check_every = "1h" 
-  }
+  shared_resources.payDockerHubResource("postgres-15-alpine", "postgres", "15-alpine") 
+    |>withCheckInterval("1h")
 
-  (shared_resources.payECRResource(
-    "ecr-postgres-15-alpine", "postgres", "pay_aws_test_account_id")
-  ) {
-    check_every = "never"
-    source { ["tag"] = "15-alpine" }
-  }
+  shared_resources.payECRResource("ecr-postgres-15-alpine", "postgres", "pay_aws_test_account_id")
+    |>withTag("15-alpine") |>withCheckInterval("never")
 
-  (shared_resources.payDockerHubResource(
-    "localstack-localstack-3", 
-    "localstack/localstack", "3")
-  ) {
-    check_every = "1h"
-  }
+  shared_resources.payDockerHubResource("localstack-localstack-3", "localstack/localstack", "3")
+    |>withCheckInterval("1h")
 
-  (shared_resources.payECRResource(
-    "ecr-localstack-localstack-3", 
-    "localstack/localstack", 
-    "pay_aws_test_account_id")
-  ) {
-    check_every = "never"
-    source { ["tag"] = "3" }
-  }
+  shared_resources.payECRResource(
+    "ecr-localstack-localstack-3", "localstack/localstack", "pay_aws_test_account_id"
+  ) |>withTag("3") |>withCheckInterval("never")
 
-  (shared_resources.payDockerHubResource(
-    "selenium-standalone-chrome-3-141-59",
-    "selenium/standalone-chrome",
-     "3.141.59")) {
-    check_every = "1h"
-  }
+  shared_resources.payDockerHubResource(
+    "selenium-standalone-chrome-3-141-59", "selenium/standalone-chrome", "3.141.59"
+  ) |>withCheckInterval("1h")
 
-  (shared_resources.payECRResource(
-    "ecr-selenium-standalone-chrome-3-141-59",
-    "selenium/standalone-chrome",
-    "pay_aws_test_account_id")
-  ) {
-    check_every = "never"
-    source { ["tag"] = "3.141.59" }
-  }
+  shared_resources.payECRResource(
+    "ecr-selenium-standalone-chrome-3-141-59", "selenium/standalone-chrome", "pay_aws_test_account_id"
+  ) |>withTag("3.141.59") |>withCheckInterval("never")
 
   shared_resources.slackNotificationResource
 }
@@ -114,21 +81,15 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new GetStep { get = "endtoend-git-release" trigger = true }
-          new GetStep { get = "pay-ci" }
+          getStep("endtoend-git-release", true, false)
+          getPayCi
         }
       }
 
       shared_resources.generateDockerCredsConfigStep
       parseReleaseTag("endtoend-git-release")
-      new LoadVarStep { load_var = "release_number_tag" file = "tags/release-number" }
-
-      new InParallelStep {  // One step in parallel, but that's what the original does
-        in_parallel = new Listing<Step> {
-          buildImage("build-endtoend-image", "endtoend-git-release")
-        }
-      }
-
+      loadVar("release_number_tag", "tags/release-number")
+      buildImage("build-endtoend-image", "endtoend-git-release")
       putCandidateImage("endtoend-candidate-ecr-registry-test")
     }
     on_failure = shared_resources.paySlackNotificationForFail(
@@ -152,30 +113,18 @@ jobs = new {
             passed = new Listing { "build-and-push-endtoend-candidate" }
             params { ["format"] = "oci" }
           }
-          new GetStep { get = "pay-ci" }
+          getPayCi
         }
       }
 
       parseCandidateTag("endtoend-candidate-ecr-registry-test")
-
-      new LoadVarStep { 
-        load_var = "candidate_number_tag" 
-        file = "parse-candidate-tag/release-number" 
-      }
-
+      loadVar("candidate_number_tag", "parse-candidate-tag/release-number")
       assumeCodeBuildRole("executor", "e2e-test-assume-role")
 
       new InParallelStep {
         in_parallel = new Listing {
-          new LoadVarStep { 
-            load_var = "candidate_image_tag" 
-            file = "endtoend-candidate-ecr-registry-test/tag" 
-          }
-          new LoadVarStep { 
-            load_var = "role" 
-            file = "assume-role/assume-role.json"
-            format = "json"
-          }
+          loadVar("candidate_image_tag", "endtoend-candidate-ecr-registry-test/tag" )
+          loadAssumeRoleVar
         }
       }
 
@@ -221,8 +170,8 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new GetStep { get = "pay-ci" }
-          new GetStep { get = "reverse-proxy-git-release" trigger = true }
+          getPayCi
+          getStep("reverse-proxy-git-release", true, false)
         }
       }
 
@@ -230,16 +179,16 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new LoadVarStep { load_var = "release-number" file = "tags/release-number" }
-          new LoadVarStep { load_var = "release-name" file = "reverse-proxy-git-release/.git/ref" }
-          new LoadVarStep { load_var = "release-sha" file = "tags/release-sha" }
-          new LoadVarStep { load_var = "candidate-image-tag" file = "tags/candidate-tag" }
-          new LoadVarStep { load_var = "date" file = "tags/date" }
+          loadVar("release-number", "tags/release-number") 
+          loadVar("release-name", "reverse-proxy-git-release/.git/ref") 
+          loadVar("release-sha", "tags/release-sha") 
+          loadVar("candidate-image-tag", "tags/candidate-tag") 
+          loadVar("date", "tags/date") 
           assumeCodeBuildRole("builder", "codebuild-assume-role")
         }
       }
 
-      new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
+      loadAssumeRoleVar
       prepareCodeBuildMultiarch("reverse-proxy")
       shared_resources.generateDockerCredsConfigStep
       runCodeBuildMultiarch("reverse-proxy", 3)
@@ -264,35 +213,19 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing {
-          new GetStep { 
-            get = "reverse-proxy-candidate-ecr-registry-test"
-            trigger = true
-            params { ["format"] = "oci" }
-          }
-          new GetStep { get = "pay-ci" }
+          getStep("reverse-proxy-candidate-ecr-registry-test", true, true)
+          getPayCi
         }
       }
 
       parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
-
-      new LoadVarStep { 
-        load_var = "candidate_number_tag"
-        file = "parse-candidate-tag/release-number" 
-      }
-
+      loadVar("candidate_number_tag", "parse-candidate-tag/release-number")
       assumeCodeBuildRole("executor", "e2e-test-assume-role")
 
       new InParallelStep {
         in_parallel = new Listing {
-          new LoadVarStep { 
-            load_var = "candidate_image_tag" 
-            file = "reverse-proxy-candidate-ecr-registry-test/tag" 
-          }
-          new LoadVarStep { 
-            load_var = "role" 
-            file = "assume-role/assume-role.json"
-            format = "json"
-          }
+          loadVar("candidate_image_tag", "reverse-proxy-candidate-ecr-registry-test/tag")
+          loadAssumeRoleVar
         }
       }
 
@@ -317,15 +250,8 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          new LoadVarStep { 
-            load_var = "retag-role" 
-            file = "assume-retag-role/assume-role.json" 
-            format = "json"
-          }
-          new LoadVarStep { 
-            load_var = "release_image_tag" 
-            file = "parse-candidate-tag/release-tag" 
-          }
+          loadVarJson("retag-role", "assume-retag-role/assume-role.json")
+          loadVar("release_image_tag", "parse-candidate-tag/release-tag")
         }
       }
 
@@ -356,8 +282,8 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new GetStep { get = "stubs-git-release" trigger = true } 
-          new GetStep { get = "pay-ci" }
+          getStep("stubs-git-release", true, false) 
+          getPayCi
         }
       }
 
@@ -372,11 +298,11 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new LoadVarStep { load_var = "release-number" file = "tags/release-number" }
-          new LoadVarStep { load_var = "release-name" file = "stubs-git-release/.git/ref" }
-          new LoadVarStep { load_var = "release-sha" file = "tags/release-sha" }
-          new LoadVarStep { load_var = "date" file = "tags/date" }
-          new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
+          loadVar("release-number", "tags/release-number")
+          loadVar("release-name", "stubs-git-release/.git/ref")
+          loadVar("release-sha", "tags/release-sha")
+          loadVar("date", "tags/date")
+          loadAssumeRoleVar
         }
       }
 
@@ -399,12 +325,8 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing {
-          new GetStep { 
-            get = "stubs-candidate-ecr-registry-test"
-            trigger = true
-            params { ["format"] = "oci" }
-          }
-          new GetStep { get = "pay-ci" }
+          getStep("stubs-candidate-ecr-registry-test", true, true)
+          getPayCi
         }
       }
 
@@ -420,33 +342,12 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          new LoadVarStep { 
-            load_var = "candidate_image_tag" 
-            file = "stubs-candidate-ecr-registry-test/tag" 
-          }
-          new LoadVarStep { 
-            load_var = "role" 
-            file = "assume-role/assume-role.json"
-            format = "json"
-          }
-          new LoadVarStep { 
-            load_var = "retag-role" 
-            file = "assume-retag-role/assume-role.json"
-            format = "json"
-          }
-          new LoadVarStep { 
-            load_var = "write-to-deploy-role" 
-            file = "assume-write-to-deploy-role/assume-role.json"
-            format = "json"
-          }
-          new LoadVarStep { 
-            load_var = "release_image_tag" 
-            file = "parse-candidate-tag/release-tag"
-          }
-          new LoadVarStep { 
-            load_var = "release_number" 
-            file = "parse-candidate-tag/release-number"
-          }
+          loadVar("candidate_image_tag", "stubs-candidate-ecr-registry-test/tag")
+          loadAssumeRoleVar
+          loadVarJson("retag-role", "assume-retag-role/assume-role.json")
+          loadVarJson("write-to-deploy-role", "assume-write-to-deploy-role/assume-role.json")
+          loadVar("release_image_tag", "parse-candidate-tag/release-tag")
+          loadVar("release_number", "parse-candidate-tag/release-number")
         }
       }
 
@@ -513,14 +414,8 @@ local function buildImage(taskName: String, context: String): TaskStep = new {
   }
 }
 
-local function putCandidateImage(putName: String): PutStep = new {
-  put = putName
-  params = new {
-    ["image"] = "image/image.tar"
-    ["additional_tags"] = "tags/candidate-tag"
-  }
-  get_params = new { ["skip_download"] = true }
-}
+local function putCandidateImage(putName: String): PutStep = 
+  putStep(putName, "image/image.tar", "tags/candidate-tag", true)
 
 local function assumeCodeBuildRole(codeBuildRole: String, sessionName: String): TaskStep = new {
   task = "assume-role"
@@ -596,46 +491,16 @@ local function copyMultiarchImageToAccount(repo: String): TaskStep = new {
   }
 }
 
-// COPIED FROM prometheus-pushgateway.pkl -- MOVE TO SHARED_RESOURCES?
-
-local function putStep(resourceName: String, imageName: String, additionalTags: String, skipDownload: Boolean): PutStep = new PutStep {
-  put = resourceName
-  params {
-    when (imageName.length > 0) {
-      ["image"] = imageName
-    }
-    when (additionalTags.length > 0) {
-      ["additional_tags"] = additionalTags
-    }
-  }
-  get_params {
-    when (skipDownload) {
-      ["skip_download"] = true
-    }
-  }
-}
-
 local function copyImageToEcr(image: String, displayName: String): Job = new {
   name = "copy-\(image)"
   plan {
-    new GetStep { 
-      get = image
-      trigger = true
-      params { ["format"] = "oci" }
-    }
-
-    new PutStep {
-      put = "ecr-\(image)"
-      params { ["image"] = "\(image)/image.tar" }
-      get_params { ["skip_download"] = true }
-    }
+    getStep(image, true, true)
+    putStep("ecr-\(image)", "\(image)/image.tar", "", true)
   }
-
   on_failure = shared_resources.paySlackNotificationForFail(
     "#govuk-pay-starling",
     "Failed copying \(displayName) image from Docker Hub to ECR"
   )
-
   on_success = shared_resources.paySlackNotificationForSuccess(
     "#govuk-pay-activity",
     "Copied \(displayName) image from Docker Hub to ECR"
@@ -705,3 +570,66 @@ local function runCodeBuildMultiarch(project: String, attempts: Int): InParallel
     runCodeBuild("run-codebuild-\(project)-armv8", "\(project)-armv8.json", attempts)
   }
 }
+
+local getPayCi = new GetStep { get = "pay-ci" }
+
+local loadAssumeRoleVar = new LoadVarStep { 
+  load_var = "role" 
+  file = "assume-role/assume-role.json" 
+  format = "json"
+}
+
+local function withTagRegex(tag: String) = new Mixin {
+  source { ["tag_regex"] = tag  }
+}
+
+local function withTag(tag: String) = new Mixin {
+  source { ["tag"] = tag  }
+}
+
+local function withCheckInterval(interval: String) = new Mixin {
+  check_every = interval
+}
+
+// FUNCTIONS BELOW HERE COPIED FROM prometheus-pushgateway.pkl -- MOVE TO SHARED_RESOURCES?
+
+local function loadVar(variable: String, fileName: String): LoadVarStep = new LoadVarStep {
+  load_var = variable
+  file = fileName
+}
+
+local function loadVarJson(variable: String, fileName: String): LoadVarStep = new LoadVarStep {
+  load_var = variable
+  file = fileName
+  format = "json"
+}
+
+local function getStep(resourceName: String, shouldTrigger: Boolean, isOci: Boolean): GetStep = new GetStep {
+  get = resourceName
+  when (shouldTrigger) {
+    trigger = true
+  }
+  when (isOci) {
+    params {
+      ["format"] = "oci"
+    }
+  }
+}
+
+local function putStep(resourceName: String, imageName: String, additionalTags: String, skipDownload: Boolean): PutStep = new PutStep {
+  put = resourceName
+  params {
+    when (imageName.length > 0) {
+      ["image"] = imageName
+    }
+    when (additionalTags.length > 0) {
+      ["additional_tags"] = additionalTags
+    }
+  }
+  get_params {
+    when (skipDownload) {
+      ["skip_download"] = true
+    }
+  }
+}
+

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -4,8 +4,6 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 
-local components = new Listing<String> { "endtoend" "reverse-proxy" "stubs" }
-
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
 
@@ -35,26 +33,23 @@ resources = new {
     source { ["tag"] = "latest" }
   }
 
-  for (component in components) {
-    (shared_resources.payECRResourceWithVariant(
-      "\(component)-candidate-ecr-registry-test", 
-      "govukpay/\(component)", 
-      "pay_aws_test_account_id", 
-      "candidate")) 
-  }
+  (shared_resources.payECRResourceWithVariant(
+    "endtoend-candidate-ecr-registry-test",
+    "govukpay/endtoend",
+    "pay_aws_test_account_id",
+    "candidate"))
 
+  (shared_resources.payECRResourceWithVariant(
+    "reverse-proxy-candidate-ecr-registry-test",
+    "govukpay/reverse-proxy",
+    "pay_aws_test_account_id",
+    "candidate"))
 
-  // (shared_resources.payECRResourceWithVariant(
-  //   "reverse-proxy-candidate-ecr-registry-test",
-  //   "govukpay/reverse-proxy",
-  //   "pay_aws_test_account_id", 
-  //   "candidate")) 
-
-  // (shared_resources.payECRResourceWithVariant(
-  //   "stubs-candidate-ecr-registry-test",
-  //   "govukpay/stubs",
-  //   "pay_aws_test_account_id", 
-  //   "candidate")) 
+  (shared_resources.payECRResourceWithVariant(
+    "stubs-candidate-ecr-registry-test",
+    "govukpay/stubs",
+    "pay_aws_test_account_id",
+    "candidate"))
 
   shared_resources.payDockerHubResource(
     "endtoend-dockerhub", 
@@ -227,7 +222,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing<Step> {
           new GetStep { get = "pay-ci" }
-          new GetStep { get = "reverse-proxy-git-release" trigger = true } //sub
+          new GetStep { get = "reverse-proxy-git-release" trigger = true }
         }
       }
 
@@ -301,11 +296,7 @@ jobs = new {
         }
       }
 
-      prepareCodeBuild(
-        "reverse-proxy", 
-        "prepare-e2e-codebuild.yml", 
-        "((.:candidate_image_tag))"
-      )
+      prepareCodeBuild("reverse-proxy", "prepare-e2e-codebuild.yml", "((.:candidate_image_tag))")
 
       new InParallelStep {
         in_parallel = new Listing {
@@ -381,9 +372,9 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new LoadVarStep { load_var = "release-number"; file = "tags/release-number" }
-          new LoadVarStep { load_var = "release-name"; file = "stubs-git-release/.git/ref" }
-          new LoadVarStep { load_var = "release-sha"; file = "tags/release-sha" }
+          new LoadVarStep { load_var = "release-number" file = "tags/release-number" }
+          new LoadVarStep { load_var = "release-name" file = "stubs-git-release/.git/ref" }
+          new LoadVarStep { load_var = "release-sha" file = "tags/release-sha" }
           new LoadVarStep { load_var = "date" file = "tags/date" }
           new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
         }
@@ -391,11 +382,7 @@ jobs = new {
 
       prepareCodeBuildMultiarch("stubs")
       runCodeBuildMultiarch("stubs", 1)
-      runCodeBuild(
-        "run-codebuild-stubs-manifest",
-        "stubs-manifest.json",
-        1
-      )
+      runCodeBuild("run-codebuild-stubs-manifest", "stubs-manifest.json", 1)
     }
     on_failure = shared_resources.paySlackNotificationForFail(
       "#govuk-pay-starling",
@@ -497,10 +484,7 @@ jobs = new {
 
   copyImageToEcr("postgres-15-alpine", "postgres:15-alpine")
   copyImageToEcr("localstack-localstack-3", "localstack/localstack:2.0")
-  copyImageToEcr(
-    "selenium-standalone-chrome-3-141-59",
-    "selenium/standalone-chrome:3-141-59"
-  )
+  copyImageToEcr("selenium-standalone-chrome-3-141-59", "selenium/standalone-chrome:3-141-59")
 }
 
 // THINGS BELOW HERE MAY BE USEFUL IN SHARED_RESOURCES

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -5,6 +5,8 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 
 resources = new {
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
+
   shared_resources.payCiGitHubResource
 
   (shared_resources.payGithubResourceWithBranch("e2e-helpers-pipeline", "pay-ci", "master")) {
@@ -49,7 +51,10 @@ resources = new {
     "pay_aws_test_account_id", 
     "candidate")) 
 
-  shared_resources.payDockerHubResource("endtoend-dockerhub", "govukpay/endtoend", "latest-master")
+  shared_resources.payDockerHubResource(
+    "endtoend-dockerhub", 
+    "governmentdigitalservice/pay-endtoend", 
+    "latest-master")
 
   (shared_resources.payDockerHubResource("postgres-15-alpine", "postgres", "15-alpine")) {
     check_every = "1h" 
@@ -62,12 +67,17 @@ resources = new {
     source { ["tag"] = "15-alpine" }
   }
 
-  (shared_resources.payDockerHubResource("localstack-localstack-3", "localstack/localstack", "3")) {
+  (shared_resources.payDockerHubResource(
+    "localstack-localstack-3", 
+    "localstack/localstack", "3")
+  ) {
     check_every = "1h"
   }
 
   (shared_resources.payECRResource(
-    "localstack-localstack-3", "localstack/localstack", "pay_aws_test_account_id")
+    "ecr-localstack-localstack-3", 
+    "localstack/localstack", 
+    "pay_aws_test_account_id")
   ) {
     check_every = "never"
     source { ["tag"] = "3" }
@@ -81,7 +91,7 @@ resources = new {
   }
 
   (shared_resources.payECRResource(
-    "selenium-standalone-chrome-3-141-59",
+    "ecr-selenium-standalone-chrome-3-141-59",
     "selenium/standalone-chrome",
     "pay_aws_test_account_id")
   ) {
@@ -90,8 +100,6 @@ resources = new {
   }
 
   shared_resources.slackNotificationResource
-
-  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
 }
 
 resource_types = new {
@@ -99,13 +107,15 @@ resource_types = new {
 }
 
 jobs = new {
+  pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/e2e-helpers.pkl")
+
   new {
     name = "build-and-push-endtoend-candidate"
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new GetStep { get = "pay-ci" }
           new GetStep { get = "endtoend-git-release" trigger = true }
+          new GetStep { get = "pay-ci" }
         }
       }
 
@@ -125,8 +135,8 @@ jobs = new {
       "#govuk-pay-starling",
       "Failed to build and push pay-endtoend candidate image"
     )
-    on_success = shared_resources.paySlackNotificationForFail(
-      "#govuk-pay-starling",
+    on_success = shared_resources.paySlackNotificationForSuccess(
+      "#govuk-pay-activity",
       "Built and pushed pay-endtoend candidate image"
     )
   }
@@ -136,19 +146,24 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing {
-          new GetStep { get = "pay-ci" }
           new GetStep { 
             get = "endtoend-candidate-ecr-registry-test"
             trigger = true
             passed = new Listing { "build-and-push-endtoend-candidate" }
             params { ["format"] = "oci" }
           }
+          new GetStep { get = "pay-ci" }
         }
       }
 
       shared_resources.parseCandidateTag("endtoend-candidate-ecr-registry-test")
-      new LoadVarStep { load_var = "candidate_number_tag" file = "tags/release-number" }
-      assumeCodeBuildRole("e2e-test-assume-role")
+
+      new LoadVarStep { 
+        load_var = "candidate_number_tag" 
+        file = "parse-candidate-tag/release-number" 
+      }
+
+      assumeCodeBuildRole("executor", "e2e-test-assume-role")
 
       new InParallelStep {
         in_parallel = new Listing {
@@ -173,13 +188,16 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_resources.runCodeBuild(
-            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json"
+            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
+            3
           )
           shared_resources.runCodeBuild(
-            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json"
+            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
+            1
           )
           shared_resources.runCodeBuild(
-            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json"
+            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json",
+            1
           )
         }
       }
@@ -205,14 +223,14 @@ jobs = new {
       "#govuk-pay-starling",
       "pay-endtoend failed post-merge e2e tests"
     )
-    on_success = shared_resources.paySlackNotificationForFail(
-      "#govuk-pay-starling",
+    on_success = shared_resources.paySlackNotificationForSuccess(
+      "#govuk-pay-activity",
       "pay-endtoend passed post-merge e2e tests and was pushed as a final release"
     )
   }
 
   new {
-    name = "build-and-push-reverse-proxy-candidate" // sub
+    name = "build-and-push-reverse-proxy-candidate"
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
@@ -221,34 +239,35 @@ jobs = new {
         }
       }
 
+      shared_resources.parseReleaseTag("reverse-proxy-git-release")
+
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new LoadVarStep { load_var = "release_number_tag" file = "tags/release-number" }
-          new LoadVarStep { load_var = "release-name" file = "tags/release-name" }
+          new LoadVarStep { load_var = "release-number" file = "tags/release-number" }
+          new LoadVarStep { load_var = "release-name" file = "reverse-proxy-git-release/.git/ref" }
           new LoadVarStep { load_var = "release-sha" file = "tags/release-sha" }
           new LoadVarStep { load_var = "candidate-image-tag" file = "tags/candidate-tag" }
           new LoadVarStep { load_var = "date" file = "tags/date" }
-          assumeCodeBuildRole("codebuild-assume-role")
+          assumeCodeBuildRole("builder", "codebuild-assume-role")
         }
       }
 
       new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
       shared_resources.prepareCodeBuildMultiarch("reverse-proxy")
       shared_resources.generateDockerCredsConfigStep
-      shared_resources.runCodeBuildMultiarch("reverse-proxy")
-
-      // TODO : abstract this away with the above. Can't work out how to do it right now.
+      shared_resources.runCodeBuildMultiarch("reverse-proxy", 3)
       shared_resources.runCodeBuild(
         "run-codebuild-reverse-proxy-manifest",
-        "../../../../run-codebuild-configuration/reverse-proxy-manifest.json"
+        "../../../../run-codebuild-configuration/reverse-proxy-manifest.json",
+        3
       )
     }
     on_failure = shared_resources.paySlackNotificationForFail(
       "#govuk-pay-starling",
       "Failed to build and push e2e helper reverse-proxy"
     )
-    on_success = shared_resources.paySlackNotificationForFail(
-      "#govuk-pay-starling",
+    on_success = shared_resources.paySlackNotificationForSuccess(
+      "#govuk-pay-activity",
       "Built and pushed e2e helper reverse-proxy"
     )
   }
@@ -258,24 +277,29 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing {
-          new GetStep { get = "pay-ci" }
           new GetStep { 
             get = "reverse-proxy-candidate-ecr-registry-test"
             trigger = true
             params { ["format"] = "oci" }
           }
+          new GetStep { get = "pay-ci" }
         }
       }
 
       shared_resources.parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
-      new LoadVarStep { load_var = "candidate_number_tag" file = "tags/release-number" }
-      assumeCodeBuildRole("e2e-test-assume-role")
+
+      new LoadVarStep { 
+        load_var = "candidate_number_tag"
+        file = "parse-candidate-tag/release-number" 
+      }
+
+      assumeCodeBuildRole("executor", "e2e-test-assume-role")
 
       new InParallelStep {
         in_parallel = new Listing {
           new LoadVarStep { 
             load_var = "candidate_image_tag" 
-            file = "endtoend-candidate-ecr-registry-test/tag" 
+            file = "reverse-proxy-candidate-ecr-registry-test/tag" 
           }
           new LoadVarStep { 
             load_var = "role" 
@@ -294,13 +318,16 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_resources.runCodeBuild(
-            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json"
+            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
+            3
           )
           shared_resources.runCodeBuild(
-            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json"
+            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
+            1
           )
           shared_resources.runCodeBuild(
-            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json"
+            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json",
+            1
           )
         }
       }
@@ -308,24 +335,30 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_resources.generateDockerCredsConfigStep
-
-          // TODO: remove. These are already done, but the original has it twice, so we will, for now.
           shared_resources.parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
-          assumeCodeBuildRole("e2e-test-assume-role")
+          assumeCodeBuildRole("executor", "e2e-test-assume-role")
+          assumeRetagRole
          }
       }
 
       new InParallelStep {
         in_parallel = new Listing {
-          new LoadVarStep { load_var = "retag-role" file = "assume-retag-role/assume-role.json" }
-          new LoadVarStep { load_var = "release_image_tag" file = "parse-candidate-tag/release-tag" }
+          new LoadVarStep { 
+            load_var = "retag-role" 
+            file = "assume-retag-role/assume-role.json" 
+            format = "json"
+          }
+          new LoadVarStep { 
+            load_var = "release_image_tag" 
+            file = "parse-candidate-tag/release-tag" 
+          }
         }
       }
 
       new InParallelStep {
         in_parallel = new Listing {
-          retagCandidateInEcr("reverse-proxy", "((.:candidate_image_tag))")
-          retagCandidateInEcr("reverse-proxy", "latest")
+          retagCandidateInEcr("reverse-proxy", "((.:release_image_tag))", "release")
+          retagCandidateInEcr("reverse-proxy", "latest", "latest")
           retagCandidateInDockerHub(
             "governmentdigitalservice/pay-reverse-proxy",
             "((.:candidate_image_tag))",
@@ -338,8 +371,8 @@ jobs = new {
       "#govuk-pay-starling",
       "e2e helper reverse-proxy failed post-merge e2e tests"
     )
-    on_success = shared_resources.paySlackNotificationForFail(
-      "#govuk-pay-starling",
+    on_success = shared_resources.paySlackNotificationForSuccess(
+      "#govuk-pay-activity",
       "e2e helper reverse-proxy passed post-merge e2e tests and was pushed as a final release"
     )
   }
@@ -349,40 +382,45 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new GetStep { get = "pay-ci" }
           new GetStep { get = "stubs-git-release" trigger = true } 
+          new GetStep { get = "pay-ci" }
         }
       }
 
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new LoadVarStep { load_var = "release_number_tag" file = "tags/release-number" }
-          new LoadVarStep { load_var = "release-name" file = "tags/release-name" }
-          new LoadVarStep { load_var = "release-sha" file = "tags/release-sha" }
-          new LoadVarStep { load_var = "candidate-image-tag" file = "tags/candidate-tag" }
-          new LoadVarStep { load_var = "date" file = "tags/date" }
-          assumeCodeBuildRole("codebuild-assume-role")
+          shared_resources.generateDockerCredsConfigStep
+          assumeCodeBuildRole("builder", "codebuild-assume-role")
         }
       }
 
-      new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
-      shared_resources.prepareCodeBuildMultiarch("stubs")
-      shared_resources.generateDockerCredsConfigStep
-      shared_resources.runCodeBuildMultiarch("stubs")
+      shared_resources.parseReleaseTag("stubs-git-release")
 
-      // TODO : abstract this away with the above. Can't work out how to do it right now.
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new LoadVarStep { load_var = "release-number"; file = "tags/release-number" }
+          new LoadVarStep { load_var = "release-name"; file = "stubs-git-release/.git/ref" }
+          new LoadVarStep { load_var = "release-sha"; file = "tags/release-sha" }
+          new LoadVarStep { load_var = "date" file = "tags/date" }
+          new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
+        }
+      }
+
+      shared_resources.prepareCodeBuildMultiarch("stubs")
+      shared_resources.runCodeBuildMultiarch("stubs", 1)
       shared_resources.runCodeBuild(
         "run-codebuild-stubs-manifest",
-        "../../../../run-codebuild-configuration/stubs-manifest.json"
+        "../../../../run-codebuild-configuration/stubs-manifest.json",
+        1
       )
     }
     on_failure = shared_resources.paySlackNotificationForFail(
       "#govuk-pay-starling",
-      "Failed to build and push e2e helper stubs"
+      "Failed to build and push pay-stubs candidate image"
     )
-    on_success = shared_resources.paySlackNotificationForFail(
-      "#govuk-pay-starling",
-      "Built and pushed e2e helper stubs"
+    on_success = shared_resources.paySlackNotificationForSuccess(
+      "#govuk-pay-activity",
+      "Built and pushed pay-stubs candidate image"
     )
   }
 
@@ -391,29 +429,53 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing {
-          new GetStep { get = "pay-ci" }
           new GetStep { 
             get = "stubs-candidate-ecr-registry-test"
             trigger = true
             params { ["format"] = "oci" }
           }
+          new GetStep { get = "pay-ci" }
         }
       }
 
-      shared_resources.parseCandidateTag("stubs-candidate-ecr-registry-test")
-      new LoadVarStep { load_var = "candidate_number_tag" file = "tags/release-number" }
-      assumeCodeBuildRole("e2e-test-assume-role")
+      new InParallelStep {
+        in_parallel = new Listing {
+          shared_resources.generateDockerCredsConfigStep
+          shared_resources.parseCandidateTag("stubs-candidate-ecr-registry-test")
+          assumeCodeBuildRole("executor", "e2e-test-assume-role")
+          assumeRetagRole
+          assumeWriteToDeployRole
+        }
+      }
 
       new InParallelStep {
         in_parallel = new Listing {
           new LoadVarStep { 
             load_var = "candidate_image_tag" 
-            file = "endtoend-candidate-ecr-registry-test/tag" 
+            file = "stubs-candidate-ecr-registry-test/tag" 
           }
           new LoadVarStep { 
             load_var = "role" 
             file = "assume-role/assume-role.json"
             format = "json"
+          }
+          new LoadVarStep { 
+            load_var = "retag-role" 
+            file = "assume-retag-role/assume-role.json"
+            format = "json"
+          }
+          new LoadVarStep { 
+            load_var = "write-to-deploy-role" 
+            file = "assume-write-to-deploy-role/assume-role.json"
+            format = "json"
+          }
+          new LoadVarStep { 
+            load_var = "release_image_tag" 
+            file = "parse-candidate-tag/release-tag"
+          }
+          new LoadVarStep { 
+            load_var = "release_number" 
+            file = "parse-candidate-tag/release-number"
           }
         }
       }
@@ -427,43 +489,26 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_resources.runCodeBuild(
-            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json"
+            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
+            3
           )
           shared_resources.runCodeBuild(
-            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json"
-          )
-          shared_resources.runCodeBuild(
-            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json"
+            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
+            1
           )
         }
       }
 
       new InParallelStep {
         in_parallel = new Listing {
-          shared_resources.generateDockerCredsConfigStep
-
-          // TODO: remove. These are already done, but the original has it twice, so we will, for now.
-          shared_resources.parseCandidateTag("stubs-candidate-ecr-registry-test")
-          assumeCodeBuildRole("e2e-test-assume-role")
-         }
-      }
-
-      new InParallelStep {
-        in_parallel = new Listing {
-          new LoadVarStep { load_var = "retag-role" file = "assume-retag-role/assume-role.json" }
-          new LoadVarStep { load_var = "release_image_tag" file = "parse-candidate-tag/release-tag" }
-        }
-      }
-
-      new InParallelStep {
-        in_parallel = new Listing {
-          retagCandidateInEcr("stubs", "((.:candidate_image_tag))")
-          retagCandidateInEcr("stubs", "latest")
+          retagCandidateInEcr("stubs", "((.:release_image_tag))", "release")
+          retagCandidateInEcr("stubs", "latest", "latest")
           retagCandidateInDockerHub(
             "governmentdigitalservice/pay-stubs",
             "((.:candidate_image_tag))",
             "release"
           )
+          copyMultiarchImageToAccount("stubs")
         }
       }
     }
@@ -471,15 +516,18 @@ jobs = new {
       "#govuk-pay-starling",
       "pay-stubs failed post-merge e2e tests"
     )
-    on_success = shared_resources.paySlackNotificationForFail(
-      "#govuk-pay-starling",
+    on_success = shared_resources.paySlackNotificationForSuccess(
+      "#govuk-pay-activity",
       "pay-stubs passed post-merge e2e tests and was pushed as a final release"
     )
   }
 
-  copyImageToEcr("postgres-15")
-  copyImageToEcr("localstack-localstack-3")
-  copyImageToEcr("selenium-standalone-chrome-3-141-59")
+  copyImageToEcr("postgres-15-alpine", "postgres:15-alpine")
+  copyImageToEcr("localstack-localstack-3", "localstack/localstack:2.0")
+  copyImageToEcr(
+    "selenium-standalone-chrome-3-141-59",
+    "selenium/standalone-chrome:3-141-59"
+  )
 }
 
 // THINGS BELOW HERE MAY BE USEFUL IN SHARED_RESOURCES
@@ -517,11 +565,11 @@ local function putCandidateImage(putName: String): PutStep = new {
   get_params = new { ["skip_download"] = true }
 }
 
-local function assumeCodeBuildRole(sessionName: String): TaskStep = new {
+local function assumeCodeBuildRole(codeBuildRole: String, sessionName: String): TaskStep = new {
   task = "assume-role"
   file = "pay-ci/ci/tasks/assume-role.yml"
   params = new {
-    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-\(codeBuildRole)-test-12"
     ["AWS_ROLE_SESSION_NAME"] = sessionName
   }
 }
@@ -538,6 +586,18 @@ local assumeRetagRole: TaskStep = new {
   }
 }
 
+local assumeWriteToDeployRole: TaskStep = new {
+  task = "assume-write-to-deploy-role"
+  file = "pay-ci/ci/tasks/assume-role.yml"
+  output_mapping = new {
+    ["assume-role"] = "assume-write-to-deploy-role"
+  }
+  params = new {
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_dev_worker_ecr_access"
+    ["AWS_ROLE_SESSION_NAME"] = "write-ecr-to-deploy"
+  }
+}
+
 local function retagCandidateInDockerHub(repo: String, tag: String, taskTag: String): TaskStep = new {
   task = "retag-candidate-as-\(taskTag)-in-dockerhub"
   file = "pay-ci/ci/tasks/manifest-retag.yml"
@@ -547,17 +607,35 @@ local function retagCandidateInDockerHub(repo: String, tag: String, taskTag: Str
   }
 }
 
-local function retagCandidateInEcr(tag: String, repo: String): TaskStep = new {
-  task = "retag-candidate-as-\(tag)-in-ecr"
+local function retagCandidateInEcr(repo: String, tag: String, taskTag: String): TaskStep = new {
+  task = "retag-candidate-as-\(taskTag)-in-ecr"
   file = "pay-ci/ci/tasks/manifest-retag.yml"
   params = new {
     ["DOCKER_LOGIN_ECR"] = "1"
     ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-    ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo)/((.:candidate_image_tag))"
-    ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo)/((.:release_image_tag))"
+    ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):((.:candidate_image_tag))"
+    ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):\(tag)"
     ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
     ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
     ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
+  }
+}
+
+local function copyMultiarchImageToAccount(repo: String): TaskStep = new {
+  task = "copy-images-to-\(repo)-ecr-registry-deploy"
+  file = "pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml"
+  privileged = true
+  params = new {
+    ["DESTINATION_AWS_ACCESS_KEY_ID"] = "((.:write-to-deploy-role.AWS_ACCESS_KEY_ID))"
+    ["DESTINATION_AWS_SECRET_ACCESS_KEY"] = "((.:write-to-deploy-role.AWS_SECRET_ACCESS_KEY))"
+    ["DESTINATION_AWS_SESSION_TOKEN"] = "((.:write-to-deploy-role.AWS_SESSION_TOKEN))"
+    ["DESTINATION_ECR_REGISTRY"] = "((pay_aws_deploy_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+    ["ECR_REPO_NAME"] = "govukpay/\(repo)"
+    ["RELEASE_NUMBER"] = "((.:release_number))"
+    ["SOURCE_AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
+    ["SOURCE_AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
+    ["SOURCE_AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
+    ["SOURCE_ECR_REGISTRY"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
   }
 }
 
@@ -580,11 +658,11 @@ local function putStep(resourceName: String, imageName: String, additionalTags: 
   }
 }
 
-local function copyImageToEcr(image: String): Job = new {
+local function copyImageToEcr(image: String, displayName: String): Job = new {
   name = "copy-\(image)"
   plan {
     new GetStep { 
-      get = "reverse-proxy-candidate-ecr-registry-test"
+      get = image
       trigger = true
       params { ["format"] = "oci" }
     }
@@ -598,10 +676,11 @@ local function copyImageToEcr(image: String): Job = new {
 
   on_failure = shared_resources.paySlackNotificationForFail(
     "#govuk-pay-starling",
-    "Copied \(image) from Docker Hub to ECR"
+    "Failed copying \(displayName) image from Docker Hub to ECR"
   )
-  on_success = shared_resources.paySlackNotificationForFail(
-    "#govuk-pay-starling",
-    "Failed copying \(image) image from Docker Hub to ECR"
+
+  on_success = shared_resources.paySlackNotificationForSuccess(
+    "#govuk-pay-activity",
+    "Copied \(displayName) image from Docker Hub to ECR"
   )
 }

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -1,5 +1,5 @@
-amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/Pipeline.pkl"
-import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/TaskConfig.pkl"
+amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.3#/Pipeline.pkl"
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.3#/TaskConfig.pkl"
 
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -4,6 +4,8 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 
+local components = new Listing<String> { "endtoend" "reverse-proxy" "stubs" }
+
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
 
@@ -33,23 +35,26 @@ resources = new {
     source { ["tag"] = "latest" }
   }
 
-  (shared_resources.payECRResourceWithVariant(
-    "endtoend-candidate-ecr-registry-test", 
-    "govukpay/endtoend", 
-    "pay_aws_test_account_id", 
-    "candidate")) 
+  for (component in components) {
+    (shared_resources.payECRResourceWithVariant(
+      "\(component)-candidate-ecr-registry-test", 
+      "govukpay/\(component)", 
+      "pay_aws_test_account_id", 
+      "candidate")) 
+  }
 
-  (shared_resources.payECRResourceWithVariant(
-    "reverse-proxy-candidate-ecr-registry-test",
-    "govukpay/reverse-proxy",
-    "pay_aws_test_account_id", 
-    "candidate")) 
 
-  (shared_resources.payECRResourceWithVariant(
-    "stubs-candidate-ecr-registry-test",
-    "govukpay/stubs",
-    "pay_aws_test_account_id", 
-    "candidate")) 
+  // (shared_resources.payECRResourceWithVariant(
+  //   "reverse-proxy-candidate-ecr-registry-test",
+  //   "govukpay/reverse-proxy",
+  //   "pay_aws_test_account_id", 
+  //   "candidate")) 
+
+  // (shared_resources.payECRResourceWithVariant(
+  //   "stubs-candidate-ecr-registry-test",
+  //   "govukpay/stubs",
+  //   "pay_aws_test_account_id", 
+  //   "candidate")) 
 
   shared_resources.payDockerHubResource(
     "endtoend-dockerhub", 
@@ -183,18 +188,9 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          runCodeBuild(
-            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
-            3
-          )
-          runCodeBuild(
-            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
-            1
-          )
-          runCodeBuild(
-            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json",
-            1
-          )
+          runCodeBuild("run-codebuild-card", "card.json", 3)
+          runCodeBuild("run-codebuild-products", "products.json", 1)
+          runCodeBuild("run-codebuild-zap", "zap.json", 1)
         }
       }
 
@@ -254,7 +250,7 @@ jobs = new {
       runCodeBuildMultiarch("reverse-proxy", 3)
       runCodeBuild(
         "run-codebuild-reverse-proxy-manifest",
-        "../../../../run-codebuild-configuration/reverse-proxy-manifest.json",
+        "reverse-proxy-manifest.json",
         3
       )
     }
@@ -313,18 +309,9 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          runCodeBuild(
-            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
-            3
-          )
-          runCodeBuild(
-            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
-            1
-          )
-          runCodeBuild(
-            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json",
-            1
-          )
+          runCodeBuild("run-codebuild-card", "card.json", 3)
+          runCodeBuild("run-codebuild-products", "products.json", 1)
+          runCodeBuild("run-codebuild-zap", "zap.json", 1)
         }
       }
 
@@ -406,7 +393,7 @@ jobs = new {
       runCodeBuildMultiarch("stubs", 1)
       runCodeBuild(
         "run-codebuild-stubs-manifest",
-        "../../../../run-codebuild-configuration/stubs-manifest.json",
+        "stubs-manifest.json",
         1
       )
     }
@@ -480,14 +467,8 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          runCodeBuild(
-            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json",
-            3
-          )
-          runCodeBuild(
-            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json",
-            1
-          )
+          runCodeBuild("run-codebuild-card", "card.json", 3)
+          runCodeBuild("run-codebuild-products", "products.json", 1)
         }
       }
 
@@ -720,14 +701,14 @@ local function prepareCodeBuildMultiarch(project: String): TaskStep = new {
   }
 }
 
-local function runCodeBuild(taskName: String, pathToConfig: String, attemptCount: Int): TaskStep = new {
+local function runCodeBuild(taskName: String, config: String, attemptCount: Int): TaskStep = new {
   task = taskName
   file = "pay-ci/ci/tasks/run-codebuild.yml"
   when (attemptCount != 1) {
     attempts = attemptCount
   }
   params = new {
-    ["PATH_TO_CONFIG"] = pathToConfig
+    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(config)"
     ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
     ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
     ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
@@ -736,15 +717,7 @@ local function runCodeBuild(taskName: String, pathToConfig: String, attemptCount
 
 local function runCodeBuildMultiarch(project: String, attempts: Int): InParallelStep= new {
   in_parallel = new Listing {
-    runCodeBuild(
-      "run-codebuild-\(project)-amd64",
-      "../../../../run-codebuild-configuration/\(project)-amd64.json",
-      attempts
-    )
-    runCodeBuild(
-      "run-codebuild-\(project)-armv8",
-      "../../../../run-codebuild-configuration/\(project)-armv8.json",
-      attempts
-    )
+    runCodeBuild("run-codebuild-\(project)-amd64", "\(project)-amd64.json", attempts)
+    runCodeBuild("run-codebuild-\(project)-armv8", "\(project)-armv8.json", attempts)
   }
 }

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -1,0 +1,607 @@
+amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/Pipeline.pkl"
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.1#/TaskConfig.pkl"
+
+import "../common/pipeline_self_update.pkl"
+import "../common/shared_resources.pkl"
+
+resources = new {
+  shared_resources.payCiGitHubResource
+
+  (shared_resources.payGithubResourceWithBranch("e2e-helpers-pipeline", "pay-ci", "master")) {
+    source { ["paths"] = new Listing<String> { "ci/pipelines/e2e-helpers.yml" } }
+  }
+
+  (shared_resources.payGithubResourceWithBranch("endtoend-git-release", "pay-endtoend", "master")) {
+    source { ["tag_regex"] = "alpha_release-(.*)" }
+  }
+
+  (shared_resources.payGithubResourceWithBranch("stubs-git-release", "pay-stubs", "master")) {
+    source { ["tag_regex"] = "alpha_release-(.*)" }
+  }
+
+  (shared_resources.payGithubResourceWithBranch(
+    "reverse-proxy-git-release", "pay-scripts", "master")
+  ) {
+    source { ["tag_regex"] = "reverse_proxy_alpha_release-(.*)" }
+  }
+
+  (shared_resources.payECRResource(
+    "endtoend-ecr-registry-test", "govukpay/endtoend", "pay_aws_test_account_id")
+  ) {
+    source { ["tag"] = "latest" }
+  }
+
+  (shared_resources.payECRResourceWithVariant(
+    "endtoend-candidate-ecr-registry-test", 
+    "govukpay/endtoend", 
+    "pay_aws_test_account_id", 
+    "candidate")) 
+
+  (shared_resources.payECRResourceWithVariant(
+    "reverse-proxy-candidate-ecr-registry-test",
+    "govukpay/reverse-proxy",
+    "pay_aws_test_account_id", 
+    "candidate")) 
+
+  (shared_resources.payECRResourceWithVariant(
+    "stubs-candidate-ecr-registry-test",
+    "govukpay/stubs",
+    "pay_aws_test_account_id", 
+    "candidate")) 
+
+  shared_resources.payDockerHubResource("endtoend-dockerhub", "govukpay/endtoend", "latest-master")
+
+  (shared_resources.payDockerHubResource("postgres-15-alpine", "postgres", "15-alpine")) {
+    check_every = "1h" 
+  }
+
+  (shared_resources.payECRResource(
+    "ecr-postgres-15-alpine", "postgres", "pay_aws_test_account_id")
+  ) {
+    check_every = "never"
+    source { ["tag"] = "15-alpine" }
+  }
+
+  (shared_resources.payDockerHubResource("localstack-localstack-3", "localstack/localstack", "3")) {
+    check_every = "1h"
+  }
+
+  (shared_resources.payECRResource(
+    "localstack-localstack-3", "localstack/localstack", "pay_aws_test_account_id")
+  ) {
+    check_every = "never"
+    source { ["tag"] = "3" }
+  }
+
+  (shared_resources.payDockerHubResource(
+    "selenium-standalone-chrome-3-141-59",
+    "selenium/standalone-chrome",
+     "3.141.59")) {
+    check_every = "1h"
+  }
+
+  (shared_resources.payECRResource(
+    "selenium-standalone-chrome-3-141-59",
+    "selenium/standalone-chrome",
+    "pay_aws_test_account_id")
+  ) {
+    check_every = "never"
+    source { ["tag"] = "3.141.59" }
+  }
+
+  shared_resources.slackNotificationResource
+
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
+}
+
+resource_types = new {
+  shared_resources.slackNotificationResourceType
+}
+
+jobs = new {
+  new {
+    name = "build-and-push-endtoend-candidate"
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "pay-ci" }
+          new GetStep { get = "endtoend-git-release" trigger = true }
+        }
+      }
+
+      shared_resources.generateDockerCredsConfigStep
+      shared_resources.parseReleaseTag("endtoend-git-release")
+      new LoadVarStep { load_var = "release_number_tag" file = "tags/release-number" }
+
+      new InParallelStep {  // One step in parallel, but that's what the original does
+        in_parallel = new Listing<Step> {
+          buildImage("build-endtoend-image", "endtoend-git-release")
+        }
+      }
+
+      putCandidateImage("endtoend-candidate-ecr-registry-test")
+    }
+    on_failure = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "Failed to build and push pay-endtoend candidate image"
+    )
+    on_success = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "Built and pushed pay-endtoend candidate image"
+    )
+  }
+
+  new {
+    name = "endtoend-e2e"
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing {
+          new GetStep { get = "pay-ci" }
+          new GetStep { 
+            get = "endtoend-candidate-ecr-registry-test"
+            trigger = true
+            passed = new Listing { "build-and-push-endtoend-candidate" }
+            params { ["format"] = "oci" }
+          }
+        }
+      }
+
+      shared_resources.parseCandidateTag("endtoend-candidate-ecr-registry-test")
+      new LoadVarStep { load_var = "candidate_number_tag" file = "tags/release-number" }
+      assumeCodeBuildRole("e2e-test-assume-role")
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          new LoadVarStep { 
+            load_var = "candidate_image_tag" 
+            file = "endtoend-candidate-ecr-registry-test/tag" 
+          }
+          new LoadVarStep { 
+            load_var = "role" 
+            file = "assume-role/assume-role.json"
+            format = "json"
+          }
+        }
+      }
+
+      shared_resources.prepareCodeBuild(
+        "endtoend", 
+        "prepare-e2e-codebuild.yml", 
+        "((.:candidate_image_tag))"
+      )
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          shared_resources.runCodeBuild(
+            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json"
+          )
+          shared_resources.runCodeBuild(
+            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json"
+          )
+          shared_resources.runCodeBuild(
+            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json"
+          )
+        }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          putStep(
+            "endtoend-ecr-registry-test",
+            "endtoend-candidate-ecr-registry-test/image.tar",
+            "parse-candidate-tag/release-tag",
+            true
+          )
+          putStep(
+            "endtoend-dockerhub",
+            "endtoend-candidate-ecr-registry-test/image.tar",
+            "",
+            true
+          )
+        }
+      }
+    }
+    on_failure = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "pay-endtoend failed post-merge e2e tests"
+    )
+    on_success = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "pay-endtoend passed post-merge e2e tests and was pushed as a final release"
+    )
+  }
+
+  new {
+    name = "build-and-push-reverse-proxy-candidate" // sub
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "pay-ci" }
+          new GetStep { get = "reverse-proxy-git-release" trigger = true } //sub
+        }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new LoadVarStep { load_var = "release_number_tag" file = "tags/release-number" }
+          new LoadVarStep { load_var = "release-name" file = "tags/release-name" }
+          new LoadVarStep { load_var = "release-sha" file = "tags/release-sha" }
+          new LoadVarStep { load_var = "candidate-image-tag" file = "tags/candidate-tag" }
+          new LoadVarStep { load_var = "date" file = "tags/date" }
+          assumeCodeBuildRole("codebuild-assume-role")
+        }
+      }
+
+      new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
+      shared_resources.prepareCodeBuildMultiarch("reverse-proxy")
+      shared_resources.generateDockerCredsConfigStep
+      shared_resources.runCodeBuildMultiarch("reverse-proxy")
+
+      // TODO : abstract this away with the above. Can't work out how to do it right now.
+      shared_resources.runCodeBuild(
+        "run-codebuild-reverse-proxy-manifest",
+        "../../../../run-codebuild-configuration/reverse-proxy-manifest.json"
+      )
+    }
+    on_failure = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "Failed to build and push e2e helper reverse-proxy"
+    )
+    on_success = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "Built and pushed e2e helper reverse-proxy"
+    )
+  }
+
+  new {
+    name = "reverse-proxy-e2e"
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing {
+          new GetStep { get = "pay-ci" }
+          new GetStep { 
+            get = "reverse-proxy-candidate-ecr-registry-test"
+            trigger = true
+            params { ["format"] = "oci" }
+          }
+        }
+      }
+
+      shared_resources.parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
+      new LoadVarStep { load_var = "candidate_number_tag" file = "tags/release-number" }
+      assumeCodeBuildRole("e2e-test-assume-role")
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          new LoadVarStep { 
+            load_var = "candidate_image_tag" 
+            file = "endtoend-candidate-ecr-registry-test/tag" 
+          }
+          new LoadVarStep { 
+            load_var = "role" 
+            file = "assume-role/assume-role.json"
+            format = "json"
+          }
+        }
+      }
+
+      shared_resources.prepareCodeBuild(
+        "reverse-proxy", 
+        "prepare-e2e-codebuild.yml", 
+        "((.:candidate_image_tag))"
+      )
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          shared_resources.runCodeBuild(
+            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json"
+          )
+          shared_resources.runCodeBuild(
+            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json"
+          )
+          shared_resources.runCodeBuild(
+            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json"
+          )
+        }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          shared_resources.generateDockerCredsConfigStep
+
+          // TODO: remove. These are already done, but the original has it twice, so we will, for now.
+          shared_resources.parseCandidateTag("reverse-proxy-candidate-ecr-registry-test")
+          assumeCodeBuildRole("e2e-test-assume-role")
+         }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          new LoadVarStep { load_var = "retag-role" file = "assume-retag-role/assume-role.json" }
+          new LoadVarStep { load_var = "release_image_tag" file = "parse-candidate-tag/release-tag" }
+        }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          retagCandidateInEcr("reverse-proxy", "((.:candidate_image_tag))")
+          retagCandidateInEcr("reverse-proxy", "latest")
+          retagCandidateInDockerHub(
+            "governmentdigitalservice/pay-reverse-proxy",
+            "((.:candidate_image_tag))",
+            "release"
+          )
+        }
+      }
+    }
+    on_failure = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "e2e helper reverse-proxy failed post-merge e2e tests"
+    )
+    on_success = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "e2e helper reverse-proxy passed post-merge e2e tests and was pushed as a final release"
+    )
+  }
+
+  new {
+    name = "build-and-push-stubs-candidate" 
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "pay-ci" }
+          new GetStep { get = "stubs-git-release" trigger = true } 
+        }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new LoadVarStep { load_var = "release_number_tag" file = "tags/release-number" }
+          new LoadVarStep { load_var = "release-name" file = "tags/release-name" }
+          new LoadVarStep { load_var = "release-sha" file = "tags/release-sha" }
+          new LoadVarStep { load_var = "candidate-image-tag" file = "tags/candidate-tag" }
+          new LoadVarStep { load_var = "date" file = "tags/date" }
+          assumeCodeBuildRole("codebuild-assume-role")
+        }
+      }
+
+      new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" format = "json" }
+      shared_resources.prepareCodeBuildMultiarch("stubs")
+      shared_resources.generateDockerCredsConfigStep
+      shared_resources.runCodeBuildMultiarch("stubs")
+
+      // TODO : abstract this away with the above. Can't work out how to do it right now.
+      shared_resources.runCodeBuild(
+        "run-codebuild-stubs-manifest",
+        "../../../../run-codebuild-configuration/stubs-manifest.json"
+      )
+    }
+    on_failure = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "Failed to build and push e2e helper stubs"
+    )
+    on_success = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "Built and pushed e2e helper stubs"
+    )
+  }
+
+  new {
+    name = "stubs-e2e"
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing {
+          new GetStep { get = "pay-ci" }
+          new GetStep { 
+            get = "stubs-candidate-ecr-registry-test"
+            trigger = true
+            params { ["format"] = "oci" }
+          }
+        }
+      }
+
+      shared_resources.parseCandidateTag("stubs-candidate-ecr-registry-test")
+      new LoadVarStep { load_var = "candidate_number_tag" file = "tags/release-number" }
+      assumeCodeBuildRole("e2e-test-assume-role")
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          new LoadVarStep { 
+            load_var = "candidate_image_tag" 
+            file = "endtoend-candidate-ecr-registry-test/tag" 
+          }
+          new LoadVarStep { 
+            load_var = "role" 
+            file = "assume-role/assume-role.json"
+            format = "json"
+          }
+        }
+      }
+
+      shared_resources.prepareCodeBuild(
+        "stubs", 
+        "prepare-e2e-codebuild.yml", 
+        "((.:candidate_image_tag))"
+      )
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          shared_resources.runCodeBuild(
+            "run-codebuild-card", "../../../../run-codebuild-configuration/card.json"
+          )
+          shared_resources.runCodeBuild(
+            "run-codebuild-products", "../../../../run-codebuild-configuration/products.json"
+          )
+          shared_resources.runCodeBuild(
+            "run-codebuild-zap", "../../../../run-codebuild-configuration/zap.json"
+          )
+        }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          shared_resources.generateDockerCredsConfigStep
+
+          // TODO: remove. These are already done, but the original has it twice, so we will, for now.
+          shared_resources.parseCandidateTag("stubs-candidate-ecr-registry-test")
+          assumeCodeBuildRole("e2e-test-assume-role")
+         }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          new LoadVarStep { load_var = "retag-role" file = "assume-retag-role/assume-role.json" }
+          new LoadVarStep { load_var = "release_image_tag" file = "parse-candidate-tag/release-tag" }
+        }
+      }
+
+      new InParallelStep {
+        in_parallel = new Listing {
+          retagCandidateInEcr("stubs", "((.:candidate_image_tag))")
+          retagCandidateInEcr("stubs", "latest")
+          retagCandidateInDockerHub(
+            "governmentdigitalservice/pay-stubs",
+            "((.:candidate_image_tag))",
+            "release"
+          )
+        }
+      }
+    }
+    on_failure = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "pay-stubs failed post-merge e2e tests"
+    )
+    on_success = shared_resources.paySlackNotificationForFail(
+      "#govuk-pay-starling",
+      "pay-stubs passed post-merge e2e tests and was pushed as a final release"
+    )
+  }
+
+  copyImageToEcr("postgres-15")
+  copyImageToEcr("localstack-localstack-3")
+  copyImageToEcr("selenium-standalone-chrome-3-141-59")
+}
+
+// THINGS BELOW HERE MAY BE USEFUL IN SHARED_RESOURCES
+
+local function buildImage(taskName: String, context: String): TaskStep = new {
+  task = taskName
+  privileged = true
+  params {
+    ["CONTEXT"] = context
+    ["DOCKER_CONFIG"] = "docker_creds"
+  }
+  config {
+    platform = "linux"
+    image_resource {
+      type = "registry-image"
+      source { ["repository"] = "concourse/oci-build-task" }
+    }
+    inputs = new Listing {
+      new TaskConfig.Input { name = context }
+      new TaskConfig.Input { name = "docker_creds" }
+    }
+    outputs = new Listing {
+      new TaskConfig.Output { name = "image" }
+    }
+    run { path = "build" }
+  }
+}
+
+local function putCandidateImage(putName: String): PutStep = new {
+  put = putName
+  params = new {
+    ["image"] = "image/image.tar"
+    ["additional_tags"] = "tags/candidate-tag"
+  }
+  get_params = new { ["skip_download"] = true }
+}
+
+local function assumeCodeBuildRole(sessionName: String): TaskStep = new {
+  task = "assume-role"
+  file = "pay-ci/ci/tasks/assume-role.yml"
+  params = new {
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
+    ["AWS_ROLE_SESSION_NAME"] = sessionName
+  }
+}
+
+local assumeRetagRole: TaskStep = new {
+  task = "assume-retag-role"
+  file = "pay-ci/ci/tasks/assume-role.yml"
+  output_mapping = new {
+    ["assume-role"] = "assume-retag-role"
+  }
+  params = new {
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/concourse"
+    ["AWS_ROLE_SESSION_NAME"] = "retag-ecr-image-as-release"
+  }
+}
+
+local function retagCandidateInDockerHub(repo: String, tag: String, taskTag: String): TaskStep = new {
+  task = "retag-candidate-as-\(taskTag)-in-dockerhub"
+  file = "pay-ci/ci/tasks/manifest-retag.yml"
+  params = new {
+    ["SOURCE_MANIFEST"] = "\(repo):\(tag)"
+    ["NEW_MANIFEST"] = "\(repo):latest-master"
+  }
+}
+
+local function retagCandidateInEcr(tag: String, repo: String): TaskStep = new {
+  task = "retag-candidate-as-\(tag)-in-ecr"
+  file = "pay-ci/ci/tasks/manifest-retag.yml"
+  params = new {
+    ["DOCKER_LOGIN_ECR"] = "1"
+    ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
+    ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo)/((.:candidate_image_tag))"
+    ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo)/((.:release_image_tag))"
+    ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
+  }
+}
+
+// COPIED FROM prometheus-pushgateway.pkl -- MOVE TO SHARED_RESOURCES?
+
+local function putStep(resourceName: String, imageName: String, additionalTags: String, skipDownload: Boolean): PutStep = new PutStep {
+  put = resourceName
+  params {
+    when (imageName.length > 0) {
+      ["image"] = imageName
+    }
+    when (additionalTags.length > 0) {
+      ["additional_tags"] = additionalTags
+    }
+  }
+  get_params {
+    when (skipDownload) {
+      ["skip_download"] = true
+    }
+  }
+}
+
+local function copyImageToEcr(image: String): Job = new {
+  name = "copy-\(image)"
+  plan {
+    new GetStep { 
+      get = "reverse-proxy-candidate-ecr-registry-test"
+      trigger = true
+      params { ["format"] = "oci" }
+    }
+
+    new PutStep {
+      put = "ecr-\(image)"
+      params { ["image"] = "\(image)/image.tar" }
+      get_params { ["skip_download"] = true }
+    }
+  }
+
+  on_failure = shared_resources.paySlackNotificationForFail(
+    "#govuk-pay-starling",
+    "Copied \(image) from Docker Hub to ECR"
+  )
+  on_success = shared_resources.paySlackNotificationForFail(
+    "#govuk-pay-starling",
+    "Failed copying \(image) image from Docker Hub to ECR"
+  )
+}


### PR DESCRIPTION
Generates the e2e-helpers file with minimal changes, mostly related to the set-pipeline job, which we've decided to do in a new, uniform way.

It can definitely be made smaller, and should be once we've pulled helper functions together in `shared_resources` but for now I think it will do. It is, I hope, clear. 

Some, possibly much, duplication can be removed by changing the jobs slightly, but my aim here was to reproduce the pipeline as-is, including oddities. (Including a single-step `in_parallel`.)