### PR TITLE
PP-12588 Reusable GitHub action workflows for node apps

### DIFF
--- a/.github/workflows/_run-node-cypress-tests.yml
+++ b/.github/workflows/_run-node-cypress-tests.yml
@@ -1,0 +1,41 @@
+name: Github Actions for NodeJS apps - run cypress tests
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  cypress-tests:
+    runs-on: ubuntu-latest
+    name: Cypress tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Setup
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache build directories
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Parse Cypress version
+        id: parse-cypress-version
+        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
+      - name: Cache Cypress
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ steps.parse-cypress-version.outputs.CYPRESS_VERSION }}
+      - name: Run cypress tests
+        run: |
+          npm run cypress:server > /dev/null 2>&1 &
+          sleep 3
+          npm run cypress:test

--- a/.github/workflows/_run-node-install-and-compile.yml
+++ b/.github/workflows/_run-node-install-and-compile.yml
@@ -1,0 +1,56 @@
+name: Github Actions for NodeJS apps - Install and Compile
+
+on:
+  workflow_call:
+    inputs:
+      has_cypress_tests:
+        type: boolean
+        required: false
+        default: false
+        description: Set to `true` if app has cypress tests
+
+permissions:
+  contents: read
+
+jobs:
+  install-and-compile:
+    runs-on: ubuntu-latest
+    name: Install and compile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Setup
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache build directories
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Cache NPM packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+      - name: Parse Cypress version
+        if: ${{ inputs.has_cypress_tests }}
+        id: parse-cypress-version
+        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
+      - name: Cache Cypress
+        if: ${{ inputs.has_cypress_tests }}
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ steps.parse-cypress-version.outputs.CYPRESS_VERSION }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile
+        run: npm run compile
+      - name: Run lint
+        run: npm run lint

--- a/.github/workflows/_run-node-unit-tests-and-publish-pacts.yml
+++ b/.github/workflows/_run-node-unit-tests-and-publish-pacts.yml
@@ -1,0 +1,109 @@
+name: Github Actions for NodeJS apps - run unit tests and publish pacts
+
+on:
+  workflow_call:
+    inputs:
+      publish_pacts:
+        type: boolean
+        required: false
+        default: false
+        description: Set to `true` if app is a consumer and to publish pacts
+    secrets:
+      pact_broker_username:
+        required: false
+        description: required if `publish_pacts` is `true`
+      pact_broker_password:
+        required: false
+        description: required if `publish_pacts` is `true`
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    name: Unit tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Setup
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache build directories
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Cache pacts directory
+        if: ${{ inputs.publish_pacts }}
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
+      - name: Run unit tests
+        run: npm test -- --forbid-only --forbid-pending
+
+  publish-consumer-contracts:
+    if: ${{ inputs.publish_pacts }}
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    name: Publish and tag consumer pacts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Setup
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache build directories
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Cache pacts directory
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
+      - name: Check for generated pacts
+        run: |
+          if [ ! -d pacts ]; then
+            echo "The pact files were not generated, this means that no pact results will be published and this build will fail to deploy"
+            exit 1
+          fi
+      - name: Set Pact Consumer variables
+        id: set-pact-consumer-variables
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Github actually creates a phantom merge commit on PR actions, but we want to record
+            # in the pact broker something we can actually trace back to a PR, using the _actual_
+            # phantom merge commit sha (github.sha) would make this essentially impossible for us
+            CONSUMER_VERSION=${{ github.event.pull_request.head.sha }}
+            CONSUMER_TAG=${{ github.event.pull_request.number }}
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]] || [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            CONSUMER_VERSION=${{ github.sha }}
+            CONSUMER_TAG=master
+          else
+            echo "Unknown type to get consumer tag from, failing on purpose"
+            exit 1
+          fi
+          echo "Setting Consumer version to ${CONSUMER_VERSION}"
+          echo "pact-consumer-version=${CONSUMER_VERSION}" >> $GITHUB_OUTPUT
+          echo "Setting Consumer tag to ${CONSUMER_TAG}"
+          echo "pact-consumer-tag=${CONSUMER_TAG}" >> $GITHUB_OUTPUT
+      - name: Publish and tag consumer pacts
+        env:
+          PACT_BROKER_URL: https://pact-broker.deploy.payments.service.gov.uk
+          PACT_BROKER_USERNAME: ${{ secrets.pact_broker_username }}
+          PACT_BROKER_PASSWORD: ${{ secrets.pact_broker_password }}
+          PACT_CONSUMER_TAG: ${{ steps.set-pact-consumer-variables.outputs.pact-consumer-tag }}
+          PACT_CONSUMER_VERSION: ${{ steps.set-pact-consumer-variables.outputs.pact-consumer-version }}
+        run: npm run publish-pacts

--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         with:
           fetch-depth: 1
       - name: Validate base images are manifests


### PR DESCRIPTION
## WHAT
- Added reusable workflow to run node tests
- Added separate workflows for install-and-compile, unit-tests and cypress-tests so we can run unit-tests and cypress-tests in parallel


Selfservice [PR](https://github.com/alphagov/pay-selfservice/pull/4218) tests demonstrating use of workflows
https://github.com/alphagov/pay-selfservice/actions/runs/9005006437