### PR TITLE
PP-12316-deployment-events

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_annotations.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_annotations.pkl
@@ -1,4 +1,4 @@
-import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.3#/Pipeline.pkl"
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
 
 grafanaAnnotationResourceType = new Pipeline.ResourceType {
 	name = "grafana-annotation"

--- a/ci/pkl-pipelines/common/shared_resources_for_annotations.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_annotations.pkl
@@ -1,0 +1,28 @@
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.3#/Pipeline.pkl"
+
+grafanaAnnotationResourceType = new Pipeline.ResourceType {
+	name = "grafana-annotation"
+	type = "docker-image"
+	source = new {
+		["repository"] = "governmentdigitalservice/pay-grafana-annotation-resource"
+		["tag"] = "latest"
+	}
+}
+
+grafanaAnnotationResource = new Pipeline.Resource {
+	name = "grafana-annotation"
+	type = "grafana-annotation"
+	source = new {
+		["url"] = "https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk"
+		["username"] = "pay_cd"
+		["password"] = "((grafana-annotations-password))"
+	}
+}
+
+function paySendAppReleaseAnnotation(pipeline: String) = new Pipeline.PutStep {
+	put = "grafana-annotation"
+	params = new {
+		["tags"] = new Listing<String> { pipeline "((.:app_name))" }
+		["template"] = "released ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} release ((.:app_release_number)) (build ${BUILD_ID})"
+	}
+}

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -6,6 +6,7 @@ import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
+import "../common/shared_resources_for_annotations.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -21,6 +22,7 @@ local awsEnvVars = Map("account", "production",
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
   shared_resources_for_metrics.prometheusPushgatewayResourceType
+  shared_resources_for_annotations.grafanaAnnotationResourceType 
 }
 
 resources = new {
@@ -37,6 +39,9 @@ resources = new {
   new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test" }
   new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application" }
   shared_resources_for_slack_notifications.slackNotificationResource
+  (shared_resources_for_annotations.grafanaAnnotationResource) {
+    source { ["tags"] = new Listing<String> { "release" "production-2" } }
+  }
 }
 
 groups {
@@ -122,6 +127,7 @@ local function getJobToDeployApp(app): Job = new {
     checkReleaseVersions(app)
 
     shared_resources_for_deploy_pipelines.deployApplicationTask(app, awsEnvVars, "deploy-to-prod")
+    shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-production")
     shared_resources_for_deploy_pipelines.waitForDeployTask(app, "production-2")
   }
   on_success = sendSlackNoticationAndPutMetrics(app,

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -5,6 +5,7 @@ import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
+import "../common/shared_resources_for_annotations.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -20,6 +21,7 @@ local awsEnvVars = Map("account", "staging",
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
   shared_resources_for_metrics.prometheusPushgatewayResourceType
+  shared_resources_for_annotations.grafanaAnnotationResourceType 
 }
 
 resources = new {
@@ -33,6 +35,9 @@ resources = new {
       app.getECRRepo(), "pay_aws_staging_account_id", "release")
   }
   shared_resources_for_slack_notifications.slackNotificationResource
+  (shared_resources_for_annotations.grafanaAnnotationResource) {
+    source { ["tags"] = new Listing<String> { "release" "staging-2" } }
+  }
 }
 
 groups {
@@ -112,6 +117,7 @@ local function getJobToDeployApp(app): Job = new {
     checkReleaseVersions(app)
 
     shared_resources_for_deploy_pipelines.deployApplicationTask(app, awsEnvVars, "deploy-to-staging")
+    shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-staging")
     shared_resources_for_deploy_pipelines.waitForDeployTask(app, "staging-2")
   }
   on_success = sendSlackNoticationAndPutMetrics(app,

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -5,6 +5,7 @@ import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
+import "../common/shared_resources_for_annotations.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -19,6 +20,7 @@ local awsEnvVars = Map("account", "test",
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
   shared_resources_for_metrics.prometheusPushgatewayResourceType
+  shared_resources_for_annotations.grafanaAnnotationResourceType 
 }
 
 resources = new {
@@ -37,6 +39,9 @@ resources = new {
     }
   }
   shared_resources_for_slack_notifications.slackNotificationResource
+  (shared_resources_for_annotations.grafanaAnnotationResource) {
+    source { ["tags"] = new Listing<String> { "release" "test-perf-1" } }
+  }
 }
 
 groups {
@@ -88,6 +93,7 @@ jobs {
           (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
           shared_resources_for_deploy_pipelines.deployApplicationTask(app,
             awsEnvVars, "deploy-to-perf")
+          shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-perf")
           shared_resources_for_deploy_pipelines.waitForDeployTask(app, "test-perf-1")
         }
         on_success = sendSlackNoticationAndPutMetrics(app, true)

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -1007,7 +1007,7 @@ local function sendNotificationAndMetrics (app: PayApp, slackConfig: SlackNotifi
       when (metricsConfig.put_metrics) {
         ...sendMetrics(app, metricsConfig)
       }
-      when (config.put_grafana_annotation && config.is_a_success) {
+      when (metricsConfig.put_grafana_annotation && metricsConfig.is_a_success) {
         shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-test")
       }
     }
@@ -1033,10 +1033,10 @@ local function putGrafanaAnnotation() = new PutStep {
   }
 }
 
-local function sendMetrics(app: PayApp, isASuccess: Boolean, sendSideCarMetrics: Boolean) = new {
-  shared_resources_for_metrics.paySendAppReleaseMetric(isASuccess, "test-12")
-  when (app.is_a_java_or_node_app == true && sendSideCarMetrics) {
-    shared_resources_for_metrics.paySendNginxReleaseMetric(isASuccess, "test-12")
+local function sendMetrics(app: PayApp, metricsConfig: MetricsConfig) = new {
+  shared_resources_for_metrics.paySendAppReleaseMetric(metricsConfig.is_a_success, "test-12")
+  when (app.is_a_java_or_node_app == true && metricsConfig.put_sidecar_metrics) {
+    shared_resources_for_metrics.paySendNginxReleaseMetric(metricsConfig.is_a_success, "test-12")
     when (app.name == "frontend") {
       shared_resources_for_metrics.paySendNginxForwardProxyReleaseMetric(metricsConfig.is_a_success, "test-12")
     }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -8,6 +8,7 @@ import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
+import "../common/shared_resources_for_annotations.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -63,15 +64,7 @@ local testEnvConfigForApps: Mapping<Identifier, AdditionalAppConfigForTestEnv> =
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
   shared_resources_for_metrics.prometheusPushgatewayResourceType
-
-  new ResourceType {
-    name = "grafana-annotation"
-    source {
-      ["repository"] = "governmentdigitalservice/pay-grafana-annotation-resource"
-      ["tag"] = "latest"
-    }
-    type = "docker-image"
-  }
+  shared_resources_for_annotations.grafanaAnnotationResourceType 
 }
 
 local function withTagRegex(regex: String) = new Mixin {
@@ -104,19 +97,8 @@ resources = new {
     "pay_aws_test_account_id")) { source { ["tag"] = "latest" } }
 
   shared_resources_for_slack_notifications.slackNotificationResource
-
-  new {
-    name = "grafana-annotation"
-    source {
-      ["password"] = "((grafana-annotations-password))"
-      ["tags"] = new Listing {
-        "test-12"
-        "release"
-      }
-      ["url"] = "https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk"
-      ["username"] = "pay_cd"
-    }
-    type = "grafana-annotation"
+  (shared_resources_for_annotations.grafanaAnnotationResource) {
+    source { ["tags"] = new Listing<String> { "release" "test-12" } }
   }
 }
 
@@ -1025,8 +1007,8 @@ local function sendNotificationAndMetrics (app: PayApp, slackConfig: SlackNotifi
       when (metricsConfig.put_metrics) {
         ...sendMetrics(app, metricsConfig)
       }
-      when (metricsConfig.put_grafana_annotation && metricsConfig.is_a_success) {
-        putGrafanaAnnotation()
+      when (config.put_grafana_annotation && config.is_a_success) {
+        shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-test")
       }
     }
   }
@@ -1051,10 +1033,10 @@ local function putGrafanaAnnotation() = new PutStep {
   }
 }
 
-local function sendMetrics(app: PayApp, metricsConfig: MetricsConfig) = new {
-  shared_resources_for_metrics.paySendAppReleaseMetric(metricsConfig.is_a_success, "test-12")
-  when (app.is_a_java_or_node_app == true && metricsConfig.put_sidecar_metrics) {
-    shared_resources_for_metrics.paySendNginxReleaseMetric(metricsConfig.is_a_success, "test-12")
+local function sendMetrics(app: PayApp, isASuccess: Boolean, sendSideCarMetrics: Boolean) = new {
+  shared_resources_for_metrics.paySendAppReleaseMetric(isASuccess, "test-12")
+  when (app.is_a_java_or_node_app == true && sendSideCarMetrics) {
+    shared_resources_for_metrics.paySendNginxReleaseMetric(isASuccess, "test-12")
     when (app.name == "frontend") {
       shared_resources_for_metrics.paySendNginxForwardProxyReleaseMetric(metricsConfig.is_a_success, "test-12")
     }


### PR DESCRIPTION
Send deployment events for all applications, across all environments.

This change adds to three pipelines, and modifies deploy-to-test to use the same mechanism as the other three.

[Here you can see toolbox being deployed by every pipeline](https://grafana.monitoring.pay-cd.deploy.payments.service.gov.uk/goto/52xoFHBIg?orgId=1), and [here](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-toolbox/builds/494) is an example build.

The pipeline diffs are all reporting as too big to show. Feel free to dig, reviewer, naturally, but I have manually checked them all. deploy-to-test just reorders a couple of attributes, for no obvious reason, and the others all add the same things.