### PR TITLE
PP-12562-use-locks-in-deploy-to-staging

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -168,7 +168,7 @@ local function getJobToSmokeTestApp(app): Job = new {
   on_failure = sendSlackNoticationAndPutMetrics(app,
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_sidecar_metrics = false })
-  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application" }
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "smoke-test" }
 
 }
 

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -6,6 +6,7 @@ import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_annotations.pkl"
+import "../common/shared_resources_for_lock_pools.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -29,6 +30,8 @@ resources = new {
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
   shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application" }
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test" }
 
   for (app in allPayApplications) {
     shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-staging",
@@ -91,15 +94,12 @@ jobs {
   getJobToDeployScheduledTasks()
 }
 
-
 local function getJobToDeployApp(app): Job = new {
   name = "deploy-\(app.name)-to-staging"
   serial = true
-  serial_groups {
-    "deploy-application"
-  }
   plan = new {
     getResourcesToDeployApp(app)
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "deploy-application" }
     parseReleaseTagsToDeployApp(app)
     loadVariablesToDeployApp(app)
     createNotificationSnippets(app, "Deployment")
@@ -130,9 +130,6 @@ local function getJobToDeployApp(app): Job = new {
 
 local function getJobToSmokeTestApp(app): Job = new {
   name = "smoke-test-\(app.name)-on-staging"
-  serial_groups {
-    "smoke-test"
-  }
   plan = new {
     new InParallelStep {
       in_parallel = new InParallelConfig {
@@ -145,6 +142,8 @@ local function getJobToSmokeTestApp(app): Job = new {
         }
       }
     }
+
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "smoke-test" }
 
     new TaskStep {
       task = "parse-ecr-release-tag"
@@ -168,6 +167,8 @@ local function getJobToSmokeTestApp(app): Job = new {
   on_failure = sendSlackNoticationAndPutMetrics(app,
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_sidecar_metrics = false })
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application" }
+
 }
 
 local function getJobToPactTagApp(app): Job = new {

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -126,6 +126,7 @@ local function getJobToDeployApp(app): Job = new {
   on_failure = sendSlackNoticationAndPutMetrics(app,
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_sidecar_metrics = true })
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application" }
 }
 
 local function getJobToSmokeTestApp(app): Job = new {


### PR DESCRIPTION
In deploy-to-staging, replace smoke test and app-deploy serial groups with lock pools.

[Here](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-staging/jobs/deploy-toolbox-to-staging/builds/477) is a run of deploy-toolbox which waited for deploy-adminusers to complete and release the lock.

And [here](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/deploy-to-staging/jobs/smoke-test-products-on-staging/builds/259) is smoke-test-products waiting for smoke-test-adminusers to finish.