### PR TITLE
PP-12537: Concourse pipeline to build pay-java-lambdas JARs

### DIFF
--- a/ci/pipelines/build-and-push-java-lambdas.yml
+++ b/ci/pipelines/build-and-push-java-lambdas.yml
@@ -4,7 +4,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-java-lambdas
-      branch: PP-12537
+      branch: main
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
   - name: ci
@@ -12,7 +12,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: PP-12537
+      branch: main
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
 

--- a/ci/pipelines/build-and-push-java-lambdas.yml
+++ b/ci/pipelines/build-and-push-java-lambdas.yml
@@ -26,7 +26,5 @@ jobs:
         trigger: false
       - task: build-java-lambdas
         file: ci/ci/tasks/build-java-lambdas.yml
-        params:
-          app_name: pay-java-lambdas
 #        TODO on_failure
 #        TODO on_success

--- a/ci/pipelines/build-and-push-java-lambdas.yml
+++ b/ci/pipelines/build-and-push-java-lambdas.yml
@@ -1,0 +1,32 @@
+resources:
+  - name: pay-java-lambdas
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-java-lambdas
+      branch: PP-12537
+      username: alphagov-pay-ci-concourse
+      password: ((github-access-token))
+  - name: ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/pay-ci
+      branch: PP-12537
+      username: alphagov-pay-ci-concourse
+      password: ((github-access-token))
+
+jobs:
+  - name: build
+    plan:
+      - get: src
+        resource: pay-java-lambdas
+        trigger: true
+      - get: ci
+        trigger: false
+      - task: build-java-lambdas
+        file: ci/ci/tasks/build-java-lambdas.yml
+        params:
+          app_name: pay-java-lambdas
+#        TODO on_failure
+#        TODO on_success

--- a/ci/pipelines/build-and-push-java-lambdas.yml
+++ b/ci/pipelines/build-and-push-java-lambdas.yml
@@ -7,7 +7,7 @@ resources:
       branch: main
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
-  - name: ci
+  - name: pay-ci
     type: git
     icon: github
     source:
@@ -22,9 +22,17 @@ jobs:
       - get: src
         resource: pay-java-lambdas
         trigger: true
-      - get: ci
+      - get: pay-ci
         trigger: false
       - task: build-java-lambdas
-        file: ci/ci/tasks/build-java-lambdas.yml
+        file: pay-ci/ci/tasks/build-java-lambdas.yml
 #        TODO on_failure
-#        TODO on_success
+#    TODO on_success:
+#      put: slack-notification
+#      params:
+#        channel: '#govuk-pay-activity'
+#        icon_emoji: ":fargate:"
+#        username: pay-concourse
+#        text: "((.:success_snippet)) \n\n
+#              <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse build #$BUILD_NAME>"
+

--- a/ci/pipelines/build-and-push-java-lambdas.yml
+++ b/ci/pipelines/build-and-push-java-lambdas.yml
@@ -12,7 +12,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/alphagov/pay-ci
-      branch: main
+      branch: master
       username: alphagov-pay-ci-concourse
       password: ((github-access-token))
 

--- a/ci/scripts/build-java-lambdas.sh
+++ b/ci/scripts/build-java-lambdas.sh
@@ -1,0 +1,41 @@
+#!/bin/ash
+# shellcheck shell=dash
+set -o pipefail
+
+cd src || exit
+
+git fetch origin main:main
+git diff --name-only --diff-filter=d main~ main | xargs -n 1 dirname | grep '^bin-ranges-' | cut -f 1 -d "/" |  uniq > submodules.txt
+echo "Submodules to build:"
+cat submodules.txt
+
+export MAVEN_HOME=/usr/lib/mvn
+export PATH=$MAVEN_HOME/bin:$PATH
+export MAVEN_REPO="$PWD/.m2"
+
+cat <<'EOF' >settings.xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+https://maven.apache.org/xsd/settings-1.0.0.xsd">
+<localRepository>${env.MAVEN_REPO}</localRepository>
+</settings>
+EOF
+
+PACKAGE_VERSION="1.0.$(date +"%Y%m%d%H%M%S")"
+echo "PACKAGE_VERSION=$PACKAGE_VERSION"
+mvn versions:set -DnewVersion="$PACKAGE_VERSION"
+
+while read -r line; do
+  mvn --global-settings settings.xml clean install --projects "$line" --also-make
+done < submodules.txt
+
+while read -r line; do
+  ls -alh "$line"/target
+  mkdir ../build/"$line"
+  cp "$line"/target/"$line"-*.jar ../build/"$line"
+done < submodules.txt
+
+cd ..
+echo "Folders written to:"
+ls -alh

--- a/ci/scripts/build-java-lambdas.sh
+++ b/ci/scripts/build-java-lambdas.sh
@@ -2,7 +2,7 @@
 # shellcheck shell=dash
 set -euo pipefail
 
-cd src || exit
+cd src
 
 git fetch origin main:main
 git diff --name-only --diff-filter=d main~ main | xargs -n 1 dirname | grep '^bin-ranges-' | cut -f 1 -d "/" |  uniq > submodules.txt

--- a/ci/scripts/build-java-lambdas.sh
+++ b/ci/scripts/build-java-lambdas.sh
@@ -1,9 +1,10 @@
 #!/bin/ash
 # shellcheck shell=dash
-set -o pipefail
+set -euo pipefail
 
 cd src || exit
 
+git fetch origin main:main
 git diff --name-only --diff-filter=d main~ main | xargs -n 1 dirname | grep '^bin-ranges-' | cut -f 1 -d "/" |  uniq > submodules.txt
 echo "Submodules to build:"
 cat submodules.txt

--- a/ci/scripts/build-java-lambdas.sh
+++ b/ci/scripts/build-java-lambdas.sh
@@ -37,5 +37,5 @@ while read -r line; do
 done < submodules.txt
 
 cd ..
-echo "Folders written to:"
-ls -alh
+echo "Folders written to in build directory:"
+ls -alh build

--- a/ci/scripts/build-java-lambdas.sh
+++ b/ci/scripts/build-java-lambdas.sh
@@ -4,7 +4,6 @@ set -o pipefail
 
 cd src || exit
 
-git fetch origin main:main
 git diff --name-only --diff-filter=d main~ main | xargs -n 1 dirname | grep '^bin-ranges-' | cut -f 1 -d "/" |  uniq > submodules.txt
 echo "Submodules to build:"
 cat submodules.txt

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -48,13 +48,18 @@ run:
     done < submodules.txt
     
     while read line; do
+      echo "target output for $line:"
+      ls -alh $line/target
       mkdir ../build/$line
       cp $line/target/$line-*.jar ../build/$line
     done < submodules.txt
     
     cd ..
     
-    ls -al build/bin-ranges-diff
-    ls -al build/bin-ranges-integrity
-    ls -al build/bin-ranges-promotion
-    ls -al build/bin-ranges-transfer
+    echo "FINAL BUILD OUTPUT:"
+    echo "ls -alh build/bin-ranges-diff"
+    ls -alh build/bin-ranges-diff
+    echo "ls -alh build/bin-ranges-promotion"
+    ls -alh build/bin-ranges-promotion
+    echo "ls -alh build/bin-ranges-transfer"
+    ls -alh build/bin-ranges-transfer

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -48,18 +48,7 @@ run:
     done < submodules.txt
     
     while read line; do
-      echo "target output for $line:"
       ls -alh $line/target
       mkdir ../build/$line
       cp $line/target/$line-*.jar ../build/$line
     done < submodules.txt
-    
-    cd ..
-    
-    echo "FINAL BUILD OUTPUT:"
-    echo "ls -alh build/bin-ranges-diff"
-    ls -alh build/bin-ranges-diff
-    echo "ls -alh build/bin-ranges-promotion"
-    ls -alh build/bin-ranges-promotion
-    echo "ls -alh build/bin-ranges-transfer"
-    ls -alh build/bin-ranges-transfer

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -44,7 +44,12 @@ run:
     mvn versions:set -DnewVersion="$PACKAGE_VERSION"
     
     while read line; do
-      mvn --global-settings settings.xml clean compile --projects $line --also-make
+      mvn --global-settings settings.xml clean install --projects $line --also-make
     done < submodules.txt
-#    cd ..
-#    cp -R src/* build
+    
+    cd ..
+    cp -R src/* build
+    ls -al build/bin-ranges-diff/target
+    ls -al build/bin-ranges-integrity/target
+    ls -al build/bin-ranges-promotion/target
+    ls -al build/bin-ranges-transfer/target

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -1,0 +1,44 @@
+container_limits: {}
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentdigitalservice/pay-concourse-runner-with-java-21
+caches:
+  - path: src/.m2
+inputs:
+  - name: src
+outputs:
+  - name: build
+params:
+  app_name:
+platform: linux
+run:
+  path: ash
+  args:
+  - -ec
+  - |
+    set -o pipefail
+    
+    cd src
+    
+    git fetch origin main:main
+    git diff --name-only --diff-filter=d main~ main | xargs -n 1 dirname | grep '^bin-ranges-' | cut -f 1 -d "/" |  uniq > submodules.txt
+    echo "Submodules to build:"
+    cat submodules.txt
+
+#    export MAVEN_HOME=/usr/lib/mvn
+#    export PATH=$MAVEN_HOME/bin:$PATH
+#    export MAVEN_REPO="$PWD/.m2"
+#
+#    cat <<'EOF' >settings.xml
+#    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+#          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+#          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+#                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+#          <localRepository>${env.MAVEN_REPO}</localRepository>
+#    </settings>
+#    EOF
+#
+#    mvn --global-settings settings.xml clean package
+#    cd ..
+#    cp -R src/* build

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -6,51 +6,12 @@ image_resource:
 caches:
   - path: src/.m2
 inputs:
-  - name: src
+  - name: ci
 outputs:
   - name: build
 params:
   app_name:
 platform: linux
 run:
-  path: ash
-  args:
-  - -ec
-  - |
-    #!/bin/ash
-    # shellcheck shell=dash
-    set -o pipefail
-  
-    cd src || exit
-    
-    git fetch origin main:main
-    git diff --name-only --diff-filter=d main~ main | xargs -n 1 dirname | grep '^bin-ranges-' | cut -f 1 -d "/" |  uniq > submodules.txt
-    echo "Submodules to build:"
-    cat submodules.txt
-    
-    export MAVEN_HOME=/usr/lib/mvn
-    export PATH=$MAVEN_HOME/bin:$PATH
-    export MAVEN_REPO="$PWD/.m2"
-    
-    cat <<'EOF' >settings.xml
-    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-    https://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <localRepository>${env.MAVEN_REPO}</localRepository>
-    </settings>
-    EOF
-    
-    PACKAGE_VERSION="1.0.$(date +"%Y%m%d%H%M%S")"
-    echo "PACKAGE_VERSION=$PACKAGE_VERSION"
-    mvn versions:set -DnewVersion="$PACKAGE_VERSION"
-  
-    while read -r line; do
-      mvn --global-settings settings.xml clean install --projects "$line" --also-make
-    done < submodules.txt
-    
-    while read -r line; do
-      ls -alh "$line"/target
-      mkdir ../build/"$line"
-      cp "$line"/target/"$line"-*.jar ../build/"$line"
-    done < submodules.txt
+  path: "/bin/ash"
+  args: ['ci/ci/scripts/build-java-lambdas.sh']

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -55,7 +55,6 @@ run:
       cp src/$line/target/$line-*.jar build/$line
     done < submodules.txt
     
-#    cp -R src/* build
     ls -al build/bin-ranges-diff/target
     ls -al build/bin-ranges-integrity/target
     ls -al build/bin-ranges-promotion/target

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -26,19 +26,25 @@ run:
     echo "Submodules to build:"
     cat submodules.txt
 
-#    export MAVEN_HOME=/usr/lib/mvn
-#    export PATH=$MAVEN_HOME/bin:$PATH
-#    export MAVEN_REPO="$PWD/.m2"
-#
-#    cat <<'EOF' >settings.xml
-#    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-#          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-#          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-#                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
-#          <localRepository>${env.MAVEN_REPO}</localRepository>
-#    </settings>
-#    EOF
-#
-#    mvn --global-settings settings.xml clean package
+    export MAVEN_HOME=/usr/lib/mvn
+    export PATH=$MAVEN_HOME/bin:$PATH
+    export MAVEN_REPO="$PWD/.m2"
+
+    cat <<'EOF' >settings.xml
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <localRepository>${env.MAVEN_REPO}</localRepository>
+    </settings>
+    EOF
+
+    PACKAGE_VERSION="1.0.$(date +"%Y%m%d%H%M%S")"
+    echo "PACKAGE_VERSION=$PACKAGE_VERSION"
+    mvn versions:set -DnewVersion="$PACKAGE_VERSION"
+    
+    while read line; do
+      mvn --global-settings settings.xml clean compile --projects $line --also-make
+    done < submodules.txt
 #    cd ..
 #    cp -R src/* build

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -48,7 +48,14 @@ run:
     done < submodules.txt
     
     cd ..
-    cp -R src/* build
+    
+    while read line; do
+      mkdir build
+      mkdir build/$line
+      cp src/$line/target/$line-*.jar build/$line
+    done < submodules.txt
+    
+#    cp -R src/* build
     ls -al build/bin-ranges-diff/target
     ls -al build/bin-ranges-integrity/target
     ls -al build/bin-ranges-promotion/target

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -6,7 +6,7 @@ image_resource:
 caches:
   - path: src/.m2
 inputs:
-  - name: ci
+  - name: pay-ci
   - name: src
 outputs:
   - name: build
@@ -15,4 +15,4 @@ params:
 platform: linux
 run:
   path: "/bin/ash"
-  args: ['ci/ci/scripts/build-java-lambdas.sh']
+  args: ['pay-ci/ci/scripts/build-java-lambdas.sh']

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -17,38 +17,40 @@ run:
   args:
   - -ec
   - |
+    #!/bin/ash
+    # shellcheck shell=dash
     set -o pipefail
-    
-    cd src
+  
+    cd src || exit
     
     git fetch origin main:main
     git diff --name-only --diff-filter=d main~ main | xargs -n 1 dirname | grep '^bin-ranges-' | cut -f 1 -d "/" |  uniq > submodules.txt
     echo "Submodules to build:"
     cat submodules.txt
-
+    
     export MAVEN_HOME=/usr/lib/mvn
     export PATH=$MAVEN_HOME/bin:$PATH
     export MAVEN_REPO="$PWD/.m2"
-
+    
     cat <<'EOF' >settings.xml
     <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <localRepository>${env.MAVEN_REPO}</localRepository>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+    https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository>${env.MAVEN_REPO}</localRepository>
     </settings>
     EOF
-
+    
     PACKAGE_VERSION="1.0.$(date +"%Y%m%d%H%M%S")"
     echo "PACKAGE_VERSION=$PACKAGE_VERSION"
     mvn versions:set -DnewVersion="$PACKAGE_VERSION"
-    
-    while read line; do
-      mvn --global-settings settings.xml clean install --projects $line --also-make
+  
+    while read -r line; do
+      mvn --global-settings settings.xml clean install --projects "$line" --also-make
     done < submodules.txt
     
-    while read line; do
-      ls -alh $line/target
-      mkdir ../build/$line
-      cp $line/target/$line-*.jar ../build/$line
+    while read -r line; do
+      ls -alh "$line"/target
+      mkdir ../build/"$line"
+      cp "$line"/target/"$line"-*.jar ../build/"$line"
     done < submodules.txt

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -7,6 +7,7 @@ caches:
   - path: src/.m2
 inputs:
   - name: ci
+  - name: src
 outputs:
   - name: build
 params:

--- a/ci/tasks/build-java-lambdas.yml
+++ b/ci/tasks/build-java-lambdas.yml
@@ -47,15 +47,14 @@ run:
       mvn --global-settings settings.xml clean install --projects $line --also-make
     done < submodules.txt
     
-    cd ..
-    
     while read line; do
-      mkdir build
-      mkdir build/$line
-      cp src/$line/target/$line-*.jar build/$line
+      mkdir ../build/$line
+      cp $line/target/$line-*.jar ../build/$line
     done < submodules.txt
     
-    ls -al build/bin-ranges-diff/target
-    ls -al build/bin-ranges-integrity/target
-    ls -al build/bin-ranges-promotion/target
-    ls -al build/bin-ranges-transfer/target
+    cd ..
+    
+    ls -al build/bin-ranges-diff
+    ls -al build/bin-ranges-integrity
+    ls -al build/bin-ranges-promotion
+    ls -al build/bin-ranges-transfer


### PR DESCRIPTION
Pipeline to test and build pay-java-lambdas JARs. Only the relevant submodules for the last pay-java-lambda's commit are built.

Pushing the JARs to the s3 bucket(s) is another task in itself and will be in the next PR.

See example output at https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/build-and-push-java-lambdas/jobs/build/builds/32:
```
FINAL BUILD OUTPUT:
ls -alh build/bin-ranges-diff
total 25M    
drwxr-xr-x    2 root     root        4.0K Apr 15 13:56 .
drwxr-xr-x    5 root     root        4.0K Apr 15 13:56 ..
-rw-r--r--    1 root     root       24.8M Apr 15 13:56 bin-ranges-diff-1.0.20240415135459.jar
ls -alh build/bin-ranges-promotion
total 25M    
drwxr-xr-x    2 root     root        4.0K Apr 15 13:56 .
drwxr-xr-x    5 root     root        4.0K Apr 15 13:56 ..
-rw-r--r--    1 root     root       24.8M Apr 15 13:56 bin-ranges-promotion-1.0.20240415135459.jar
ls -alh build/bin-ranges-transfer
total 37M    
drwxr-xr-x    2 root     root        4.0K Apr 15 13:56 .
drwxr-xr-x    5 root     root        4.0K Apr 15 13:56 ..
-rw-r--r--    1 root     root       37.4M Apr 15 13:56 bin-ranges-transfer-1.0.20240415135459.jar
```
which shows the relevant JARs have been copied to the `build` output.