### PR TITLE
PP-12484-extend-test-role-duration

### DIFF
--- a/ci/scripts/assume-role.js
+++ b/ci/scripts/assume-role.js
@@ -8,7 +8,8 @@ const sts = new AWS.STS()
 const run = async function run () {
   const assumeRoleResponse = await sts.assumeRole({
     RoleArn: process.env.AWS_ROLE_ARN,
-    RoleSessionName: process.env.AWS_ROLE_SESSION_NAME
+    RoleSessionName: process.env.AWS_ROLE_SESSION_NAME,
+    DurationSeconds: 10800, // 3 hours
   }).promise()
   const tempCreds = assumeRoleResponse.Credentials
 


### PR DESCRIPTION
Request a three hour assume-role lease. I think this will work: I didn't find any cap on duration in the `pay-cd-pay-dev-codebuild-executor-perf-tests-test-perf-1` role.