### PR TITLE
BAU-tag-releases-with-pipeline

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -123,6 +123,7 @@ definitions:
     params:
       tags:
         - ((.:app_name))
+        - "${BUILD_PIPELINE_NAME}"
       template:  "released ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} release ((.:app_release_number)) (build ${BUILD_ID})"
 
   pushgateway_default_labels: &pushgateway_default_labels


### PR DESCRIPTION
When we do a release annotation, put the pipeline name in as an extra tag. This will let us filter annotation displays in dashboards.