### PR TITLE
BAU-tag-releases-with-pipeline-literal

### DIFF
--- a/ci/pipelines/deploy-to-test.yml
+++ b/ci/pipelines/deploy-to-test.yml
@@ -123,7 +123,7 @@ definitions:
     params:
       tags:
         - ((.:app_name))
-        - "${BUILD_PIPELINE_NAME}"
+        - deploy-to-test
       template:  "released ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} release ((.:app_release_number)) (build ${BUILD_ID})"
 
   pushgateway_default_labels: &pushgateway_default_labels


### PR DESCRIPTION
use literal string, because variable isn't expanded. (And isn't necessary, really.)