### PR TITLE
BAU: 3 attempts to send metrics and annotations

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_annotations.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_annotations.pkl
@@ -21,6 +21,7 @@ grafanaAnnotationResource = new Pipeline.Resource {
 
 function paySendAppReleaseAnnotation(pipeline: String) = new Pipeline.PutStep {
 	put = "grafana-annotation"
+	attempts = 3
 	params = new {
 		["tags"] = new Listing<String> { pipeline "((.:app_name))" }
 		["template"] = "released ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} release ((.:app_release_number)) (build ${BUILD_ID})"

--- a/ci/pkl-pipelines/common/shared_resources_for_metrics.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_metrics.pkl
@@ -44,7 +44,7 @@ function paySendAppReleaseMetric(success: Boolean, environment: String): Pipelin
 
 function paySendAdotReleaseMetric(success: Boolean, environment: String): Pipeline.PutStep = new {
   put = "send-adot-release-number-metric"
-  attemps = 3
+  attempts = 3
   resource = "prometheus-pushgateway"
   params {
     ["metric"] = "deployment_pipeline_sidecar_release_number"

--- a/ci/pkl-pipelines/common/shared_resources_for_metrics.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_metrics.pkl
@@ -20,6 +20,7 @@ prometheusPushgatewayResource = new Pipeline.Resource {
 
 function paySendAppReleaseMetric(success: Boolean, environment: String): Pipeline.PutStep = new {
   put = "send-app-release-number-metric"
+  attempts = 3
   resource = "prometheus-pushgateway"
   params {
     ["metric"] = "deployment_pipeline_app_release_number"
@@ -43,6 +44,7 @@ function paySendAppReleaseMetric(success: Boolean, environment: String): Pipelin
 
 function paySendAdotReleaseMetric(success: Boolean, environment: String): Pipeline.PutStep = new {
   put = "send-adot-release-number-metric"
+  attemps = 3
   resource = "prometheus-pushgateway"
   params {
     ["metric"] = "deployment_pipeline_sidecar_release_number"
@@ -67,6 +69,7 @@ function paySendAdotReleaseMetric(success: Boolean, environment: String): Pipeli
 
 function paySendNginxReleaseMetric(success: Boolean, environment: String): Pipeline.PutStep = new {
   put = "send-nginx-release-number-metric"
+  attempts = 3
   resource = "prometheus-pushgateway"
   params {
     ["metric"] = "deployment_pipeline_sidecar_release_number"
@@ -91,6 +94,7 @@ function paySendNginxReleaseMetric(success: Boolean, environment: String): Pipel
 
 function paySendNginxForwardProxyReleaseMetric(success: Boolean, environment: String): Pipeline.PutStep = new {
   put = "send-nginx-forward-proxy-release-number-metric"
+  attempts = 3
   resource = "prometheus-pushgateway"
   params {
     ["metric"] = "deployment_pipeline_sidecar_release_number"


### PR DESCRIPTION
Lots of the send metrics tasks fail erroneously, so lets just try them 3 times to stop nonsense failed jobs.