### PR TITLE
PP-12571 Remove cardId tests

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -216,9 +216,6 @@ groups:
 
   - name: cardid
     jobs:
-      - cardid-unit-test
-      - cardid-integration-test
-      - cardid-as-provider-pact-test
       - cardid-e2e
 
   - name: connector
@@ -1074,63 +1071,6 @@ jobs:
     on_failure:
       <<: *put-e2e-failed-status
       put: adminusers-pull-request
-
-  - <<: *job-definition
-    name: cardid-unit-test
-    serial_groups: [unit-test]
-    plan:
-    - <<: *get-pull-request
-      resource: cardid-pull-request
-    - <<: *get-ci
-    - <<: *put-unit-tests-pending-status
-      put: cardid-pull-request
-    - <<: *run-java-unit-test
-      params:
-        app_name: cardid
-      on_failure:
-        <<: *put-unit-test-failed-status
-        put: cardid-pull-request
-    - <<: *put-unit-test-success-status
-      put: cardid-pull-request
-
-  - <<: *job-definition
-    name: cardid-integration-test
-    serial_groups: [integration-test]
-    plan:
-    - <<: *get-pull-request
-      resource: cardid-pull-request
-    - <<: *put-integration-test-pending-status
-      put: cardid-pull-request
-    - <<: *get-ci
-    - <<: *run-java-integration-tests
-      on_failure:
-        <<: *put-integration-test-failed-status
-        put: cardid-pull-request
-    - <<: *publish-pacts
-      params:
-        consumer_name: cardid
-    - <<: *put-integration-test-success-status
-      put: cardid-pull-request
-
-  - <<: *job-definition
-    name: cardid-as-provider-pact-test
-    plan:
-    - <<: *get-pull-request
-      resource: cardid-pull-request
-    - <<: *put-pact-provider-pending-status
-      put: cardid-pull-request
-    - <<: *get-ci
-    - <<: *pact-provider-test-preflight-check
-    - <<: *pact-provider-verification
-      input_mapping:
-        test_target: src
-      params:
-        provider: cardid
-      on_failure:
-        <<: *put-pact-provider-failed-status
-        put: cardid-pull-request
-    - <<: *put-pact-provider-success-status
-      put: cardid-pull-request
 
   - <<: *job-definition
     name: cardid-e2e


### PR DESCRIPTION
# WHAT
- Removed all (except E2E) cardId tests from Concourse

Depends on https://github.com/alphagov/pay-cardid/pull/1208