### PR TITLE
PP-12494: Add jobs to force release locks

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -73,5 +73,14 @@ jobs {
       }
     }
   }
+  for (pool_name in pools_to_init) {
+    new Job {
+      name = "force-release-\(pool_name)-lock"
+      plan {
+        new shared_resources_for_lock_pools.GetLockStep { pool = pool_name }
+        new shared_resources_for_lock_pools.ReleaseLockStep { pool = pool_name }
+      }
+    }
+  }
   pipeline_self_update.PayPipelineSelfUpdateJob("\(concourseTeamName)/init-lock-pools.pkl")
 }

--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -78,7 +78,12 @@ jobs {
       name = "force-release-\(pool_name)-lock"
       plan {
         new shared_resources_for_lock_pools.GetLockStep { pool = pool_name }
-        new shared_resources_for_lock_pools.ReleaseLockStep { pool = pool_name }
+        new shared_resources_for_lock_pools.ReleaseLockStep {
+          pool = pool_name
+          params {
+            ["release"] = "get-already-claimed-\(pool_name)-lock"
+          }
+        }
       }
     }
   }

--- a/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
@@ -31,3 +31,9 @@ class ReleaseLockStep extends Pipeline.PutStep {
     ["release"] = "claim-\(pool)-lock"
   }
 }
+
+class GetLockStep extends Pipeline.GetStep {
+  hidden pool: String
+  get = "get-already-claimed-\(pool)-lock"
+  resource = "lock-pool-\(pool)"
+}


### PR DESCRIPTION
This adds job which allow us to force unlock a claimed lock.

You can see this where I got a test lock, then force unlcoked it. You can see the lock was claimed in https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/test-locks/jobs/test-lock-1/builds/2 at 16:55:01

![Screenshot 2024-04-17 at 16 57 38](https://github.com/alphagov/pay-ci/assets/2170030/0782a7c0-a2bd-465d-9cb7-ed892129e2c1)

Then force unlocked in https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/init-lock-pools/jobs/force-release-test-locks-lock/builds/3 at 16:55:07

![Screenshot 2024-04-17 at 16 57 42](https://github.com/alphagov/pay-ci/assets/2170030/f95fcfb4-87f1-4cb2-8df9-93e6db0bee9a)


Then the original test lock job https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/test-locks/jobs/test-lock-1/builds/2 fails (correctly) to release the (already force released) lock at 16:55:57 (See the first screenshot again)
