### PR TITLE
BAU: Fix e2e-helpers pipeline

### DIFF
--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -8,10 +8,6 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
   shared_resources.payCiGitHubResource
 
-  (shared_resources.payGithubResourceWithBranch("e2e-helpers-pipeline", "pay-ci", "master")) {
-    source { ["paths"] = new Listing<String> { "ci/pipelines/e2e-helpers.yml" } }
-  }
-
   shared_resources.payGithubResourceWithBranch("endtoend-git-release", "pay-endtoend", "master")
     |>withTagRegex("alpha_release-(.*)")
 


### PR DESCRIPTION
The resource "e2e-helpers-pipeline" was used prior to using the pipeline self update tasks, it no longer has any jobs using it and trying to set the piepline generates the error https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/e2e-helpers/jobs/update-pipeline/builds/1

```
error: invalid pipeline config:
invalid resources:
	resource 'e2e-helpers-pipeline' is not used

```