### PR TITLE
PP-12494: Add locks to pools on init

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -2,6 +2,7 @@ extends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/p
 
 import "../pipeline_self_update.pkl"
 import "../shared_resources.pkl"
+import "../shared_resources_for_lock_pools.pkl"
 
 hidden pools_to_init = new Listing<String> {}
 
@@ -16,6 +17,19 @@ resources {
       ["branch"] = "pool"
       ["uri"] = "((readonly_codecommit_pool_uri))"
       ["private_key"] = "((readonly_codecommit_private_key))"
+    }
+  }
+  for (pool_name in pools_to_init) {
+    (shared_resources_for_lock_pools.LockPoolResource) { pool = pool_name }
+    new {
+      name = "\(pool_name)-lock-config"
+      type = "mock"
+      source {
+        ["create_files"] = new Mapping<String, String> {
+          ["name"] = "\(pool_name)-lock"
+          ["metadata"] = ""
+        }
+      }
     }
   }
   shared_resources.payCiGitHubResource
@@ -39,6 +53,22 @@ jobs {
         params {
           ["repository"] = "lock-pool-repo"
           ["force"] = "true"
+        }
+      }
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          for (pool in pools_to_init) {
+            new GetStep {get = "\(pool)-lock-config" }
+          }
+        }
+      }
+      for (pool in pools_to_init) {
+        new PutStep {
+          put = "add-\(pool)-lock"
+          resource = "lock-pool-\(pool)"
+          params {
+            ["add"] = "\(pool)-lock-config"
+          }
         }
       }
     }

--- a/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
@@ -1,0 +1,32 @@
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+
+class LockPoolResource extends Pipeline.Resource {
+  hidden pool: String
+  name = "lock-pool-\(pool)"
+  type = "pool"
+  icon = "pool"
+  source {
+    ["branch"] = "pool"
+    ["uri"] = "((readonly_codecommit_pool_uri))"
+    ["private_key"] = "((readonly_codecommit_private_key))"
+    ["pool"] = pool
+  }
+}
+
+class AcquireLockStep extends Pipeline.PutStep {
+  hidden pool: String
+  put = "claim-\(pool)-lock"
+  resource = "lock-pool-\(pool)"
+  params {
+    ["claim"] = "\(pool)-lock"
+  }
+}
+
+class ReleaseLockStep extends Pipeline.PutStep {
+  hidden pool: String
+  put = "release-\(pool)-lock"
+  resource = "lock-pool-\(pool)"
+  params {
+    ["release"] = "claim-\(pool)-lock"
+  }
+}


### PR DESCRIPTION
As well as setting up the lock pools, we need to actually add some locks into the pools which are the things that will actually be claimed and released.

I've tried this out and you can see a successful init in pay-deploy: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/init-lock-pools/jobs/initialise-pools/builds/14

I've also made a test-locks pipeline (not to be committed) which demonstrates it in use. All 3 jobs try and acquire the same lock, and then release it at the end. If you start them all you can watch them behave as expected (one claims the lock, the others wait until it's released before continuing) https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/test-locks