### PR TITLE
PP-11718 Concourse runner with Java 21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,16 @@ updates:
     - govuk-pay
     - docker
 - package-ecosystem: docker
+  directory: "/ci/docker/concourse-runner-with-java-21"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 10
+  labels:
+    - dependencies
+    - govuk-pay
+    - docker
+- package-ecosystem: docker
   directory: "/ci/docker/pact-broker"
   schedule:
     interval: daily

--- a/ci/docker/concourse-runner-with-java-21/Dockerfile
+++ b/ci/docker/concourse-runner-with-java-21/Dockerfile
@@ -1,0 +1,54 @@
+FROM docker:26.0.0-dind
+
+ARG FLY_CLI_SHA256SUM=90a05559d36f259903ca76988b51fbca8948f0c30a42e260d27dda659052db22
+ARG PKL_VERSION=0.25.2
+ARG PKL_CLI_SHA256SUM=33aa2b56b4852e00fce821073fa74c5302433e61f3cf8d07f44acd34b4cb13c9
+
+RUN apk add --no-cache \
+  aws-cli \
+  bash \
+  curl \
+  docker-compose \
+  netcat-openbsd \
+  git \
+  python3 \
+  ca-certificates \
+  jq \
+  openjdk21 \
+  maven \
+  tini \
+  # dockerd dependencies
+  iptables \
+  util-linux
+
+RUN apk add --virtual build-dependencies build-base
+
+RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.86.0/pact-1.86.0-linux-x86_64.tar.gz \
+    && tar xzf pact-1.86.0-linux-x86_64.tar.gz \
+    && rm -f pact-1.86.0-linux-x86_64.tar.gz
+
+RUN ln -s /pact/bin/pact /usr/local/bin \
+    && ln -s /pact/bin/pact-broker /usr/local/bin \
+    && ln -s /pact/bin/pact-message /usr/local/bin \
+    && ln -s /pact/bin/pact-mock-service /usr/local/bin \
+    && ln -s /pact/bin/pact-provider-verifier /usr/local/bin \
+    && ln -s /pact/bin/pact-publish /usr/local/bin \
+    && ln -s /pact/bin/pact-stub-service /usr/local/bin
+
+RUN echo "$PKL_CLI_SHA256SUM  /tmp/pkl" >> /tmp/pkl.sha256 \
+  && wget -O /tmp/pkl "https://github.com/apple/pkl/releases/download/${PKL_VERSION}/pkl-alpine-linux-amd64" \
+  && sha256sum -c /tmp/pkl.sha256 \
+  && mv /tmp/pkl /usr/local/bin \
+  && chmod 555 /usr/local/bin/pkl
+
+RUN echo "$FLY_CLI_SHA256SUM  /tmp/fly" >> /tmp/fly.sha256 \
+  && wget -O /tmp/fly 'https://pay-cd.deploy.payments.service.gov.uk/api/v1/cli?arch=amd64&platform=linux' \
+  && sha256sum -c /tmp/fly.sha256 \
+  && mv /tmp/fly /usr/local/bin/ \
+  && chmod 555 /usr/local/bin/fly
+
+COPY ./docker-helpers.sh /
+COPY ./docker-wrapper /usr/local/bin/
+ENTRYPOINT [ "docker-wrapper" ]
+
+CMD "ash"

--- a/ci/docker/concourse-runner-with-java-21/README.md
+++ b/ci/docker/concourse-runner-with-java-21/README.md
@@ -1,0 +1,5 @@
+# Pay Concourse Runner with java 21
+
+This Docker image identical to the original [governmentdigitalservice/pay-concourse-runner](https://github.com/alphagov/pay-ci/tree/master/ci/docker/concourse-runner) but with Java 21.
+
+Once our Java apps are upgraded to Java 21 we can deprecate the `concourse-runner` and `concourse-runner-with-java-17` Dockerfiles.

--- a/ci/docker/concourse-runner-with-java-21/docker-helpers.sh
+++ b/ci/docker/concourse-runner-with-java-21/docker-helpers.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Based on https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+# See https://github.com/meAmidos/dcind
+
+LOG_FILE=${LOG_FILE:-/tmp/docker.log}
+SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
+
+sanitize_cgroups() {
+  if [ -e /sys/fs/cgroup/cgroup.controllers ]; then
+    return
+  fi
+
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if [ ! -e /sys/fs/cgroup/systemd ] && [ $(cat /proc/self/cgroup | grep '^1:name=openrc:' | wc -l) -eq 0 ]; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+
+start_docker() {
+  echo "Starting Docker..."
+
+  if [ -f /tmp/docker.pid ]; then
+    echo "Docker is already running"
+    return
+  fi
+
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  if [ "$SKIP_PRIVILEGED" = "false" ]; then
+    sanitize_cgroups
+
+    # check for /proc/sys being mounted readonly, as systemd does
+    if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+      mount -o remount,rw /proc/sys
+    fi
+  fi
+
+  local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
+  local server_args="--mtu ${mtu}"
+  local registry=""
+
+  for registry in $1; do
+    server_args="${server_args} --insecure-registry ${registry}"
+  done
+
+  if [ -n "$2" ]; then
+    server_args="${server_args} --registry-mirror $2"
+  fi
+
+  export server_args LOG_FILE
+
+  try_start() {
+    dockerd --data-root /scratch/docker ${server_args} >$LOG_FILE 2>&1 &
+    echo $! > /tmp/docker.pid
+
+    sleep 1
+
+    echo waiting for docker to come up...
+    until docker info >/dev/null 2>&1; do
+      sleep 1
+      if ! kill -0 "$(cat /tmp/docker.pid)" 2>/dev/null; then
+        return 1
+      fi
+    done
+  }
+
+  if [ "$(command -v declare)" ]; then
+    declare -fx try_start
+
+    if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+      echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+      return 1
+    fi
+  else
+    try_start
+  fi
+}
+
+stop_docker() {
+  echo "Stopping Docker..."
+
+  if [ ! -f /tmp/docker.pid ]; then
+    return 0
+  fi
+
+  local pid=$(cat /tmp/docker.pid)
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  kill -TERM $pid
+  rm /tmp/docker.pid
+}
+
+clean_docker() {
+  [[ ! -f /tmp/docker.pid ]] && return 0;
+  echo "cleaning up docker"
+  docker system prune -af --volumes || true
+}

--- a/ci/docker/concourse-runner-with-java-21/docker-wrapper
+++ b/ci/docker/concourse-runner-with-java-21/docker-wrapper
@@ -1,0 +1,16 @@
+#!/sbin/tini /bin/bash
+
+{
+  . /docker-helpers.sh
+  function cleanup_docker() {
+    # prune docker data to work around garbage collection not being consistent
+    clean_docker || true
+    # explicitly kill docker in our own special way defined in docker-helpers,
+    # instead of using dumb-init to propagate different signals up
+    stop_docker || true
+  }
+  trap cleanup_docker EXIT
+}
+
+# This deliberately doesn't use 'exec', as this will prevent the above signal handling from working
+"$@"

--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -16,6 +16,7 @@ resources = new {
     |> withPaths(new Listing<String>{
         "ci/docker/concourse-runner/**";
         "ci/docker/concourse-runner-with-java-17/**";
+        "ci/docker/concourse-runner-with-java-21/**";
         "ci/pipelines/concourse-runner.yml" })
   shared_resources.payGithubResourceWithBranch("adminusers-master", "pay-adminusers", "master")
   shared_resources.payGithubResourceWithBranch("webhooks-main", "pay-webhooks", "main")
@@ -23,8 +24,11 @@ resources = new {
     |> withPath("ci/docker/concourse-runner/*")
   shared_resources.payGithubResourceWithBranch("concourse-runner-with-java-17-src", "pay-ci", "master")
     |> withPath("ci/docker/concourse-runner-with-java-17/*")
+  shared_resources.payGithubResourceWithBranch("concourse-runner-with-java-21-src", "pay-ci", "master")
+  |> withPath("ci/docker/concourse-runner-with-java-21/*")
   shared_resources.payDockerHubResource("concourse-runner", "governmentdigitalservice/pay-concourse-runner", "latest")
   shared_resources.payDockerHubResource("concourse-runner-with-java-17", "governmentdigitalservice/pay-concourse-runner-with-java-17", "latest")
+  shared_resources.payDockerHubResource("concourse-runner-with-java-21", "governmentdigitalservice/pay-concourse-runner-with-java-21", "latest")
 }
 
 jobs = new{

--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -33,8 +33,8 @@ resources = new {
 
 jobs = new{
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-deploy/concourse-runner.pkl")
-  buildAnPushConcourseJob(false, "adminusers-master")
-  buildAnPushConcourseJob(true, "webhooks-main")
+  buildAndPushConcourseJob(false, "adminusers-master")
+  buildAndPushConcourseJob(true, "webhooks-main")
   new {
     name = "concourse-runner-pr"
     plan {
@@ -233,7 +233,7 @@ local function testConcourseRunnerTask(imageName: String, appRepo: String): Pipe
   }
 }
 
-local function buildAnPushConcourseJob(java17: Boolean, sampleRepo: String): Pipeline.Job = new {
+local function buildAndPushConcourseJob(java17: Boolean, sampleRepo: String): Pipeline.Job = new {
   local versionModifier = if (java17) "-with-java-17" else ""
   local baseName = "concourse-runner\(versionModifier)"
 

--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -33,8 +33,9 @@ resources = new {
 
 jobs = new{
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-deploy/concourse-runner.pkl")
-  buildAndPushConcourseJob(false, "adminusers-master")
-  buildAndPushConcourseJob(true, "webhooks-main")
+  buildAndPushConcourseJob("", "adminusers-master")
+  buildAndPushConcourseJob("-with-java-17", "webhooks-main")
+
   new {
     name = "concourse-runner-pr"
     plan {
@@ -233,9 +234,8 @@ local function testConcourseRunnerTask(imageName: String, appRepo: String): Pipe
   }
 }
 
-local function buildAndPushConcourseJob(java17: Boolean, sampleRepo: String): Pipeline.Job = new {
-  local versionModifier = if (java17) "-with-java-17" else ""
-  local baseName = "concourse-runner\(versionModifier)"
+local function buildAndPushConcourseJob(javaVersionSuffix: String, sampleRepo: String): Pipeline.Job = new {
+  local baseName = "concourse-runner\(javaVersionSuffix)"
 
   name = "build-and-push-\(baseName)"
   plan {

--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -35,6 +35,7 @@ jobs = new{
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-deploy/concourse-runner.pkl")
   buildAndPushConcourseJob("", "adminusers-master")
   buildAndPushConcourseJob("-with-java-17", "webhooks-main")
+  buildAndPushConcourseJobWithoutTest("-with-java-21")
 
   new {
     name = "concourse-runner-pr"
@@ -289,3 +290,54 @@ local function buildAndPushConcourseJob(javaVersionSuffix: String, sampleRepo: S
 }
 
 
+local function buildAndPushConcourseJobWithoutTest(javaVersionSuffix: String): Pipeline.Job = new {
+  local baseName = "concourse-runner\(javaVersionSuffix)"
+
+  name = "build-and-push-\(baseName)"
+  plan {
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        getStepWithTrigger("\(baseName)-src", true)
+        getStep("pay-ci")
+      }
+    }
+    shared_resources.generateDockerCredsConfigStep
+    new TaskStep {
+      task = "build"
+      privileged = true
+      params = new {
+        ["CONTEXT"] = "\(baseName)-src/ci/docker/\(baseName)"
+        ["DOCKER_CONFIG"] = "docker_creds"
+        ["UNPACK_ROOTFS"] = "true"
+      }
+      config {
+        platform = "linux"
+        image_resource = new {
+          type = "registry-image"
+          source = new {
+            ["repository"] = "concourse/oci-build-task"
+          }
+        }
+        inputs {
+          new {
+            name = "\(baseName)-src"
+          }
+        }
+        outputs {
+          new {
+            name = "image"
+          }
+        }
+        run {
+          path = "build"
+        }
+      }
+    }
+    new PutStep{
+      put = baseName
+      params = new {
+        ["image"] = "image/image.tar"
+      }
+    }
+  }
+}

--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -118,6 +118,40 @@ jobs = new{
               }
             }
           }
+          new TaskStep {
+            task = "build-concourse-runner-with-java-21"
+            privileged = true
+            output_mapping {
+              ["image"] = "concourse-runner-with-java-21-image"
+            }
+            params = new {
+              ["CONTEXT"] = "concourse-runner-pr/ci/docker/concourse-runner-with-java-21"
+              ["UNPACK_ROOTFS"] = "true"
+              ["DOCKER_CONFIG"] = "docker_creds"
+            }
+            config {
+              platform = "linux"
+              image_resource = new {
+                type = "registry-image"
+                source = new {
+                  ["repository"] = "concourse/oci-build-task"
+                }
+              }
+              inputs {
+                new {
+                  name = "concourse-runner-pr"
+                }
+              }
+              outputs {
+                new {
+                  name = "image"
+                }
+              }
+              run {
+                path = "build"
+              }
+            }
+          }
         }
       }
       new InParallelStep {


### PR DESCRIPTION
My first attempt at some pkl. Very happy to amend anything if I've gone down the wrong track. 

At some point we'll need a container for running Java 21 tests on Concourse, similar to how we have a Java 17 container for Webhooks tests. I'm not too worried about DRYing this as eventually we won't need the Java 11 and Java 17 versions.

- Clones the Dockerfile and associated helper scripts into a new folder. These are identical to the Java 17 files apart from the `openjdk` version.
- Adds Dependabot config for the new Java 21 Dockerfile
- Adds the new resources to the concourse-runner pipeline (I've created the new repo in DockerHub already)
- Adds the Java 21 build steps to a) the PR job b) the post-merge job. Unlike Java 17 and webhooks, there is no app running on Java 21 where we can test the build. So for now we just have the build! This meant I had to create an extra function, but hopefully that's OK. We can remove it once there's an app to test on.
- Fixed a typo in the existing build function name and refactored a little, ready for when we can move the Java 21 into it.