### PR TITLE
Revert "BAU: Wait 10 mins to claim lock, retry 10 times"

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
@@ -16,8 +16,6 @@ class LockPoolResource extends Pipeline.Resource {
 class AcquireLockStep extends Pipeline.PutStep {
   hidden pool: String
   put = "claim-\(pool)-lock"
-  timeout = "10m"
-  attempts = 10
   resource = "lock-pool-\(pool)"
   params {
     ["claim"] = "\(pool)-lock"
@@ -27,7 +25,7 @@ class AcquireLockStep extends Pipeline.PutStep {
 class ReleaseLockStep extends Pipeline.PutStep {
   hidden pool: String
   put = "release-\(pool)-lock"
-  attempts = 3
+  attempts = 10
   resource = "lock-pool-\(pool)"
   params {
     ["release"] = "claim-\(pool)-lock"


### PR DESCRIPTION
Reverts alphagov/pay-ci#1203

This change seems to break the locking quite hard.

The timeout doesn't make the job stop (probably for the same reason we can't kill it in the UI), and it seems that once the "supposed to have been terminated" task claims the lock it then hangs forever in the claim lock task

![Screenshot 2024-05-13 at 18 31 00](https://github.com/alphagov/pay-ci/assets/2170030/50bce8fa-90c5-432c-b12d-435f0b67a52d)

I hijacked the task, there's nothing running anymore in it, so the actual task finished, but there's an ssh-agent task hanging, I sent it a SIGINT which made it terminate and the task immediately went into timeout exceeded:


![Screenshot 2024-05-13 at 18 35 52](https://github.com/alphagov/pay-ci/assets/2170030/cea96a46-10b3-4fa4-8658-c61cdd53151d)

Which means it's created a deadlock since it claimed the lock and died.