### PR TITLE
PP-12422 Fix typo

### DIFF
--- a/ci/pipelines/deploy-to-production.yml
+++ b/ci/pipelines/deploy-to-production.yml
@@ -157,7 +157,7 @@ definitions:
 
   pushgateway_default_labels: &pushgateway_default_labels
     pipeline: "$BUILD_PIPELINE_NAME"
-    conocurse_job: "$BUILD_JOB_NAME"
+    concourse_job: "$BUILD_JOB_NAME"
     app: "((.:app_name))"
     environment: production-2
     instance: "concourse"

--- a/ci/pipelines/deploy-to-staging.yml
+++ b/ci/pipelines/deploy-to-staging.yml
@@ -163,7 +163,7 @@ definitions:
 
   pushgateway_default_labels: &pushgateway_default_labels
     pipeline: "$BUILD_PIPELINE_NAME"
-    conocurse_job: "$BUILD_JOB_NAME"
+    concourse_job: "$BUILD_JOB_NAME"
     app: "((.:app_name))"
     environment: staging-2
     instance: "concourse"

--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -127,7 +127,7 @@ definitions:
 
   pushgateway_default_labels: &pushgateway_default_labels
     pipeline: "$BUILD_PIPELINE_NAME"
-    conocurse_job: "$BUILD_JOB_NAME"
+    concourse_job: "$BUILD_JOB_NAME"
     app: "((.:app_name))"
     environment: test-12
     instance: "concourse"


### PR DESCRIPTION
## WHAT
- Fix the typo in `conocurse` so that when pipelines are being migrated from yml to pkl, diffs shown are minimal