### PR TITLE
BAU: Fix shared lock pools so they are limited to a single pipeline

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -36,8 +36,8 @@ resources = new {
       app.getECRRepo(), "pay_aws_prod_account_id", "release")
   }
 
-  new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test" }
-  new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application" }
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test-production" }
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-production" }
   shared_resources_for_slack_notifications.slackNotificationResource
   (shared_resources_for_annotations.grafanaAnnotationResource) {
     source { ["tags"] = new Listing<String> { "release" "production-2" } }
@@ -109,7 +109,7 @@ local function getJobToDeployApp(app): Job = new {
 
   plan = new {
     getResourcesToDeployApp(app)
-    new shared_resources_for_lock_pools.AcquireLockStep { pool = "deploy-application" }
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "deploy-application-production" }
     parseReleaseTagsToDeployApp(app)
     loadVariablesToDeployApp(app)
     createNotificationSnippets(app, "Deployment")
@@ -136,7 +136,7 @@ local function getJobToDeployApp(app): Job = new {
   on_failure = sendSlackNoticationAndPutMetrics(app,
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_sidecar_metrics = true })
-  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application" }
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application-production" }
 }
 
 local function getJobToSmokeTestApp(app): Job = new {
@@ -153,7 +153,7 @@ local function getJobToSmokeTestApp(app): Job = new {
         }
       }
     }
-    new shared_resources_for_lock_pools.AcquireLockStep { pool = "smoke-test" }
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "smoke-test-production" }
     loadVar("application_image_tag", "\(app.name)-ecr-registry-prod/tag")
     createNotificationSnippets(app, "Smoke test")
     loadNotificationSnippetVariables(app, false)
@@ -168,7 +168,7 @@ local function getJobToSmokeTestApp(app): Job = new {
   on_failure = sendSlackNoticationAndPutMetrics(app,
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_sidecar_metrics = false })
-  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "smoke-test" }
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "smoke-test-production" }
 }
 
 local function getJobToPactTagApp(app): Job = new {

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -30,8 +30,8 @@ resources = new {
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
   shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
-  new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application" }
-  new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test" }
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-staging" }
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test-staging" }
 
   for (app in allPayApplications) {
     shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-staging",
@@ -99,7 +99,7 @@ local function getJobToDeployApp(app): Job = new {
   serial = true
   plan = new {
     getResourcesToDeployApp(app)
-    new shared_resources_for_lock_pools.AcquireLockStep { pool = "deploy-application" }
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "deploy-application-staging" }
     parseReleaseTagsToDeployApp(app)
     loadVariablesToDeployApp(app)
     createNotificationSnippets(app, "Deployment")
@@ -126,7 +126,7 @@ local function getJobToDeployApp(app): Job = new {
   on_failure = sendSlackNoticationAndPutMetrics(app,
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_sidecar_metrics = true })
-  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application" }
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application-staging" }
 }
 
 local function getJobToSmokeTestApp(app): Job = new {
@@ -144,7 +144,7 @@ local function getJobToSmokeTestApp(app): Job = new {
       }
     }
 
-    new shared_resources_for_lock_pools.AcquireLockStep { pool = "smoke-test" }
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "smoke-test-staging" }
 
     new TaskStep {
       task = "parse-ecr-release-tag"
@@ -168,7 +168,7 @@ local function getJobToSmokeTestApp(app): Job = new {
   on_failure = sendSlackNoticationAndPutMetrics(app,
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_sidecar_metrics = false })
-  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "smoke-test" }
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "smoke-test-staging" }
 
 }
 

--- a/ci/pkl-pipelines/pay-deploy/init-lock-pools.pkl
+++ b/ci/pkl-pipelines/pay-deploy/init-lock-pools.pkl
@@ -1,8 +1,10 @@
 amends "../common/shared_pipelines/init_lock_pools.pkl"
 
 pools_to_init {
-  "deploy-application"
-  "smoke-test"
+  "deploy-application-staging"
+  "smoke-test-staging"
+  "deploy-application-production"
+  "smoke-test-production"
 }
 
 concourseTeamName = "pay-deploy"

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -76,8 +76,8 @@ resources = new {
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
   shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
-  new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application" }
-  new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test" }
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-test" }
+  new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test-test" }
 
   for (app in allPayApplications) {
     shared_resources.payGithubResourceWithBranch("\(app.name)-git-release", app.getGithubRepo(),
@@ -584,7 +584,7 @@ local function getJobToDeployApp(app): Job = new {
   serial = true
   plan = new {
     getResourcesToDeployApp(app)
-    new shared_resources_for_lock_pools.AcquireLockStep { pool = "deploy-application" }
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "deploy-application-test" }
     loadVariablesToDeployApp(app)
     createNotificationSnippets(app, "Deployment")
     loadNotificationSnippetVariables(app, true)
@@ -608,7 +608,7 @@ local function getJobToDeployApp(app): Job = new {
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_metrics = true; put_sidecar_metrics = true })
 
-  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application" }
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "deploy-application-test" }
 }
 
 local function getJobToSmokeTestApp(app): Job = new {
@@ -628,7 +628,7 @@ local function getJobToSmokeTestApp(app): Job = new {
         }
       }
     }
-    new shared_resources_for_lock_pools.AcquireLockStep { pool = "smoke-test" }
+    new shared_resources_for_lock_pools.AcquireLockStep { pool = "smoke-test-test" }
 
     loadVar("application_image_tag", "\(app.name)-ecr-registry-test/tag")
     createNotificationSnippets(app, "Smoke test")
@@ -646,7 +646,7 @@ local function getJobToSmokeTestApp(app): Job = new {
     new SlackNotificationConfig { is_a_success = false },
     new MetricsConfig { is_a_success = false; put_metrics = true })
 
-  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "smoke-test" }
+  ensure = new shared_resources_for_lock_pools.ReleaseLockStep { pool = "smoke-test-test" }
 }
 
 local function getJobToPactTagApp(app): Job = new {

--- a/ci/pkl-pipelines/pay-dev/init-lock-pools.pkl
+++ b/ci/pkl-pipelines/pay-dev/init-lock-pools.pkl
@@ -1,12 +1,12 @@
 amends "../common/shared_pipelines/init_lock_pools.pkl"
 
 pools_to_init {
-  "deploy-application"
+  "deploy-application-test"
   "integration-test"
   "node-test"
   "unit-test"
   "perf-tests"
-  "smoke-test"
+  "smoke-test-test"
 }
 
 concourseTeamName = "pay-dev"


### PR DESCRIPTION
When I created the lock pool I've accidentally made staging and prod share the same deploy application and smoke test locks, they need to be suffixed with the env the pipeline is deploying to.