### PR TITLE
PP-12584 Reusable workflows for Java tests

### DIFF
--- a/.github/workflows/_run-app-as-provider-contract-tests.yml
+++ b/.github/workflows/_run-app-as-provider-contract-tests.yml
@@ -1,0 +1,68 @@
+# This workflow is meant to be run on a pact provider build. It will check pacts
+# all the consumers that depend on it against itself (the provider).
+#
+name: Provider Contract Tests
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        type: string
+        required: false
+        default: 11
+        description: JDK version to setup and run tests. Defaults to 11
+    secrets:
+      pact_broker_username:
+        required: true
+      pact_broker_password:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  provider-contract-tests:
+    name: App as provider contract tests
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Set up JDK ${{ inputs.java_version }}
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Pull docker image dependencies
+        run: |
+          docker pull postgres:15.2
+      - name: Set Pact Provider Version
+        id: set-pact-provider-version
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Github actually creates a phantom merge commit on PR actions, but we want to record
+            # in the pact broker something we can actually trace back to a PR, using the _actual_
+            # phantom merge commit sha (github.sha) would make this essentially impossible for us
+            PROVIDER_VERSION=${{ github.event.pull_request.head.sha }}
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            PROVIDER_VERSION=${{ github.sha }}
+          else
+            echo "Unknown type to get provider tag from, failing on purpose"
+            exit 1
+          fi
+          echo "Setting Provider version to ${PROVIDER_VERSION}"
+          echo "pact-provider-version=${PROVIDER_VERSION}" >> $GITHUB_OUTPUT
+      - name: Run provider contract tests
+        run: |
+          mvn test --no-transfer-progress \
+          -DrunContractTests \
+          -DPACT_CONSUMER_TAG=master \
+          -DPACT_BROKER_USERNAME=${{ secrets.pact_broker_username }} \
+          -DPACT_BROKER_PASSWORD=${{ secrets.pact_broker_password }} \
+          -Dpact.provider.version=${{ steps.set-pact-provider-version.outputs.pact-provider-version }} \
+          -Dpact.verifier.publishResults=true

--- a/.github/workflows/_run-java-tests-and-publish-pacts.yml
+++ b/.github/workflows/_run-java-tests-and-publish-pacts.yml
@@ -1,0 +1,124 @@
+name: Github Actions - Java tests
+
+on:
+  workflow_call:
+    inputs:
+      publish_pacts:
+        type: boolean
+        required: false
+        default: false
+        description: Set to `true` if app is a consumer and to publish pacts
+      java_version:
+        type: string
+        required: false
+        default: 11
+        description: JDK version to setup and run tests. Defaults to 11
+    secrets:
+      pact_broker_username:
+        required: false
+        description: required if `publish_pacts` is `true`
+      pact_broker_password:
+        required: false
+        description: required if `publish_pacts` is `true`
+
+permissions:
+  contents: read
+
+jobs:
+  integration-tests:
+    name: Unit and Integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Set up JDK ${{ inputs.java_version }}
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Cache pacts directory
+        if: ${{ inputs.publish_pacts }}
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: target/pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
+      - name: Pull docker image dependencies
+        run: |
+          docker pull postgres:15.2
+      - name: Compile
+        run: mvn clean compile --no-transfer-progress
+      - name: Check for OpenApi file changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo "Changes to the OpenApi file have not been committed. Run \`mvn compile\` on your branch to regenerate the file and then commit the changes."
+            exit 1
+          fi
+      - name: Run unit and integration tests
+        run: |
+          mvn verify --no-transfer-progress
+
+  publish-consumer-contracts:
+    if: ${{ inputs.publish_pacts }}
+    needs:
+      - integration-tests
+    runs-on: ubuntu-latest
+    name: Publish consumer pacts
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Set up JDK ${{ inputs.java_version }}
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Cache pacts directory
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: target/pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
+      - name: Check for generated pacts
+        run: |
+          if [ ! -d target/pacts ]; then
+            echo "The pact files were not generated, this means that no pact results will be published and this build will fail to deploy"
+            exit 1
+          fi
+      - name: Set Pact Consumer variables
+        id: set-pact-consumer-variables
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Github actually creates a phantom merge commit on PR actions, but we want to record
+            # in the pact broker something we can actually trace back to a PR, using the _actual_
+            # phantom merge commit sha (github.sha) would make this essentially impossible for us
+            CONSUMER_VERSION=${{ github.event.pull_request.head.sha }}
+            CONSUMER_TAG=${{ github.event.pull_request.number }}
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            CONSUMER_VERSION=${{ github.sha }}
+            CONSUMER_TAG=master
+          else
+            echo "Unknown type to get consumer tag from, failing on purpose"
+            exit 1
+          fi
+          echo "Setting Consumer version to ${CONSUMER_VERSION}"
+          echo "pact-consumer-version=${CONSUMER_VERSION}" >> $GITHUB_OUTPUT
+          echo "Setting Consumer tag to ${CONSUMER_TAG}"
+          echo "pact-consumer-tag=${CONSUMER_TAG}" >> $GITHUB_OUTPUT
+      - name: Publish consumer pacts
+        run: |
+          mvn pact:publish --no-transfer-progress \
+          -DPACT_BROKER_URL=https://pact-broker.deploy.payments.service.gov.uk \
+          -DrunConsumerContractTests \
+          -DPACT_BROKER_USERNAME=${{ secrets.pact_broker_username }} \
+          -DPACT_BROKER_PASSWORD=${{ secrets.pact_broker_password }} \
+          -DPACT_CONSUMER_TAG=${{ steps.set-pact-consumer-variables.outputs.pact-consumer-tag }} \
+          -DPACT_CONSUMER_VERSION=${{ steps.set-pact-consumer-variables.outputs.pact-consumer-version }}

--- a/.github/workflows/_run-provider-pact-tests-for-consumer.yml
+++ b/.github/workflows/_run-provider-pact-tests-for-consumer.yml
@@ -1,0 +1,85 @@
+name: Github Actions - Provider tests for consumer
+
+on:
+  workflow_call:
+    inputs:
+      consumer:
+        description: Name of the consumer app, e.g. frontend
+        required: true
+        type: string
+      provider:
+        type: string
+        required: true
+        description: Name of the provider. Example -  connector
+      java_version:
+        type: string
+        required: false
+        default: 11
+    secrets:
+      pact_broker_username:
+        required: true
+      pact_broker_password:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  provider-contract-tests-for-consumer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        with:
+          repository: alphagov/pay-${{ inputs.provider }}
+          path: pay-${{ inputs.provider }}
+      - name: Get Provider SHA
+        id: get-provider-sha
+        run: |
+          cd pay-${{ inputs.provider }}
+          echo "provider-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo $provider-sha
+      - name: Set up JDK ${{ inputs.java_version }}
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Pull docker image dependencies
+        run: |
+          docker pull postgres:15.2
+      - name: Set Pact Consumer variables
+        id: set-pact-consumer-variables
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Github actually creates a phantom merge commit on PR actions, but we want to record
+            # in the pact broker something we can actually trace back to a PR, using the _actual_
+            # phantom merge commit sha (github.sha) would make this essentially impossible for us
+            CONSUMER_TAG=${{ github.event.pull_request.number }}
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            CONSUMER_TAG=master
+          else
+            echo "Unknown type to get consumer tag from, failing on purpose"
+            exit 1
+          fi
+          echo "Setting Consumer Tag to ${CONSUMER_TAG}"
+          echo "pact-consumer-tag=${CONSUMER_TAG}" >> $GITHUB_OUTPUT
+      - name: Run provider pact tests
+        run: |
+          export MAVEN_REPO="$HOME/.m2"
+          cd pay-${{ inputs.provider }}
+
+          mvn test --no-transfer-progress \
+          --batch-mode \
+          -DrunContractTests \
+          -DCONSUMER="${{ inputs.consumer }}" \
+          -DPACT_CONSUMER_TAG="${{ steps.set-pact-consumer-variables.outputs.pact-consumer-tag }}" \
+          -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \
+          -DPACT_BROKER_PASSWORD="${{ secrets.pact_broker_password }}" \
+          -DPACT_BROKER_HOST=pact-broker.deploy.payments.service.gov.uk \
+          -Dpact.provider.version="${{ steps.get-provider-sha.outputs.provider-sha }}" \
+          -Dpact.verifier.publishResults=true

--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Detect secrets
         uses: alphagov/pay-ci/actions/detect-secrets@master


### PR DESCRIPTION
## WHAT
- Added reusable GitHub actions workflow to
   - run integration tests for Java apps and publish pact (based on input param)
   - run app as provider contract tests
   - run pact provider tests for consumer

Used workflows in adminusers PR
- https://github.com/alphagov/pay-adminusers/pull/2486
- Test run: https://github.com/alphagov/pay-adminusers/actions/runs/8923066283 
<img width="962" alt="image" src="https://github.com/alphagov/pay-ci/assets/40598480/c2146595-3ddc-4340-af90-0768385de8f0">


- and a PR demonstrating failed pact tests on PR https://github.com/alphagov/pay-adminusers/pull/2491