### PR TITLE
PP-12494: Add init lock pools pipeline in pay-deploy and pay-dev

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -1,0 +1,51 @@
+extends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+
+import "../pipeline_self_update.pkl"
+import "../shared_resources.pkl"
+
+hidden pools_to_init = new Listing<String> {}
+
+hidden concourseTeamName = "UPDATE_ME"
+
+resources {
+  new {
+    name = "lock-pool-repo"
+    type = "git"
+    icon = "git"
+    source {
+      ["branch"] = "pool"
+      ["uri"] = "((readonly_codecommit_pool_uri))"
+      ["private_key"] = "((readonly_codecommit_private_key))"
+    }
+  }
+  (shared_resources.payCiGitHubResource) {
+    source {
+      branch = "pp-12494/add-init-pool-pipeline"
+    }
+  }
+  pipeline_self_update.PayPipelineSelfUpdateResource("\(concourseTeamName)/init-lock-pools.pkl", "master")
+}
+
+jobs {
+  new Job {
+    name = "initialise-pools"
+    plan {
+      new GetStep { get = "pay-ci" }
+      new TaskStep {
+        task = "init-pools"
+        file = "pay-ci/ci/tasks/init-lock-pools.yml"
+        params {
+          ["POOLS_TO_INIT"] = pools_to_init.toList().join(",")
+        }
+      }
+      new PutStep {
+        put = "lock-pool-repo"
+        params {
+          ["repository"] = "lock-pool-repo"
+          ["force"] = "true"
+        }
+      }
+    }
+  }
+  pipeline_self_update.PayPipelineSelfUpdateJob("\(concourseTeamName)/init-lock-pools.pkl")
+}

--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -18,11 +18,7 @@ resources {
       ["private_key"] = "((readonly_codecommit_private_key))"
     }
   }
-  (shared_resources.payCiGitHubResource) {
-    source {
-      branch = "pp-12494/add-init-pool-pipeline"
-    }
-  }
+  shared_resources.payCiGitHubResource
   pipeline_self_update.PayPipelineSelfUpdateResource("\(concourseTeamName)/init-lock-pools.pkl", "master")
 }
 

--- a/ci/pkl-pipelines/pay-deploy/init-lock-pools.pkl
+++ b/ci/pkl-pipelines/pay-deploy/init-lock-pools.pkl
@@ -1,0 +1,8 @@
+amends "../common/shared_pipelines/init_lock_pools.pkl"
+
+pools_to_init {
+  "deploy-application"
+  "smoke-test"
+}
+
+concourseTeamName = "pay-deploy"

--- a/ci/pkl-pipelines/pay-dev/init-lock-pools.pkl
+++ b/ci/pkl-pipelines/pay-dev/init-lock-pools.pkl
@@ -1,0 +1,12 @@
+amends "../common/shared_pipelines/init_lock_pools.pkl"
+
+pools_to_init {
+  "deploy-application"
+  "integration-test"
+  "node-test"
+  "unit-test"
+  "perf-tests"
+  "smoke-test"
+}
+
+concourseTeamName = "pay-dev"

--- a/ci/scripts/init-lock-pools.sh
+++ b/ci/scripts/init-lock-pools.sh
@@ -1,0 +1,23 @@
+#!/bin/ash
+
+set -euo pipefail
+
+git config --global user.email "concourse-pools-init@concourse.local"
+git config --global user.name "Concourse init-lock-pools job"
+
+git init .
+
+if [ -z "$POOLS_TO_INIT" ]; then
+  echo "ERROR: Must set POOLS_TO_INIT env var to a non-empty string, this should be a comma separated list of pools to init."
+  exit 1
+fi
+
+for POOL in $(echo "$POOLS_TO_INIT" | tr "," "\n"); do
+  echo "Making Pool $POOL"
+  mkdir -p "$POOL/claimed"
+  mkdir -p "$POOL/unclaimed"
+  touch "$POOL/claimed/.gitkeep"
+  touch "$POOL/unclaimed/.gitkeep"
+  git add "$POOL"
+  git commit -m "Setup $POOL"
+done

--- a/ci/tasks/init-lock-pools.yml
+++ b/ci/tasks/init-lock-pools.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentdigitalservice/pay-concourse-runner
+inputs:
+  - name: pay-ci
+outputs:
+  - name: lock-pool-repo
+params:
+  POOLS_TO_INIT:
+run:
+  path: "/bin/ash"
+  dir: "lock-pool-repo/"
+  args: ['../pay-ci/ci/scripts/init-lock-pools.sh']


### PR DESCRIPTION
I had said I wasn't going to do this the right way initially, but actually it's far easier to get concourse to make the pools than it is for me to setup manual code commit access, so I just made the pipelines which provision the lock pools for the existing pipelines.

In order to use the concourse pool resource we have to init the pools. I took inspriation from:

https://github.com/alphagov/pay-concourse/blob/main/pipelines/concourse-deployer.yml#L459-L469
https://github.com/alphagov/pay-concourse/blob/main/pipelines/tasks/test-init-pool.yml

And also the docs for the concourse pool resource: https://github.com/concourse/pool-resource

This initialises pay-dev and pay-deploy pools (each team has it's own team) with pools that mimic the existing serial groups.

I've run the init job for the pay-deploy team and you can see it working https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/init-lock-pools/jobs/initialise-pools/builds/10 and see the codecommit repo with the files in at https://eu-west-1.console.aws.amazon.com/codesuite/codecommit/repositories/pool-resource-pay-cd-pay-deploy/browse?region=eu-west-1 (It's in the deploy account, so you'll need to log into that to see it)