### PR TITLE
PP-12422 Refactor: move list of apps to separate pkl module

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
@@ -1,0 +1,51 @@
+
+class PayApplication {
+  name: String
+  is_a_java_or_node_app: Boolean = false
+  has_db: Boolean = false
+  rds_identifier_suffix: Int = 0
+  override_app_to_deploy: String?
+  override_ecr_repo: String?
+  use_app_specific_deploy_task: Boolean = false
+  smoke_test: Boolean = true
+  pact_tag: Boolean = false
+
+  function getECRRepo(): String = "govukpay/\(override_ecr_repo ?? name)"
+}
+
+local payApps: Listing<PayApplication> = new Listing<PayApplication> {
+  new { name = "adminusers"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
+  new { name = "cardid"; pact_tag = true; is_a_java_or_node_app = true }
+  new { name = "connector"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
+  new { name = "egress"; use_app_specific_deploy_task = true }
+  new { name = "frontend"; use_app_specific_deploy_task = true; pact_tag = true;is_a_java_or_node_app = true }
+  new { name = "ledger"; has_db = true; pact_tag = true ; is_a_java_or_node_app = true }
+  new { name = "notifications" }
+  new { name = "products"; has_db = true; pact_tag = true ; is_a_java_or_node_app = true }
+  new { name = "products-ui"; pact_tag = true ; is_a_java_or_node_app = true }
+  new { name = "publicapi"; pact_tag = true ; is_a_java_or_node_app = true }
+  new { name = "publicauth"; has_db = true;  rds_identifier_suffix = 1; is_a_java_or_node_app = true }
+  new { name = "selfservice"; pact_tag = true; is_a_java_or_node_app = true }
+  new { name = "toolbox"; smoke_test = false; is_a_java_or_node_app = true }
+  new { name = "webhooks"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
+  new { name = "webhooks-egress"; use_app_specific_deploy_task = true }
+}.toList().sortBy((app) -> app.name).toListing()
+
+// sidecars or other helpers
+local payHelpers: Listing<PayApplication> = new Listing<PayApplication> {
+  new { name = "adot"; smoke_test = false; }
+  new { name = "alpine"; smoke_test = false; override_app_to_deploy = "scheduled-tasks" }
+  new { name = "nginx-forward-proxy"; smoke_test = false; override_app_to_deploy = "frontend" }
+  new { name = "nginx-proxy"; smoke_test = false; override_ecr_repo = "docker-nginx-proxy"
+    override_app_to_deploy = "toolbox" }
+  new { name = "stream-s3-sqs"; smoke_test = false; override_app_to_deploy = "scheduled-tasks" }
+}.toList().sortBy((app) -> app.name).toListing()
+
+payScheduledTask = new PayApplication { name = "scheduled-tasks"; use_app_specific_deploy_task = true }
+
+allPayApplications: Listing<PayApplication> = new {
+  ...payApps
+  ...payHelpers
+}
+
+payApplicationsWithDB = payApps.toList().filter((app) -> app.has_db).toListing()

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -6,57 +6,13 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/shared_resources_for_deploy_pipelines.pkl"
 
-local class PayApp {
-  name: String
-  is_a_java_or_node_app: Boolean = false
-  has_db: Boolean = false
-  rds_identifier_suffix: Int = 0
-  override_app_to_deploy: String?
-  override_ecr_repo: String?
-  use_app_specific_deploy_task: Boolean = false
-  smoke_test: Boolean = true
-  pact_tag: Boolean = false
+local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 
-  function getECRRepo(): String = "govukpay/\(override_ecr_repo ?? name)"
-}
-
-local payApps: Listing<PayApp> = new Listing<PayApp> {
-  new { name = "adminusers"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
-  new { name = "cardid"; pact_tag = true; is_a_java_or_node_app = true }
-  new { name = "connector"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
-  new { name = "egress"; use_app_specific_deploy_task = true }
-  new { name = "frontend"; use_app_specific_deploy_task = true; pact_tag = true;is_a_java_or_node_app = true }
-  new { name = "ledger"; has_db = true; pact_tag = true ; is_a_java_or_node_app = true }
-  new { name = "notifications" }
-  new { name = "products"; has_db = true; pact_tag = true ; is_a_java_or_node_app = true }
-  new { name = "products-ui"; pact_tag = true ; is_a_java_or_node_app = true }
-  new { name = "publicapi"; pact_tag = true ; is_a_java_or_node_app = true }
-  new { name = "publicauth"; has_db = true;  rds_identifier_suffix = 1; is_a_java_or_node_app = true }
-  new { name = "selfservice"; pact_tag = true; is_a_java_or_node_app = true }
-  new { name = "toolbox"; smoke_test = false; is_a_java_or_node_app = true }
-  new { name = "webhooks"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
-  new { name = "webhooks-egress"; use_app_specific_deploy_task = true }
-}.toList().sortBy((app) -> app.name).toListing()
-
-// sidecars or other helpers
-local payHelpers: Listing<PayApp> = new Listing<PayApp> {
-  new { name = "adot"; smoke_test = false; }
-  new { name = "alpine"; smoke_test = false; override_app_to_deploy = "scheduled-tasks" }
-  new { name = "nginx-forward-proxy"; smoke_test = false; override_app_to_deploy = "frontend" }
-  new { name = "nginx-proxy"; smoke_test = false; override_ecr_repo = "docker-nginx-proxy"
-    override_app_to_deploy = "toolbox" }
-  new { name = "stream-s3-sqs"; smoke_test = false; override_app_to_deploy = "scheduled-tasks" }
-}.toList().sortBy((app) -> app.name).toListing()
-
-local payScheduledTask = new PayApp { name = "scheduled-tasks"; use_app_specific_deploy_task = true }
-
-local allPayApps: Listing<PayApp> = new {
-  ...payApps
-  ...payHelpers
-}
-
-local payApplicationsWithDB = payApps.toList().filter((app) -> app.has_db).toListing()
+local payScheduledTask = shared_resources_for_deploy_pipelines.payScheduledTask
+local allPayApplications = shared_resources_for_deploy_pipelines.allPayApplications
+local payApplicationsWithDB = shared_resources_for_deploy_pipelines.payApplicationsWithDB
 
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
@@ -69,7 +25,7 @@ resources = new {
   shared_resources.payCiGitHubResource
   shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
 
-  for (app in allPayApps) {
+  for (app in allPayApplications) {
     shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-prod",
       app.getECRRepo(), "pay_aws_prod_account_id", "release")
   }
@@ -77,7 +33,7 @@ resources = new {
 }
 
 groups {
-  for (app in allPayApps) {
+  for (app in allPayApplications) {
     new {
       name = app.name
       jobs = new Listing {
@@ -114,7 +70,7 @@ groups {
 jobs {
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-deploy/deploy-to-production.pkl")
 
-  for (app in allPayApps) {
+  for (app in allPayApplications) {
     when (app.override_app_to_deploy == null && app.name != "adot") {
       getJobToDeployApp(app)
     }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -6,51 +6,13 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/shared_resources_for_deploy_pipelines.pkl"
 
-local class PayApp {
-  name: String
-  has_db: Boolean = false
-  include_nginx_and_adot_sidecar: Boolean = true
-  override_app_to_deploy: String?
-  override_ecr_repo: String?
-  rds_identifier_suffix: Int = 0
-  use_app_specific_deploy_task: Boolean = false
-}
+local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 
-local payApps: Listing<PayApp> = new Listing<PayApp> {
-  new { name = "adminusers"; has_db = true }
-  new { name = "cardid" }
-  new { name = "connector"; has_db = true }
-  new { name = "egress"; include_nginx_and_adot_sidecar = false; use_app_specific_deploy_task = true }
-  new { name = "frontend"; use_app_specific_deploy_task = true }
-  new { name = "ledger"; has_db = true }
-  new { name = "notifications"; include_nginx_and_adot_sidecar = false }
-  new { name = "products"; has_db = true }
-  new { name = "products-ui" }
-  new { name = "publicapi" }
-  new { name = "publicauth"; has_db = true;  rds_identifier_suffix = 1 }
-  new { name = "selfservice" }
-  new { name = "toolbox" }
-  new { name = "webhooks"; has_db = true }
-  new { name = "webhooks-egress"; include_nginx_and_adot_sidecar = false; use_app_specific_deploy_task = true }
-}.toList().sortBy((app) -> app.name).toListing()
-
-// sidecars or other helpers
-local payHelpers: Listing<PayApp> = new Listing<PayApp> {
-  new { name = "alpine"; override_app_to_deploy = "scheduled-tasks"; include_nginx_and_adot_sidecar = false }
-  new { name = "nginx-forward-proxy"; override_app_to_deploy = "frontend"; include_nginx_and_adot_sidecar = false }
-  new { name = "nginx-proxy"; override_ecr_repo = "docker-nginx-proxy"; override_app_to_deploy = "toolbox"; include_nginx_and_adot_sidecar = false }
-  new { name = "stream-s3-sqs"; override_app_to_deploy = "scheduled-tasks";  include_nginx_and_adot_sidecar = false }
-}.toList().sortBy((app) -> app.name).toListing()
-
-local payScheduledTask = new PayApp { name = "scheduled-tasks"; use_app_specific_deploy_task = true; include_nginx_and_adot_sidecar = false }
-
-local allPayApps: Listing<PayApp> = new {
-  ...payApps
-  ...payHelpers
-}
-
-local payApplicationsWithDB = payApps.toList().filter((app) -> app.has_db).toListing()
+local payScheduledTask = shared_resources_for_deploy_pipelines.payScheduledTask
+local allPayApplications = shared_resources_for_deploy_pipelines.allPayApplications
+local payApplicationsWithDB = shared_resources_for_deploy_pipelines.payApplicationsWithDB
 
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
@@ -64,42 +26,46 @@ resources = new {
   shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
 
   shared_resources.payECRResourceWithVariant("adot-ecr-registry-perf", "govukpay/adot", "pay_aws_test_account_id", "perf")
-  for (app in allPayApps) {
-    shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-perf", "govukpay/\(if (app.override_ecr_repo == null) app.name else app.override_ecr_repo)", "pay_aws_test_account_id", "perf")
-    when (app.has_db) {
-      shared_resources.payECRResourceWithVariant("\(app.name)-db-ecr-registry-perf", "govukpay/\(app.name)", "pay_aws_test_account_id", "perf-db")
+  for (app in allPayApplications) {
+    when (app.name != "adot") {
+      shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-perf", "govukpay/\(if (app.override_ecr_repo == null) app.name else app.override_ecr_repo)", "pay_aws_test_account_id", "perf")
+      when (app.has_db) {
+        shared_resources.payECRResourceWithVariant("\(app.name)-db-ecr-registry-perf", "govukpay/\(app.name)", "pay_aws_test_account_id", "perf-db")
+      }
     }
   }
   shared_resources_for_slack_notifications.slackNotificationResource
 }
 
 groups {
-  for (app in allPayApps) {
-    new {
-      name = app.name
-      jobs = new Listing {
-        when (app.override_app_to_deploy != null) {
-          when (app.override_app_to_deploy == "scheduled-tasks") {
-            "deploy-\(app.override_app_to_deploy)"
-          } else {
-            "deploy-\(app.override_app_to_deploy)-to-perf"
+  for (app in allPayApplications) {
+    when (app.name != "adot") {
+        new {
+          name = app.name
+          jobs = new Listing {
+            when (app.override_app_to_deploy != null) {
+              when (app.override_app_to_deploy == "scheduled-tasks") {
+                "deploy-\(app.override_app_to_deploy)"
+              } else {
+                "deploy-\(app.override_app_to_deploy)-to-perf"
+              }
+            } else {
+              "deploy-\(app.name)-to-perf"
+            }
+            when (app.has_db) {
+              "\(app.name)-db-migration-perf"
+            }
           }
-        } else {
-          "deploy-\(app.name)-to-perf"
-        }
-        when (app.has_db) {
-          "\(app.name)-db-migration-perf"
         }
       }
-    }
   }
   pipeline_self_update.payPipelineSelfUpdateGroup
 }
 
 jobs {
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/deploy-to-perf.pkl")
-  for (app in allPayApps) {
-    when (app.override_app_to_deploy == null) {
+  for (app in allPayApplications) {
+    when (app.override_app_to_deploy == null && app.name != "adot") {
       new {
         name = "deploy-\(app.name)-to-perf"
         serial = true
@@ -184,7 +150,7 @@ local function getResourcesToDeployApp(app: PayApp): Listing<Step> = new Listing
     getStep("nginx-forward-proxy-ecr-registry-perf", true)
   }
 
-  when (app.include_nginx_and_adot_sidecar) {
+  when (app.is_a_java_or_node_app) {
     getStep("nginx-proxy-ecr-registry-perf", true)
     getStep("adot-ecr-registry-perf", true)
   }
@@ -198,7 +164,7 @@ local function loadVariablesToDeployApp(app: PayApp): Listing<Step> = new Listin
   loadVar("app_release_number", "ecr-release-info/release-number")
   loadVar("application_image_tag", "\(app.name)-ecr-registry-perf/tag")
 
-  when (app.include_nginx_and_adot_sidecar == true) {
+  when (app.is_a_java_or_node_app == true) {
     loadVar("adot_image_tag", "adot-ecr-registry-perf/tag")
     loadVar("adot_release_number", "adot-release-info/release-number")
     loadVar("nginx_image_tag", "nginx-proxy-ecr-registry-perf/tag")
@@ -228,7 +194,7 @@ local function parseReleaseTag(appName: String, includeOutputMapping: Boolean) =
 local function parseReleaseTagsToDeployApp(app: PayApp): Listing<Step> = new Listing<Step> {
   parseReleaseTag(app.name, false)
 
-  when (app.include_nginx_and_adot_sidecar == true) {
+  when (app.is_a_java_or_node_app == true) {
     parseReleaseTag("adot", true)
     parseReleaseTag("nginx-proxy", true)
   }
@@ -266,7 +232,7 @@ local function deployToPerf(app: PayApp) = new TaskStep {
     when (app.name == "frontend") {
       ["NGINX_FORWARD_PROXY_IMAGE_TAG"] = "((.:nginx_forward_proxy_image_tag))"
     }
-    when (app.include_nginx_and_adot_sidecar == true) {
+    when (app.is_a_java_or_node_app == true) {
       ["NGINX_IMAGE_TAG"] = "((.:nginx_image_tag))"
       ["ADOT_IMAGE_TAG"] = "((.:adot_image_tag))"
     }
@@ -288,7 +254,7 @@ local function waitForDeploy(app: PayApp) = new TaskStep {
     ["APP_NAME"] = app.name
     ["APPLICATION_IMAGE_TAG"] = "((.:application_image_tag))"
     ["ENVIRONMENT"] = "test-perf-1"
-    when (app.include_nginx_and_adot_sidecar == true) {
+    when (app.is_a_java_or_node_app == true) {
       ["NGINX_IMAGE_TAG"] = "((.:nginx_image_tag))"
       ["ADOT_IMAGE_TAG"] = "((.:adot_image_tag))"
     }
@@ -358,7 +324,7 @@ local function sendSlackNoticationAndPutMetrics(app: PayApp, isASuccess: Boolean
         shared_resources_for_slack_notifications.paySlackNotificationForAppDeployment("#govuk-pay-announce", false, "Deployment of ((.:app_name)) to perf failed")
       }
       shared_resources_for_metrics.paySendAppReleaseMetric(isASuccess, "test-perf-1")
-      when (app.include_nginx_and_adot_sidecar == true) {
+      when (app.is_a_java_or_node_app == true) {
         shared_resources_for_metrics.paySendNginxReleaseMetric(isASuccess, "test-perf-1")
         shared_resources_for_metrics.paySendAdotReleaseMetric(isASuccess, "test-perf-1")
       }


### PR DESCRIPTION
## WHAT
- Moved list of apps to separate pkl module and used in perf and prod pipelines
- Added aliases to avoid lengthy references throughout
- Common tasks in deploy pipelines can be added to `shared_resources_for_deploy_pipelines.pkl`