### PR TITLE
PP-12424: Input pay-ci and fix script file name

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -177,13 +177,16 @@ local function testConcourseRunnerTask(imageName: String, appRepo: String): Pipe
     platform = "linux"
     inputs{
       new {
+        name = "pay-ci"
+      }
+      new {
         name = "app-repo"
       }
     }
     run {
       path = "/bin/bash"
       args {
-        "pay-ci/ci/scripts/test-concourse-runner"
+        "pay-ci/ci/scripts/test-concourse-runner.sh"
       }
     }
   }


### PR DESCRIPTION
To use the extracted script file, the `pay-ci` resource must be an input. Additionally, reference to the script file `test-concourse-runner` was incorrect. It should be `test-concourse-runner.sh`