### PR TITLE
PP-12582-migrate-pr-pipeline-to-pkl

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_test_pipelines.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_test_pipelines.pkl
@@ -75,3 +75,4 @@ loadAssumeRoleVar = new Pipeline.LoadVarStep {
   format = "json"
 }
 
+getPayCi = new Pipeline.GetStep { get = "pay-ci" }

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -82,7 +82,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing<Step> {
           shared_test.getStep("endtoend-git-release", true, false)
-          getPayCi
+          shared_test.getPayCi
         }
       }
 
@@ -113,7 +113,7 @@ jobs = new {
             passed = new Listing { "build-and-push-endtoend-candidate" }
             params { ["format"] = "oci" }
           }
-          getPayCi
+          shared_test.getPayCi
         }
       }
 
@@ -169,7 +169,7 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          getPayCi
+          shared_test.getPayCi
           shared_test.getStep("reverse-proxy-git-release", true, false)
         }
       }
@@ -212,7 +212,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_test.getStep("reverse-proxy-candidate-ecr-registry-test", true, true)
-          getPayCi
+          shared_test.getPayCi
         }
       }
 
@@ -280,7 +280,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing<Step> {
           shared_test.getStep("stubs-git-release", true, false)
-          getPayCi
+          shared_test.getPayCi
         }
       }
 
@@ -323,7 +323,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing {
           shared_test.getStep("stubs-candidate-ecr-registry-test", true, true)
-          getPayCi
+          shared_test.getPayCi
         }
       }
 
@@ -530,8 +530,6 @@ local function runCodeBuildMultiarch(project: String, attempts: Int): InParallel
     shared_test.runCodeBuild("run-codebuild-\(project)-armv8", "\(project)-armv8.json", attempts)
   }
 }
-
-local getPayCi = new GetStep { get = "pay-ci" }
 
 local function withTagRegex(tag: String) = new Mixin {
   source { ["tag_regex"] = tag }

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -4,28 +4,29 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
+import "../common/shared_resources_for_test_pipelines.pkl" as shared_test
 import "../common/PayResources.pkl"
 
 local e2e_test_apps = new Mapping<String, AppConfig> {
-  ["adminusers"] = new { job_name = "adminusers"; tests = new { "card" } }
-  ["cardid"] = new { use_cardid_submodule = true; job_name = "cardid"; tests = new { "card" "zap" } }
-  ["connector"] = new { job_name = "card-connector"; tests = new {"card" } }
-  ["endtoend"] = new { tests = new {"card" "products" "zap"}; job_name = "endtoend" }
-  ["frontend"] = new { job_name = "card-frontend"; tests = new {"card" "products" "zap"} }
-  ["ledger"] = new { job_name = "ledger"; tests = new { "card" } }
-  ["products"] = new { job_name = "products"; tests = new { "products" } }
-  ["products_ui"] = new { job_name = "products-ui" ; tests = new { "products" }; node_build = true }
-  ["publicapi"] = new { job_name = "publicapi"; tests = new {"card" "products" "zap"} }
-  ["publicauth"] = new { job_name = "publicauth"; tests = new { "card" "zap" } }
-  ["selfservice"] = new { job_name = "selfservice"; tests = new { "card" }; node_build = true }
+  ["adminusers"] = new { tests = new { "card" } }
+  ["cardid"] = new { tests = new { "card" "zap" }; use_cardid_submodule = true }
+  ["connector"] = new { tests = new {"card" } }
+  ["endtoend"] = new { tests = new {"card" "products" "zap"} }
+  ["frontend"] = new { tests = new {"card" "products" "zap"} }
+  ["ledger"] = new { tests = new { "card" } }
+  ["products"] = new { tests = new { "products" } }
+  ["products_ui"] = new { tests = new { "products" }; node_build = true }
+  ["publicapi"] = new { tests = new {"card" "products" "zap"} }
+  ["publicauth"] = new { tests = new { "card" "zap" } }
+  ["selfservice"] = new { tests = new { "card" }; node_build = true }
 } // pay-ci-endtoend-config is different enough to break out
 
 local groupMap = new Mapping <String, Listing<String>> {
   ["adminusers"] = new { "adminusers-e2e" }
   ["cardid"] = new { "cardid-e2e" }
-  ["connector"] = new { "card-connector-e2e" }
+  ["connector"] = new { "connector-e2e" }
   ["end_to_end"] = new { "endtoend-e2e" "pay-ci-endtoend-config" }
-  ["frontend"] = new { "card-frontend-e2e" }
+  ["frontend"] = new { "frontend-e2e" }
   ["ledger"] = new { "ledger-e2e" }
   ["products"] = new { "products-e2e" }
   ["products_ui"] = new { "products-ui-e2e" }
@@ -38,7 +39,6 @@ local groupMap = new Mapping <String, Listing<String>> {
 
 local class AppConfig {
   use_cardid_submodule: Boolean = false
-  job_name: String 
   tests: Listing<String> = new {}
   node_build: Boolean = false
 }
@@ -53,12 +53,11 @@ resource_types {
 
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "master")
-  shared_resources.payGithubResourceWithBranch("ci", "pay-ci", "master")
-    // Can be replaced with shared_resources.payCiGitHubResource, but for now trying to exactly replace
+  shared_resources.payCiGitHubResource
 
   for (app, config in e2e_test_apps) {
     new PayResources.PayGitHubPullRequestResource {
-      name = "\(config.job_name)-pull-request" 
+      name = "\(app)-pull-request" 
       repo = "pay-\(app)"
     }
   }
@@ -102,51 +101,7 @@ jobs = new {
 
       new TaskStep {
         task = "check-pipelines-and-tasks"
-        config {
-          platform = "linux"
-          image_resource { 
-            // Sample output has a name property, but image_resource is anonymous according
-            // to https://github.com/alphagov/pkl-concourse-pipeline/blob/pkl-concourse-pipeline%400.0.4/src/TaskConfig.pkl#L6
-            type = "registry-image"
-            source {
-              ["repository"] = "golang"
-              ["tag"] = "1.20-alpine"
-            }
-          }
-          inputs = new Listing { 
-            new TaskConfig.Input { name = "src" }
-          }
-          // TODO extract to file
-          run {
-            path = "sh"
-            dir = "src"
-            args = new Listing {
-              "-ec"
-              """
-          apk add git shellcheck
-          go install github.com/alphagov/paas-cf/tools/pipecleaner@latest
-
-          cd /tmp/
-
-          echo "c7d331052a6bf552b017adf5288b8e162346157c  fly-7.6.0-linux-amd64.tgz" > fly-7.6.0-linux-amd64.tgz.sha1
-          wget -c https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-linux-amd64.tgz -O fly-7.6.0-linux-amd64.tgz
-          sha1sum -c fly-7.6.0-linux-amd64.tgz.sha1
-          tar -O -zxf fly-7.6.0-linux-amd64.tgz > /usr/local/bin/fly
-          chmod u+x /usr/local/bin/fly
-
-          cd -
-
-          pipecleaner --rubocop=false ci/tasks/*.yml
-
-          find ci/pipelines -name '*.yml' | while read -r PIPELINE; do
-            echo "Validating: $PIPELINE"
-            fly validate-pipeline -c "$PIPELINE"
-            echo
-          done
-          """
-            }
-          }
-        }
+        file = "tasks/update-cardid-submodule.yml"
         on_failure = putStatus("ci-pull-request", "test", "failure")
       }
       putStatus("ci-pull-request", "test", "success")
@@ -160,20 +115,20 @@ jobs = new {
     plan {
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          new GetStep { get = "ci" resource = "ci" } // TODO ci->pay-ci
+          shared_test.getPayCi
           pullRequestGetStep("pay-ci-endtoend-config-pull-request")
         }
       }
       putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "pending")
-      assumeCodeBuildRole("pay-cd-pay-dev-codebuild-executor", "pay-ci-endtoend-config-pr-assume-role")
-      new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" }
-      prepareCodeBuild("pay-ci", "prepare-e2e-codebuild.yml", "") 
-        |> withInputMapping("pay-ci", "src")
+      shared_test.assumeCodeBuildRole("executor", "pay-ci-endtoend-config-pr-assume-role")
+      shared_test.loadVarJson("role", "assume-role/assume-role.json")
+      shared_test.prepareCodeBuild("pay-ci", "prepare-e2e-codebuild.yml", "") 
+        |> shared_test.withInputMapping("pay-ci", "src")
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          runCodeBuild("run-card-e2e-tests", "card.json", 3) |> withInputMapping("pay-ci", "ci")
-          runCodeBuild("run-products-e2e-tests", "products.json", 3) |> withInputMapping("pay-ci", "ci")
-          runCodeBuild("run-zap-e2e-tests", "zap.json", 3) |> withInputMapping("pay-ci", "ci")
+          shared_test.runCodeBuild("run-card-e2e-tests", "card.json", 3)
+          shared_test.runCodeBuild("run-products-e2e-tests", "products.json", 3)
+          shared_test.runCodeBuild("run-zap-e2e-tests", "zap.json", 3)
         }
       }
       putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "success")
@@ -182,70 +137,65 @@ jobs = new {
 }
 
 local function e2eJob(app: String, config: AppConfig) = new Job {
-  name = "\(config.job_name)-e2e" // TODO rename card-connector
-  // name = "\(_name)-e2e" // TODO rename card-connnector
+  name = "\(app)-e2e"
   max_in_flight = 3
   build_log_retention = new { builds = 500 }
-  on_failure = putStatus("\(config.job_name)-pull-request", "e2e tests", "failure")
+  on_failure = putStatus("\(app)-pull-request", "e2e tests", "failure")
   plan {
     new GetStep {
       get = "src"
       params = new { ["integration_tool"] = "checkout" }
-      resource = "\(config.job_name)-pull-request"
+      resource = "\(app)-pull-request"
       trigger = true
       version = "every"
     }
     new InParallelStep {
       in_parallel = new Listing<Step> {
-        new GetStep { get = "ci" resource = "ci" } // TODO ci->pay-ci
-        putStatus("\(config.job_name)-pull-request", "e2e tests", "pending")
+        shared_test.getPayCi
+        putStatus("\(app)-pull-request", "e2e tests", "pending")
       }
     }
 
     when (config.node_build) {
       new Pipeline.TaskStep {
         task = "build"
-        file = "ci/ci/tasks/node-build-pr.yml" // TODO ci->pay-ci
+        file = "pay-ci/ci/tasks/node-build-pr.yml"
         params = new { ["skip_tests"] = "true" }
       }
     }
 
-    when (config.use_cardid_submodule) { updateCardidSubmodule() }
-    // TODO replace with shared_resources.generateDockerCredsConfigStep when ci->pay-ci
-    new Pipeline.TaskStep {
-      task = "generate-docker-creds-config"
-      file = "ci/ci/tasks/generate-docker-config-file.yml"
-      params = new {
-          ["USERNAME"] = "((docker-username))"
-          ["PASSWORD"] = "((docker-access-token))"
-          ["EMAIL"] = "((docker-email))"
+    // TODO remove, along with task and script files, once cardid submodule is no longer needed
+    when (config.use_cardid_submodule) { 
+      new TaskStep {
+        task = "update-submodule"
+        file = "tasks/update-cardid-submodule.yml"
       }
     }
 
+    shared_resources.generateDockerCredsConfigStep 
+
     new TaskStep {
       task = "build-image"
-      file = "ci/ci/tasks/build-docker-image.yml" // TODO ci->pay-ci
+      file = "pay-ci/ci/tasks/build-docker-image.yml" 
       privileged = true
-      params = new {
-        ["app_name"] = app
-      }
+      params = new { ["app_name"] = app }
     }
 
     new InParallelStep {
       in_parallel = new Listing<Step> {
         new TaskStep {
           task = "get-docker-image-info"
-          file = "ci/ci/tasks/get-pr-build-docker-image-info.yml" // TODO ci->pay-ci
+          file = "pay-ci/ci/tasks/get-pr-build-docker-image-info.yml"
           params = new { ["app_name"] = app }
         }
-        assumeCodeBuildRole("pay-cd-pay-dev-codebuild-executor", "e2e-test-assume-role")
+        shared_test.assumeCodeBuildRole("executor", "e2e-test-assume-role")
       }
     }
     new InParallelStep {
       in_parallel = new Listing<Step> {
-        new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" }
-        new LoadVarStep { load_var = "image_filename" file = "image_info/image_filename" }
-        new LoadVarStep { load_var = "image_tag" file = "image_info/tag" }
+        shared_test.loadVarJson("role", "assume-role/assume-role.json")
+        shared_test.loadVar("image_filename", "image_info/image_filename")
+        shared_test.loadVar("image_tag", "image_info/tag")
       }
     }
     new InParallelStep {
@@ -258,79 +208,25 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
             ["image"] = "local_image/((.:image_filename))"
           }
         }
-        prepareCodeBuild(app, "prepare-e2e-codebuild.yml", "((.:image_tag))") 
-          |> withParam("PR_BUILD", "true")
-          |> withInputMapping("pay-ci", "ci")
+        shared_test.prepareCodeBuild(app, "prepare-e2e-codebuild.yml", "((.:image_tag))") 
+          |> shared_test.withParam("PR_BUILD", "true")
       }
     }
     when (config.tests.length > 1) {
       new InParallelStep {
         in_parallel = new Listing<Step> {
           for (test in config.tests) {
-            runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 3) |> withInputMapping("pay-ci", "ci")
+            shared_test.runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 3)
           }
         }
       }
     } else {
       for (test in config.tests) {
-        runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 1) |> withInputMapping("pay-ci", "ci")
+        shared_test.runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 1)
       }
     }
-    putStatus("\(config.job_name)-pull-request", "e2e tests", "success")
+    putStatus("\(app)-pull-request", "e2e tests", "success")
   }
-}
-
-local function updateCardidSubmodule() = new TaskStep {
-  task = "update-submodule"
-  config {
-    image_resource { 
-      // Sample output has a name property, but image_resource is anonymous according
-      // to https://github.com/alphagov/pkl-concourse-pipeline/blob/pkl-concourse-pipeline%400.0.4/src/TaskConfig.pkl#L6
-      type = "registry-image"
-      source {
-        ["repository"] = "governmentdigitalservice/pay-concourse-runner"
-      }
-    }
-    inputs = new Listing { 
-      new TaskConfig.Input { name = "src" }
-    }
-    outputs = new Listing { 
-      new TaskConfig.Output { name = "src" }
-    }
-    params = new {
-      ["GH_ACCESS_TOKEN"] = "((github-access-token))"
-    }
-    platform = "linux"
-    // TODO extract to file
-    run {
-      path = "bash"
-      dir = "src"
-      args = new Listing {
-        "-ec"
-        """
-    # rewrite the submodule url for https to add the token.
-    # The risk of setting the token in the url is mitigated since these files are not committed,
-    # the container is ephemeral and anyone with access to read the files could read the token from
-    # environment variable. Furthermore we redact the token from the files after the update.
-    sed -i "s/https:\\/\\/github.com/https:\\/\\/${GH_ACCESS_TOKEN}@github.com\\//" .gitmodules
-    git submodule init -q data
-    git submodule update data
-    sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
-    sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
-    """
-      }
-    }
-  }
-}
-
-local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
-  type = "git"
-  name = _name
-  icon = "github"
-  source = new {
-    ["branch"] = "master"
-    ["uri"] = "https://github.com/alphagov/\(repo)"
-    }
 }
 
 local function pullRequestGetStep(name: String) = new GetStep {
@@ -350,4 +246,3 @@ local function putStatus(stepName: String, context: String, status: String) = ne
     ["status"] = status
   }
 }
-

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -53,7 +53,7 @@ resource_types {
 }
 
 resources = new {
-  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "PP-12582-migrate-pr-pipeline-to-pkl")
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "master")
   shared_resources.payCiGitHubResource
 
   for (app, config in e2e_test_apps) {

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -97,6 +97,7 @@ jobs = new {
     max_in_flight = 3
     build_log_retention = new { builds = 500 }
     plan {
+      shared_test.getPayCi
       pullRequestGetStep("ci-pull-request")
       putStatus("ci-pull-request", "test", "pending")
 

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -139,9 +139,9 @@ jobs = new {
 
 local function e2eJob(app: String, config: AppConfig) = new Job {
   name = "\(app)-e2e"
-  when (config.migrate_from.length > 0) { // TODO Remove after deployment
-    old_name = config.migrate_from
-  }
+  // when (config.migrate_from.length > 0) { // TODO Remove after deployment
+  //   old_name = config.migrate_from
+  // }
   max_in_flight = 3
   build_log_retention = new { builds = 500 }
   on_failure = putStatus("\(app)-pull-request", "e2e tests", "failure")
@@ -169,7 +169,7 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
     }
 
     when (config.node_build) {
-      new Pipeline.TaskStep {
+      new TaskStep {
         task = "build"
         file = "pay-ci/ci/tasks/node-build-pr.yml"
         params = new { ["skip_tests"] = "true" }

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -10,12 +10,12 @@ import "../common/PayResources.pkl"
 local e2e_test_apps = new Mapping<String, AppConfig> {
   ["adminusers"] = new { tests = new { "card" } }
   ["cardid"] = new { tests = new { "card" "zap" }; use_cardid_submodule = true }
-  ["connector"] = new { tests = new {"card" } }
+  ["connector"] = new { tests = new {"card" }; migrate_from = "card-connector" }
   ["endtoend"] = new { tests = new {"card" "products" "zap"} }
-  ["frontend"] = new { tests = new {"card" "products" "zap"} }
+  ["frontend"] = new { tests = new {"card" "products" "zap"}; migrate_from = "card-frontend" }
   ["ledger"] = new { tests = new { "card" } }
   ["products"] = new { tests = new { "products" } }
-  ["products_ui"] = new { tests = new { "products" }; node_build = true }
+  ["products-ui"] = new { tests = new { "products" }; node_build = true }
   ["publicapi"] = new { tests = new {"card" "products" "zap"} }
   ["publicauth"] = new { tests = new { "card" "zap" } }
   ["selfservice"] = new { tests = new { "card" }; node_build = true }
@@ -29,7 +29,7 @@ local groupMap = new Mapping <String, Listing<String>> {
   ["frontend"] = new { "frontend-e2e" }
   ["ledger"] = new { "ledger-e2e" }
   ["products"] = new { "products-e2e" }
-  ["products_ui"] = new { "products_ui-e2e" }
+  ["products-ui"] = new { "products-ui-e2e" }
   ["publicapi"] = new { "publicapi-e2e" }
   ["publicauth"] = new { "publicauth-e2e" }
   ["selfservice"] = new { "selfservice-e2e" }
@@ -41,6 +41,7 @@ local class AppConfig {
   use_cardid_submodule: Boolean = false
   tests: Listing<String> = new {}
   node_build: Boolean = false
+  migrate_from: String = ""
 }
 
 groups {
@@ -121,7 +122,7 @@ jobs = new {
       }
       putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "pending")
       shared_test.assumeCodeBuildRole("executor", "pay-ci-endtoend-config-pr-assume-role")
-      shared_test.loadVarJson("role", "assume-role/assume-role.json")
+      shared_test.loadVar("role", "assume-role/assume-role.json")
       shared_test.prepareCodeBuild("pay-ci", "prepare-e2e-codebuild.yml", "") 
         |> shared_test.withInputMapping("pay-ci", "src")
       new InParallelStep {
@@ -138,6 +139,9 @@ jobs = new {
 
 local function e2eJob(app: String, config: AppConfig) = new Job {
   name = "\(app)-e2e"
+  when (config.migrate_from.length > 0) { // TODO Remove after deployment
+    old_name = config.migrate_from
+  }
   max_in_flight = 3
   build_log_retention = new { builds = 500 }
   on_failure = putStatus("\(app)-pull-request", "e2e tests", "failure")
@@ -153,6 +157,14 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
       in_parallel = new Listing<Step> {
         shared_test.getPayCi
         putStatus("\(app)-pull-request", "e2e tests", "pending")
+
+        // TODO remove, along with task and script files, once cardid submodule is no longer needed
+        when (config.use_cardid_submodule) { 
+          new TaskStep {
+            task = "update-submodule"
+            file = "pay-ci/ci/tasks/update-cardid-submodule.yml"
+          }
+        }
       }
     }
 
@@ -161,14 +173,6 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
         task = "build"
         file = "pay-ci/ci/tasks/node-build-pr.yml"
         params = new { ["skip_tests"] = "true" }
-      }
-    }
-
-    // TODO remove, along with task and script files, once cardid submodule is no longer needed
-    when (config.use_cardid_submodule) { 
-      new TaskStep {
-        task = "update-submodule"
-        file = "pay-ci/ci/tasks/update-cardid-submodule.yml"
       }
     }
 
@@ -193,7 +197,7 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
     }
     new InParallelStep {
       in_parallel = new Listing<Step> {
-        shared_test.loadVarJson("role", "assume-role/assume-role.json")
+        shared_test.loadVar("role", "assume-role/assume-role.json")
         shared_test.loadVar("image_filename", "image_info/image_filename")
         shared_test.loadVar("image_tag", "image_info/tag")
       }
@@ -216,7 +220,7 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
       new InParallelStep {
         in_parallel = new Listing<Step> {
           for (test in config.tests) {
-            shared_test.runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 3)
+            shared_test.runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 1)
           }
         }
       }

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -165,7 +165,7 @@ jobs = new {
         }
       }
       putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "pending")
-      assumeCodeBuildRole("pay-ci-endtoend-config-pr-assume-role")
+      assumeCodeBuildRole("pay-cd-pay-dev-codebuild-executor", "pay-ci-endtoend-config-pr-assume-role")
       new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" }
       prepareCodeBuild("pay-ci", "prepare-e2e-codebuild.yml", "") 
         |> withInputMapping("pay-ci", "src")
@@ -238,7 +238,7 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
           file = "ci/ci/tasks/get-pr-build-docker-image-info.yml" // TODO ci->pay-ci
           params = new { ["app_name"] = app }
         }
-        assumeCodeBuildRole("e2e-test-assume-role")
+        assumeCodeBuildRole("pay-cd-pay-dev-codebuild-executor", "e2e-test-assume-role")
       }
     }
     new InParallelStep {
@@ -323,42 +323,6 @@ local function updateCardidSubmodule() = new TaskStep {
   }
 }
 
-local function prepareCodeBuild(project: String, taskFile: String, tag: String): TaskStep = new {
-  task = "prepare-codebuild"
-  file = "ci/ci/tasks/\(taskFile)" // TODO ci->pay-ci
-  params = new {
-    ["PROJECT_UNDER_TEST"] = project
-    when (tag.length > 0) {
-      ["RELEASE_TAG_UNDER_TEST"] = tag
-    }
-    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
-  }
-}
-
-local function runCodeBuild(taskName: String, config: String, attemptCount: Int): TaskStep = new {
-  task = taskName
-  file = "ci/ci/tasks/run-codebuild.yml" // TODO ci->pay-ci
-  when (attemptCount != 1) {
-    attempts = attemptCount
-  }
-  params = new {
-    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(config)"
-    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
-  }
-}
-
-local function withParam(key: String, value: String) = new Mixin {
-  params { [key] = value }
-}
-
-local function withInputMapping(from: String, to: String) = new Mixin {
-  input_mapping = new { [from] = to }
-}
-
 local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
   type = "git"
   name = _name
@@ -367,16 +331,6 @@ local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
     ["branch"] = "master"
     ["uri"] = "https://github.com/alphagov/\(repo)"
     }
-}
-
-local function assumeCodeBuildRole(session_name: String) = new TaskStep {
-  task = "assume-role"
-  file = "ci/ci/tasks/assume-role.yml" // TODO ci->pay-ci
-  params = new {
-    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
-    ["AWS_ROLE_SESSION_NAME"] = session_name
-  }
-  input_mapping = new { ["pay-ci"] = "ci" } // TODO remove when ci->pay-ci
 }
 
 local function pullRequestGetStep(name: String) = new GetStep {

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -52,7 +52,7 @@ resource_types {
 }
 
 resources = new {
-  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "master")
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "PP-12582-migrate-pr-pipeline-to-pkl")
   shared_resources.payCiGitHubResource
 
   for (app, config in e2e_test_apps) {

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -6,6 +6,19 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/PayResources.pkl"
 
+local e2e_test_apps = new Listing {
+  "adminusers"
+  "cardid"
+  "connector"
+  "frontend"
+  "ledger"
+  "products"
+  "products_ui"
+  "publicapi"
+  "publicauth"
+  "selfservice"
+} // end_to_end is different
+
 local group_map = new Mapping {
   ["adminusers"] = new Listing<String> { "adminusers-e2e" }
   ["cardid"] = new Listing<String> { "cardid-e2e" }
@@ -27,6 +40,170 @@ groups {
 }
 
 jobs = new {
+  e2eJob("cardid")
+}
+
+local function putStatus(stepName: String, context: String, status: String) = new PutStep {
+  put = stepName 
+  get_params = new { ["skip_download"] = true }
+  params = new {
+    ["context"] = context
+    ["path"] = "src"
+    ["status"] = status
+  }
+}
+
+local function e2eJob(app: String) = new Job {
+  name = "\(app)-e2e"
+  max_in_flight = 3
+  build_log_retention = new { builds = 500 }
+  on_failure = putStatus("\(app)-pull-request", "e2e tests", "failure")
+  plan {
+    new GetStep {
+      get = "src"
+      params = new { ["integration_tool"] = "checkout" }
+      resource = "\(app)-pull-request"
+      trigger = true
+      version = "every"
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new GetStep { get = "pay-ci" resource = "pay-ci" }
+        putStatus("\(app)-pull-request", "e2e tests", "pending")
+      }
+    }
+    new TaskStep {
+      task = "update-submodule"
+      config {
+        image_resource { 
+          // Sample output has a name property, but image_resource is anonymous according
+          // to https://github.com/alphagov/pkl-concourse-pipeline/blob/pkl-concourse-pipeline%400.0.4/src/TaskConfig.pkl#L6
+          type = "registry-image"
+          source {
+            ["repository"] = "governmentdigitalservice/pay-concourse-runner"
+          }
+        }
+        inputs = new Listing { 
+          new TaskConfig.Input { name = "src" }
+        }
+        outputs = new Listing { 
+          new TaskConfig.Output { name = "src" }
+        }
+        params = new {
+          ["GH_ACCESS_TOKEN"] = "((github-access-token))"
+        }
+        platform = "linux"
+        // TODO extract to file
+        run {
+          path = "bash"
+          dir = "src"
+          args = new Listing {
+            "-ec"
+            """
+        # rewrite the submodule url for https to add the token.
+        # The risk of setting the token in the url is mitigated since these files are not committed,
+        # the container is ephemeral and anyone with access to read the files could read the token from
+        # environment variable. Furthermore we redact the token from the files after the update.
+        sed -i "s/https://github.com/https://${GH_ACCESS_TOKEN}@github.com//" .gitmodules
+        git submodule init -q data
+        git submodule update data
+        sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
+        sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
+        """
+          }
+        }
+      }
+    }
+    shared_resources.generateDockerCredsConfigStep
+
+    new TaskStep {
+      task = "build-image"
+      file = "pay-ci/ci/tasks/build-docker-image.yml"
+      privileged = true
+      params = new {
+        ["app_name"] = "cardid"
+      }
+    }
+
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new TaskStep {
+          task = "get-docker-image-info"
+          file = "pay-ci/ci/tasks/get-pr-build-docker-image-info.yml"
+          params = new { ["app_name"] = "cardid" }
+        }
+        new TaskStep {
+          task = "assume-role"
+          file = "pay-ci/ci/tasks/assume-role.yml"
+          params = new {
+            ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
+            ["AWS_ROLE_SESSION_NAME"] = "e2e-test-assume-role"
+          }
+        }
+      }
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" }
+        new LoadVarStep { load_var = "image_filename" file = "image_info/image_filename" }
+        new LoadVarStep { load_var = "image_tag" file = "image_info/tag" }
+      }
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new PutStep {
+          put = "pull-request-builds-ecr"
+          get_params = new { ["skip_download"] = true }
+          params = new {
+            ["additional_tags"] = "image_info/tag"
+            ["image"] = "local_image/((.:image_filename))"
+          }
+        }
+        prepareCodeBuild(app, "prepare-e2e-codebuild.yml", "((.:image_tag))") 
+          |> withParam("PR_BUILD", "true")
+      }
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        runCodeBuild("run-card-e2e-tests", "card.json", 3)
+        runCodeBuild("run-zap-tests", "zap.json", 3)
+      }
+    }
+    putStatus("\(app)-pull-request", "e2e tests", "success")
+  }
+}
+
+// TODO move this and mixin to common
+local function prepareCodeBuild(project: String, taskFile: String, tag: String): TaskStep = new {
+  task = "prepare-codebuild"
+  file = "pay-ci/ci/tasks/\(taskFile)"
+  params = new {
+    ["PROJECT_UNDER_TEST"] = project
+    ["RELEASE_TAG_UNDER_TEST"] = tag
+    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+  }
+}
+
+local function runCodeBuild(taskName: String, config: String, attemptCount: Int): TaskStep = new {
+  task = taskName
+  file = "pay-ci/ci/tasks/run-codebuild.yml"
+  when (attemptCount != 1) {
+    attempts = attemptCount
+  }
+  params = new {
+    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(config)"
+    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+  }
+}
+
+local function withParam(key: String, value: String) = new Mixin {
+  params { [key] = value }
+}
+  /*
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/pr-ci.pkl")
 
   new {
@@ -42,7 +219,7 @@ jobs = new {
         version = "every"
       }
 
-      PutStepCiPull("pending")
+      putStatus("ci-pull-request", "test", "pending")
 
       new TaskStep {
         task = "check-pipelines-and-tasks"
@@ -91,23 +268,14 @@ jobs = new {
             }
           }
         }
-        on_failure = PutStepCiPull("failure")
+        putStatus("ci-pull-request", "test", "failure")
       }
 
-      PutStepCiPull("success")
+      putStatus("ci-pull-request", "test", "success")
     }
   }
 }
 
-local function PutStepCiPull(status: String) = new PutStep {
-  put = "ci-pull-request"
-  get_params = new { ["skip_download"] = true }
-  params = new {
-    ["context"] = "test"
-    ["path"] = "src"
-    ["status"] = status
-  }
-}
 
 resource_types {
   shared_resources.pullRequestResourceType // Concourse has v0.21, default is v0.23
@@ -176,4 +344,4 @@ local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
     ["uri"] = "https://github.com/alphagov/\(repo)"
     }
 }
-
+*/

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -140,9 +140,9 @@ jobs = new {
 
 local function e2eJob(app: String, config: AppConfig) = new Job {
   name = "\(app)-e2e"
-  // when (config.migrate_from.length > 0) { // TODO Remove after deployment
-  //   old_name = config.migrate_from
-  // }
+  when (config.migrate_from.length > 0) { // TODO Remove after deployment
+    old_name = config.migrate_from
+  }
   max_in_flight = 3
   build_log_retention = new { builds = 500 }
   on_failure = putStatus("\(app)-pull-request", "e2e tests", "failure")

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -101,7 +101,7 @@ jobs = new {
 
       new TaskStep {
         task = "check-pipelines-and-tasks"
-        file = "pay-ci/ci/tasks/update-cardid-submodule.yml"
+        file = "pay-ci/ci/tasks/check-pipelines-and-tasks.yml"
         on_failure = putStatus("ci-pull-request", "test", "failure")
       }
       putStatus("ci-pull-request", "test", "success")

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -101,7 +101,7 @@ jobs = new {
 
       new TaskStep {
         task = "check-pipelines-and-tasks"
-        file = "tasks/update-cardid-submodule.yml"
+        file = "pay-ci/ci/tasks/update-cardid-submodule.yml"
         on_failure = putStatus("ci-pull-request", "test", "failure")
       }
       putStatus("ci-pull-request", "test", "success")
@@ -168,7 +168,7 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
     when (config.use_cardid_submodule) { 
       new TaskStep {
         task = "update-submodule"
-        file = "tasks/update-cardid-submodule.yml"
+        file = "pay-ci/ci/tasks/update-cardid-submodule.yml"
       }
     }
 

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -147,16 +147,20 @@ local function e2eJob(app: String, config: AppConfig) = new Job {
   build_log_retention = new { builds = 500 }
   on_failure = putStatus("\(app)-pull-request", "e2e tests", "failure")
   plan {
-    new GetStep {
-      get = "src"
-      params = new { ["integration_tool"] = "checkout" }
-      resource = "\(app)-pull-request"
-      trigger = true
-      version = "every"
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new GetStep {
+          get = "src"
+          params = new { ["integration_tool"] = "checkout" }
+          resource = "\(app)-pull-request"
+          trigger = true
+          version = "every"
+        }
+        shared_test.getPayCi
+      }
     }
     new InParallelStep {
       in_parallel = new Listing<Step> {
-        shared_test.getPayCi
         putStatus("\(app)-pull-request", "e2e tests", "pending")
 
         // TODO remove, along with task and script files, once cardid submodule is no longer needed

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -126,9 +126,9 @@ jobs = new {
         |> shared_test.withInputMapping("pay-ci", "src")
       new InParallelStep {
         in_parallel = new Listing<Step> {
-          shared_test.runCodeBuild("run-card-e2e-tests", "card.json", 3)
-          shared_test.runCodeBuild("run-products-e2e-tests", "products.json", 3)
-          shared_test.runCodeBuild("run-zap-e2e-tests", "zap.json", 3)
+          shared_test.runCodeBuild("run-card-e2e-tests", "card.json", 1)
+          shared_test.runCodeBuild("run-products-e2e-tests", "products.json", 1)
+          shared_test.runCodeBuild("run-zap-e2e-tests", "zap.json", 1)
         }
       }
       putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "success")

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -29,12 +29,12 @@ local groupMap = new Mapping <String, Listing<String>> {
   ["frontend"] = new { "frontend-e2e" }
   ["ledger"] = new { "ledger-e2e" }
   ["products"] = new { "products-e2e" }
-  ["products_ui"] = new { "products-ui-e2e" }
+  ["products_ui"] = new { "products_ui-e2e" }
   ["publicapi"] = new { "publicapi-e2e" }
   ["publicauth"] = new { "publicauth-e2e" }
   ["selfservice"] = new { "selfservice-e2e" }
   ["ci"] = new { "ci-pr-test" }
-  ["update_pipeline"] = new { "update-pr-ci-pipeline" }
+  ["update_pipeline"] = new { "update-pipeline" }
 }
 
 local class AppConfig {

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -37,30 +37,10 @@ local groupMap = new Mapping <String, Listing<String>> {
 }
 
 local class AppConfig {
-  // run_products_e2e: Boolean = false
-  // run_zap_e2e: Boolean = false
   use_cardid_submodule: Boolean = false
   job_name: String 
   tests: Listing<String> = new {}
   node_build: Boolean = false
-}
-
-local class ResourceConfig {
-  name: String
-}
-
-local resource_apps = new Mapping<String, ResourceConfig> {
-  ["adminusers"] = new { name = "adminusers" }
-  ["cardid"] = new { name = "cardid" }
-  ["connector"] = new { name = "card-connector" }
-  ["endtoend"] = new { name = "endtoend" }
-  ["frontend"] = new { name = "card-frontend" }
-  ["ledger"] = new { name = "ledger" }
-  ["products"] = new { name = "products" }
-  ["products-ui"] = new { name = "products-ui" }
-  ["publicapi"] = new { name = "publicapi" }
-  ["publicauth"] = new { name = "publicauth" }
-  ["selfservice"] = new { name = "selfservice" }
 }
 
 groups {
@@ -73,15 +53,12 @@ resource_types {
 
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "master")
-  // githubRepo("card-connector-master", "pay-connector")
-  // githubRepo("ledger-master", "pay-ledger")
-
-  // Can be replaced with shared_resources.payCiGitHubResource, but for now trying to exactly replace
   shared_resources.payGithubResourceWithBranch("ci", "pay-ci", "master")
+    // Can be replaced with shared_resources.payCiGitHubResource, but for now trying to exactly replace
 
-  for (app, config in resource_apps) {
+  for (app, config in e2e_test_apps) {
     new PayResources.PayGitHubPullRequestResource {
-      name = "\(config.name)-pull-request" 
+      name = "\(config.job_name)-pull-request" 
       repo = "pay-\(app)"
     }
   }
@@ -110,14 +87,6 @@ resources = new {
       ["tag"] = "latest"
     }
   }
-}
-
-local function pullRequestGetStep(name: String) = new GetStep {
-  get = "src"
-  params = new { ["integration_tool"] = "checkout" }
-  resource = name
-  trigger = true
-  version = "every"
 }
 
 jobs = new {
@@ -209,26 +178,6 @@ jobs = new {
       }
       putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "success")
     }
-  }
-}
-
-local function assumeCodeBuildRole(session_name: String) = new TaskStep {
-  task = "assume-role"
-  file = "ci/ci/tasks/assume-role.yml" // TODO ci->pay-ci
-  params = new {
-    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
-    ["AWS_ROLE_SESSION_NAME"] = session_name
-  }
-  input_mapping = new { ["pay-ci"] = "ci" } // TODO remove when ci->pay-ci
-}
-
-local function putStatus(stepName: String, context: String, status: String) = new PutStep {
-  put = stepName 
-  get_params = new { ["skip_download"] = true }
-  params = new {
-    ["context"] = context
-    ["path"] = "src"
-    ["status"] = status
   }
 }
 
@@ -407,9 +356,8 @@ local function withParam(key: String, value: String) = new Mixin {
 }
 
 local function withInputMapping(from: String, to: String) = new Mixin {
-  input_mapping = new { [from] = to } // TODO remove when ci->pay-ci
+  input_mapping = new { [from] = to }
 }
-
 
 local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
   type = "git"
@@ -420,3 +368,32 @@ local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
     ["uri"] = "https://github.com/alphagov/\(repo)"
     }
 }
+
+local function assumeCodeBuildRole(session_name: String) = new TaskStep {
+  task = "assume-role"
+  file = "ci/ci/tasks/assume-role.yml" // TODO ci->pay-ci
+  params = new {
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
+    ["AWS_ROLE_SESSION_NAME"] = session_name
+  }
+  input_mapping = new { ["pay-ci"] = "ci" } // TODO remove when ci->pay-ci
+}
+
+local function pullRequestGetStep(name: String) = new GetStep {
+  get = "src"
+  params = new { ["integration_tool"] = "checkout" }
+  resource = name
+  trigger = true
+  version = "every"
+}
+
+local function putStatus(stepName: String, context: String, status: String) = new PutStep {
+  put = stepName 
+  get_params = new { ["skip_download"] = true }
+  params = new {
+    ["context"] = context
+    ["path"] = "src"
+    ["status"] = status
+  }
+}
+

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -6,7 +6,6 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/PayResources.pkl"
 
-/*
 local group_map = new Mapping {
   ["adminusers"] = new Listing<String> { "adminusers-e2e" }
   ["cardid"] = new Listing<String> { "cardid-e2e" }
@@ -26,11 +25,9 @@ local group_map = new Mapping {
 groups {
   for (_name, _jobs in group_map) { new Pipeline.Group { name = _name jobs = _jobs } }
 }
-*/
-
 
 jobs = new {
-  //pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/pr-ci.pkl")
+  pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/pr-ci.pkl")
 
   new {
     name = "ci-pr-test"
@@ -45,15 +42,7 @@ jobs = new {
         version = "every"
       }
 
-      new PutStep {
-        put = "ci-pull-request"
-        get_params = new { ["skip_download"] = true }
-        params = new {
-          ["context"] = "test"
-          ["path"] = "src"
-          ["status"] = "pending"
-        }
-      }
+      PutStepCiPull("pending")
 
       new TaskStep {
         task = "check-pipelines-and-tasks"
@@ -102,34 +91,24 @@ jobs = new {
             }
           }
         }
-        on_failure = new PutStep {
-            put = "ci-pull-request"
-            get_params = new { ["skip_download"] = true }
-            params = new {
-              ["context"] = "test"
-              ["path"] = "src"
-              ["status"] = "failure"
-            }
-          }
+        on_failure = PutStepCiPull("failure")
       }
 
-      new PutStep {
-        put = "ci-pull-request"
-        get_params = new { ["skip_download"] = true }
-        params = new {
-          ["context"] = "test"
-          ["path"] = "src"
-          ["status"] = "success"
-        }
-      }
+      PutStepCiPull("success")
     }
   }
 }
 
-// local function PutStepCiPull(status: String) = new PutStep {
-// }
+local function PutStepCiPull(status: String) = new PutStep {
+  put = "ci-pull-request"
+  get_params = new { ["skip_download"] = true }
+  params = new {
+    ["context"] = "test"
+    ["path"] = "src"
+    ["status"] = status
+  }
+}
 
-/*
 resource_types {
   shared_resources.pullRequestResourceType // Concourse has v0.21, default is v0.23
 }
@@ -197,4 +176,4 @@ local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
     ["uri"] = "https://github.com/alphagov/\(repo)"
     }
 }
-*/
+

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -1,0 +1,200 @@
+amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/TaskConfig.pkl"
+
+import "../common/pipeline_self_update.pkl"
+import "../common/shared_resources.pkl"
+import "../common/PayResources.pkl"
+
+/*
+local group_map = new Mapping {
+  ["adminusers"] = new Listing<String> { "adminusers-e2e" }
+  ["cardid"] = new Listing<String> { "cardid-e2e" }
+  ["connector"] = new Listing<String> { "card-connector-e2e" }
+  ["end_to_end"] = new Listing<String> { "endtoend-e2e" "pay-ci-endtoend-config" }
+  ["frontend"] = new Listing<String> { "card-frontend-e2e" }
+  ["ledger"] = new Listing<String> { "ledger-e2e" }
+  ["products"] = new Listing<String> { "products-e2e" }
+  ["products_ui"] = new Listing<String> { "products-ui-e2e" }
+  ["publicapi"] = new Listing<String> { "publicapi-unit-test" "publicapi-integration-test" "publicapi-e2e" "publicapi-as-consumer-pact-test" }
+  ["publicauth"] = new Listing<String> { "publicauth-e2e" }
+  ["selfservice"] = new Listing<String> { "selfservice-e2e" }
+  ["ci"] = new Listing<String> { "ci-pr-test" }
+  ["update_pipeline"] = new Listing<String> { "update-pr-ci-pipeline" }
+}
+
+groups {
+  for (_name, _jobs in group_map) { new Pipeline.Group { name = _name jobs = _jobs } }
+}
+*/
+
+
+jobs = new {
+  //pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/pr-ci.pkl")
+
+  new {
+    name = "ci-pr-test"
+    max_in_flight = 3
+    build_log_retention = new { builds = 500 }
+    plan {
+      new GetStep {
+        get = "src"
+        params = new { ["integration_tool"] = "checkout" }
+        resource = "ci-pull-request"
+        trigger = true
+        version = "every"
+      }
+
+      new PutStep {
+        put = "ci-pull-request"
+        get_params = new { ["skip_download"] = true }
+        params = new {
+          ["context"] = "test"
+          ["path"] = "src"
+          ["status"] = "pending"
+        }
+      }
+
+      new TaskStep {
+        task = "check-pipelines-and-tasks"
+        config {
+          platform = "linux"
+          image_resource { 
+            // Sample output has a name property, but image_resource is anonymous according
+            // to https://github.com/alphagov/pkl-concourse-pipeline/blob/pkl-concourse-pipeline%400.0.4/src/TaskConfig.pkl#L6
+            type = "registry-image"
+            source {
+              ["repository"] = "golang"
+              ["tag"] = "1.20-alpine"
+            }
+          }
+          inputs = new Listing { 
+            new TaskConfig.Input { name = "src" }
+          }
+          // TODO extract to file
+          run {
+            path = "sh"
+            dir = "src"
+            args = new Listing {
+              "-ec"
+              """
+          apk add git shellcheck
+          go install github.com/alphagov/paas-cf/tools/pipecleaner@latest
+
+          cd /tmp/
+
+          echo "c7d331052a6bf552b017adf5288b8e162346157c  fly-7.6.0-linux-amd64.tgz" > fly-7.6.0-linux-amd64.tgz.sha1
+          wget -c https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-linux-amd64.tgz -O fly-7.6.0-linux-amd64.tgz
+          sha1sum -c fly-7.6.0-linux-amd64.tgz.sha1
+          tar -O -zxf fly-7.6.0-linux-amd64.tgz > /usr/local/bin/fly
+          chmod u+x /usr/local/bin/fly
+
+          cd -
+
+          pipecleaner --rubocop=false ci/tasks/*.yml
+
+          find ci/pipelines -name '*.yml' | while read -r PIPELINE; do
+            echo "Validating: $PIPELINE"
+            fly validate-pipeline -c "$PIPELINE"
+            echo
+          done
+          """
+            }
+          }
+        }
+        on_failure = new PutStep {
+            put = "ci-pull-request"
+            get_params = new { ["skip_download"] = true }
+            params = new {
+              ["context"] = "test"
+              ["path"] = "src"
+              ["status"] = "failure"
+            }
+          }
+      }
+
+      new PutStep {
+        put = "ci-pull-request"
+        get_params = new { ["skip_download"] = true }
+        params = new {
+          ["context"] = "test"
+          ["path"] = "src"
+          ["status"] = "success"
+        }
+      }
+    }
+  }
+}
+
+// local function PutStepCiPull(status: String) = new PutStep {
+// }
+
+/*
+resource_types {
+  shared_resources.pullRequestResourceType // Concourse has v0.21, default is v0.23
+}
+
+local resource_apps = new {
+  "adminusers"
+  "cardid"
+  "selfservice"
+  "publicauth"
+  "publicapi"
+  "products"
+  "products-ui"
+  "ledger"
+  "endtoend"
+  "connector" // original calls it card-connector
+  "frontend"  // original calls it card-fronted
+}
+
+resources = new {
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "master")
+  githubRepo("card-connector-master", "pay-connector")
+  githubRepo("ledger-master", "pay-ledger")
+  shared_resources.payCiGitHubResource
+
+  for (app in resource_apps) {
+    new PayResources.PayGitHubPullRequestResource {
+      name = "\(app)-pull-request" 
+      repo = "pay-\(app)"
+    }
+  }
+  new PayResources.PayGitHubPullRequestResource {
+    name = "pay-ci-endtoend-config-pull-request" 
+    repo = "pay-ci"
+    source { ["paths"] = new Listing<String> { "ci/tasks/endtoend/" } }
+  }
+  new PayResources.PayGitHubPullRequestResource {
+    name = "ci-pull-request" 
+    repo = "pay-ci"
+    source { ["paths"] = new Listing<String> { "ci/pipelines/*"  "ci/tasks/*"} }
+  }
+
+  new Pipeline.Resource {
+    name = "pull-request-builds-ecr"
+    icon = "docker"
+    type = "registry-image"
+    source = new {
+      ["aws_access_key_id"] = "((readonly_access_key_id))"
+      ["aws_ecr_registry_id"] = "((pay_aws_test_account_id))"
+      ["aws_region"] = "eu-west-1"
+      ["aws_role_arn"] = "arn:aws:iam::((pay_aws_test_account_id)):role/concourse"
+      ["aws_secret_access_key"] = "((readonly_secret_access_key))"
+      ["aws_session_token"] = "((readonly_session_token))"
+      ["repository"] = "govukpay/pull-request-builds"
+      ["tag"] = "latest"
+    }
+  }
+}
+
+local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
+  type = "git"
+  name = _name
+  icon = "github"
+  source = new {
+    ["branch"] = "master"
+    ["uri"] = "https://github.com/alphagov/\(repo)"
+    }
+}
+*/

--- a/ci/pkl-pipelines/pay-dev/pr-ci.pkl
+++ b/ci/pkl-pipelines/pay-dev/pr-ci.pkl
@@ -6,219 +6,129 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/PayResources.pkl"
 
-local e2e_test_apps = new Listing {
-  "adminusers"
-  "cardid"
-  "connector"
-  "frontend"
-  "ledger"
-  "products"
-  "products_ui"
-  "publicapi"
-  "publicauth"
-  "selfservice"
-} // end_to_end is different
+local e2e_test_apps = new Mapping<String, AppConfig> {
+  ["adminusers"] = new { job_name = "adminusers"; tests = new { "card" } }
+  ["cardid"] = new { use_cardid_submodule = true; job_name = "cardid"; tests = new { "card" "zap" } }
+  ["connector"] = new { job_name = "card-connector"; tests = new {"card" } }
+  ["endtoend"] = new { tests = new {"card" "products" "zap"}; job_name = "endtoend" }
+  ["frontend"] = new { job_name = "card-frontend"; tests = new {"card" "products" "zap"} }
+  ["ledger"] = new { job_name = "ledger"; tests = new { "card" } }
+  ["products"] = new { job_name = "products"; tests = new { "products" } }
+  ["products_ui"] = new { job_name = "products-ui" ; tests = new { "products" }; node_build = true }
+  ["publicapi"] = new { job_name = "publicapi"; tests = new {"card" "products" "zap"} }
+  ["publicauth"] = new { job_name = "publicauth"; tests = new { "card" "zap" } }
+  ["selfservice"] = new { job_name = "selfservice"; tests = new { "card" }; node_build = true }
+} // pay-ci-endtoend-config is different enough to break out
 
-local group_map = new Mapping {
-  ["adminusers"] = new Listing<String> { "adminusers-e2e" }
-  ["cardid"] = new Listing<String> { "cardid-e2e" }
-  ["connector"] = new Listing<String> { "card-connector-e2e" }
-  ["end_to_end"] = new Listing<String> { "endtoend-e2e" "pay-ci-endtoend-config" }
-  ["frontend"] = new Listing<String> { "card-frontend-e2e" }
-  ["ledger"] = new Listing<String> { "ledger-e2e" }
-  ["products"] = new Listing<String> { "products-e2e" }
-  ["products_ui"] = new Listing<String> { "products-ui-e2e" }
-  ["publicapi"] = new Listing<String> { "publicapi-unit-test" "publicapi-integration-test" "publicapi-e2e" "publicapi-as-consumer-pact-test" }
-  ["publicauth"] = new Listing<String> { "publicauth-e2e" }
-  ["selfservice"] = new Listing<String> { "selfservice-e2e" }
-  ["ci"] = new Listing<String> { "ci-pr-test" }
-  ["update_pipeline"] = new Listing<String> { "update-pr-ci-pipeline" }
+local groupMap = new Mapping <String, Listing<String>> {
+  ["adminusers"] = new { "adminusers-e2e" }
+  ["cardid"] = new { "cardid-e2e" }
+  ["connector"] = new { "card-connector-e2e" }
+  ["end_to_end"] = new { "endtoend-e2e" "pay-ci-endtoend-config" }
+  ["frontend"] = new { "card-frontend-e2e" }
+  ["ledger"] = new { "ledger-e2e" }
+  ["products"] = new { "products-e2e" }
+  ["products_ui"] = new { "products-ui-e2e" }
+  ["publicapi"] = new { "publicapi-e2e" }
+  ["publicauth"] = new { "publicauth-e2e" }
+  ["selfservice"] = new { "selfservice-e2e" }
+  ["ci"] = new { "ci-pr-test" }
+  ["update_pipeline"] = new { "update-pr-ci-pipeline" }
+}
+
+local class AppConfig {
+  // run_products_e2e: Boolean = false
+  // run_zap_e2e: Boolean = false
+  use_cardid_submodule: Boolean = false
+  job_name: String 
+  tests: Listing<String> = new {}
+  node_build: Boolean = false
+}
+
+local class ResourceConfig {
+  name: String
+}
+
+local resource_apps = new Mapping<String, ResourceConfig> {
+  ["adminusers"] = new { name = "adminusers" }
+  ["cardid"] = new { name = "cardid" }
+  ["connector"] = new { name = "card-connector" }
+  ["endtoend"] = new { name = "endtoend" }
+  ["frontend"] = new { name = "card-frontend" }
+  ["ledger"] = new { name = "ledger" }
+  ["products"] = new { name = "products" }
+  ["products-ui"] = new { name = "products-ui" }
+  ["publicapi"] = new { name = "publicapi" }
+  ["publicauth"] = new { name = "publicauth" }
+  ["selfservice"] = new { name = "selfservice" }
 }
 
 groups {
-  for (_name, _jobs in group_map) { new Pipeline.Group { name = _name jobs = _jobs } }
+  for (groupName, groupJobs in groupMap) { new Pipeline.Group { name = groupName jobs = groupJobs } }
+}
+
+resource_types {
+  shared_resources.pullRequestResourceType // Concourse has v0.21, default is v0.23
+}
+
+resources = new {
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "master")
+  // githubRepo("card-connector-master", "pay-connector")
+  // githubRepo("ledger-master", "pay-ledger")
+
+  // Can be replaced with shared_resources.payCiGitHubResource, but for now trying to exactly replace
+  shared_resources.payGithubResourceWithBranch("ci", "pay-ci", "master")
+
+  for (app, config in resource_apps) {
+    new PayResources.PayGitHubPullRequestResource {
+      name = "\(config.name)-pull-request" 
+      repo = "pay-\(app)"
+    }
+  }
+  new PayResources.PayGitHubPullRequestResource {
+    name = "pay-ci-endtoend-config-pull-request" 
+    repo = "pay-ci"
+    source { ["paths"] = new Listing<String> { "ci/tasks/endtoend/" } }
+  }
+  new PayResources.PayGitHubPullRequestResource {
+    name = "ci-pull-request" 
+    repo = "pay-ci"
+    source { ["paths"] = new Listing<String> { "ci/pipelines/*"  "ci/tasks/*"} }
+  }
+  new Pipeline.Resource {
+    name = "pull-request-builds-ecr"
+    icon = "docker"
+    type = "registry-image"
+    source = new {
+      ["aws_access_key_id"] = "((readonly_access_key_id))"
+      ["aws_ecr_registry_id"] = "((pay_aws_test_account_id))"
+      ["aws_region"] = "eu-west-1"
+      ["aws_role_arn"] = "arn:aws:iam::((pay_aws_test_account_id)):role/concourse"
+      ["aws_secret_access_key"] = "((readonly_secret_access_key))"
+      ["aws_session_token"] = "((readonly_session_token))"
+      ["repository"] = "govukpay/pull-request-builds"
+      ["tag"] = "latest"
+    }
+  }
+}
+
+local function pullRequestGetStep(name: String) = new GetStep {
+  get = "src"
+  params = new { ["integration_tool"] = "checkout" }
+  resource = name
+  trigger = true
+  version = "every"
 }
 
 jobs = new {
-  e2eJob("cardid")
-}
-
-local function putStatus(stepName: String, context: String, status: String) = new PutStep {
-  put = stepName 
-  get_params = new { ["skip_download"] = true }
-  params = new {
-    ["context"] = context
-    ["path"] = "src"
-    ["status"] = status
-  }
-}
-
-local function e2eJob(app: String) = new Job {
-  name = "\(app)-e2e"
-  max_in_flight = 3
-  build_log_retention = new { builds = 500 }
-  on_failure = putStatus("\(app)-pull-request", "e2e tests", "failure")
-  plan {
-    new GetStep {
-      get = "src"
-      params = new { ["integration_tool"] = "checkout" }
-      resource = "\(app)-pull-request"
-      trigger = true
-      version = "every"
-    }
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        new GetStep { get = "pay-ci" resource = "pay-ci" }
-        putStatus("\(app)-pull-request", "e2e tests", "pending")
-      }
-    }
-    new TaskStep {
-      task = "update-submodule"
-      config {
-        image_resource { 
-          // Sample output has a name property, but image_resource is anonymous according
-          // to https://github.com/alphagov/pkl-concourse-pipeline/blob/pkl-concourse-pipeline%400.0.4/src/TaskConfig.pkl#L6
-          type = "registry-image"
-          source {
-            ["repository"] = "governmentdigitalservice/pay-concourse-runner"
-          }
-        }
-        inputs = new Listing { 
-          new TaskConfig.Input { name = "src" }
-        }
-        outputs = new Listing { 
-          new TaskConfig.Output { name = "src" }
-        }
-        params = new {
-          ["GH_ACCESS_TOKEN"] = "((github-access-token))"
-        }
-        platform = "linux"
-        // TODO extract to file
-        run {
-          path = "bash"
-          dir = "src"
-          args = new Listing {
-            "-ec"
-            """
-        # rewrite the submodule url for https to add the token.
-        # The risk of setting the token in the url is mitigated since these files are not committed,
-        # the container is ephemeral and anyone with access to read the files could read the token from
-        # environment variable. Furthermore we redact the token from the files after the update.
-        sed -i "s/https://github.com/https://${GH_ACCESS_TOKEN}@github.com//" .gitmodules
-        git submodule init -q data
-        git submodule update data
-        sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
-        sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
-        """
-          }
-        }
-      }
-    }
-    shared_resources.generateDockerCredsConfigStep
-
-    new TaskStep {
-      task = "build-image"
-      file = "pay-ci/ci/tasks/build-docker-image.yml"
-      privileged = true
-      params = new {
-        ["app_name"] = "cardid"
-      }
-    }
-
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        new TaskStep {
-          task = "get-docker-image-info"
-          file = "pay-ci/ci/tasks/get-pr-build-docker-image-info.yml"
-          params = new { ["app_name"] = "cardid" }
-        }
-        new TaskStep {
-          task = "assume-role"
-          file = "pay-ci/ci/tasks/assume-role.yml"
-          params = new {
-            ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
-            ["AWS_ROLE_SESSION_NAME"] = "e2e-test-assume-role"
-          }
-        }
-      }
-    }
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" }
-        new LoadVarStep { load_var = "image_filename" file = "image_info/image_filename" }
-        new LoadVarStep { load_var = "image_tag" file = "image_info/tag" }
-      }
-    }
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        new PutStep {
-          put = "pull-request-builds-ecr"
-          get_params = new { ["skip_download"] = true }
-          params = new {
-            ["additional_tags"] = "image_info/tag"
-            ["image"] = "local_image/((.:image_filename))"
-          }
-        }
-        prepareCodeBuild(app, "prepare-e2e-codebuild.yml", "((.:image_tag))") 
-          |> withParam("PR_BUILD", "true")
-      }
-    }
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        runCodeBuild("run-card-e2e-tests", "card.json", 3)
-        runCodeBuild("run-zap-tests", "zap.json", 3)
-      }
-    }
-    putStatus("\(app)-pull-request", "e2e tests", "success")
-  }
-}
-
-// TODO move this and mixin to common
-local function prepareCodeBuild(project: String, taskFile: String, tag: String): TaskStep = new {
-  task = "prepare-codebuild"
-  file = "pay-ci/ci/tasks/\(taskFile)"
-  params = new {
-    ["PROJECT_UNDER_TEST"] = project
-    ["RELEASE_TAG_UNDER_TEST"] = tag
-    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
-  }
-}
-
-local function runCodeBuild(taskName: String, config: String, attemptCount: Int): TaskStep = new {
-  task = taskName
-  file = "pay-ci/ci/tasks/run-codebuild.yml"
-  when (attemptCount != 1) {
-    attempts = attemptCount
-  }
-  params = new {
-    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(config)"
-    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
-  }
-}
-
-local function withParam(key: String, value: String) = new Mixin {
-  params { [key] = value }
-}
-  /*
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/pr-ci.pkl")
-
+  for (app, config in e2e_test_apps) { e2eJob(app, config) }
   new {
     name = "ci-pr-test"
     max_in_flight = 3
     build_log_retention = new { builds = 500 }
     plan {
-      new GetStep {
-        get = "src"
-        params = new { ["integration_tool"] = "checkout" }
-        resource = "ci-pull-request"
-        trigger = true
-        version = "every"
-      }
-
+      pullRequestGetStep("ci-pull-request")
       putStatus("ci-pull-request", "test", "pending")
 
       new TaskStep {
@@ -268,72 +178,238 @@ local function withParam(key: String, value: String) = new Mixin {
             }
           }
         }
-        putStatus("ci-pull-request", "test", "failure")
+        on_failure = putStatus("ci-pull-request", "test", "failure")
       }
-
       putStatus("ci-pull-request", "test", "success")
     }
   }
-}
-
-
-resource_types {
-  shared_resources.pullRequestResourceType // Concourse has v0.21, default is v0.23
-}
-
-local resource_apps = new {
-  "adminusers"
-  "cardid"
-  "selfservice"
-  "publicauth"
-  "publicapi"
-  "products"
-  "products-ui"
-  "ledger"
-  "endtoend"
-  "connector" // original calls it card-connector
-  "frontend"  // original calls it card-fronted
-}
-
-resources = new {
-  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/pr-ci.pkl", "master")
-  githubRepo("card-connector-master", "pay-connector")
-  githubRepo("ledger-master", "pay-ledger")
-  shared_resources.payCiGitHubResource
-
-  for (app in resource_apps) {
-    new PayResources.PayGitHubPullRequestResource {
-      name = "\(app)-pull-request" 
-      repo = "pay-\(app)"
-    }
-  }
-  new PayResources.PayGitHubPullRequestResource {
-    name = "pay-ci-endtoend-config-pull-request" 
-    repo = "pay-ci"
-    source { ["paths"] = new Listing<String> { "ci/tasks/endtoend/" } }
-  }
-  new PayResources.PayGitHubPullRequestResource {
-    name = "ci-pull-request" 
-    repo = "pay-ci"
-    source { ["paths"] = new Listing<String> { "ci/pipelines/*"  "ci/tasks/*"} }
-  }
-
-  new Pipeline.Resource {
-    name = "pull-request-builds-ecr"
-    icon = "docker"
-    type = "registry-image"
-    source = new {
-      ["aws_access_key_id"] = "((readonly_access_key_id))"
-      ["aws_ecr_registry_id"] = "((pay_aws_test_account_id))"
-      ["aws_region"] = "eu-west-1"
-      ["aws_role_arn"] = "arn:aws:iam::((pay_aws_test_account_id)):role/concourse"
-      ["aws_secret_access_key"] = "((readonly_secret_access_key))"
-      ["aws_session_token"] = "((readonly_session_token))"
-      ["repository"] = "govukpay/pull-request-builds"
-      ["tag"] = "latest"
+  new {
+    name = "pay-ci-endtoend-config"
+    max_in_flight = 3
+    build_log_retention = new { builds = 500 }
+    on_failure = putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "failure")
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "ci" resource = "ci" } // TODO ci->pay-ci
+          pullRequestGetStep("pay-ci-endtoend-config-pull-request")
+        }
+      }
+      putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "pending")
+      assumeCodeBuildRole("pay-ci-endtoend-config-pr-assume-role")
+      new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" }
+      prepareCodeBuild("pay-ci", "prepare-e2e-codebuild.yml", "") 
+        |> withInputMapping("pay-ci", "src")
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          runCodeBuild("run-card-e2e-tests", "card.json", 3) |> withInputMapping("pay-ci", "ci")
+          runCodeBuild("run-products-e2e-tests", "products.json", 3) |> withInputMapping("pay-ci", "ci")
+          runCodeBuild("run-zap-e2e-tests", "zap.json", 3) |> withInputMapping("pay-ci", "ci")
+        }
+      }
+      putStatus("pay-ci-endtoend-config-pull-request", "e2e tests", "success")
     }
   }
 }
+
+local function assumeCodeBuildRole(session_name: String) = new TaskStep {
+  task = "assume-role"
+  file = "ci/ci/tasks/assume-role.yml" // TODO ci->pay-ci
+  params = new {
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/pay-cd-pay-dev-codebuild-executor-test-12"
+    ["AWS_ROLE_SESSION_NAME"] = session_name
+  }
+  input_mapping = new { ["pay-ci"] = "ci" } // TODO remove when ci->pay-ci
+}
+
+local function putStatus(stepName: String, context: String, status: String) = new PutStep {
+  put = stepName 
+  get_params = new { ["skip_download"] = true }
+  params = new {
+    ["context"] = context
+    ["path"] = "src"
+    ["status"] = status
+  }
+}
+
+local function e2eJob(app: String, config: AppConfig) = new Job {
+  name = "\(config.job_name)-e2e" // TODO rename card-connector
+  // name = "\(_name)-e2e" // TODO rename card-connnector
+  max_in_flight = 3
+  build_log_retention = new { builds = 500 }
+  on_failure = putStatus("\(config.job_name)-pull-request", "e2e tests", "failure")
+  plan {
+    new GetStep {
+      get = "src"
+      params = new { ["integration_tool"] = "checkout" }
+      resource = "\(config.job_name)-pull-request"
+      trigger = true
+      version = "every"
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new GetStep { get = "ci" resource = "ci" } // TODO ci->pay-ci
+        putStatus("\(config.job_name)-pull-request", "e2e tests", "pending")
+      }
+    }
+
+    when (config.node_build) {
+      new Pipeline.TaskStep {
+        task = "build"
+        file = "ci/ci/tasks/node-build-pr.yml" // TODO ci->pay-ci
+        params = new { ["skip_tests"] = "true" }
+      }
+    }
+
+    when (config.use_cardid_submodule) { updateCardidSubmodule() }
+    // TODO replace with shared_resources.generateDockerCredsConfigStep when ci->pay-ci
+    new Pipeline.TaskStep {
+      task = "generate-docker-creds-config"
+      file = "ci/ci/tasks/generate-docker-config-file.yml"
+      params = new {
+          ["USERNAME"] = "((docker-username))"
+          ["PASSWORD"] = "((docker-access-token))"
+          ["EMAIL"] = "((docker-email))"
+      }
+    }
+
+    new TaskStep {
+      task = "build-image"
+      file = "ci/ci/tasks/build-docker-image.yml" // TODO ci->pay-ci
+      privileged = true
+      params = new {
+        ["app_name"] = app
+      }
+    }
+
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new TaskStep {
+          task = "get-docker-image-info"
+          file = "ci/ci/tasks/get-pr-build-docker-image-info.yml" // TODO ci->pay-ci
+          params = new { ["app_name"] = app }
+        }
+        assumeCodeBuildRole("e2e-test-assume-role")
+      }
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new LoadVarStep { load_var = "role" file = "assume-role/assume-role.json" }
+        new LoadVarStep { load_var = "image_filename" file = "image_info/image_filename" }
+        new LoadVarStep { load_var = "image_tag" file = "image_info/tag" }
+      }
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new PutStep {
+          put = "pull-request-builds-ecr"
+          get_params = new { ["skip_download"] = true }
+          params = new {
+            ["additional_tags"] = "image_info/tag"
+            ["image"] = "local_image/((.:image_filename))"
+          }
+        }
+        prepareCodeBuild(app, "prepare-e2e-codebuild.yml", "((.:image_tag))") 
+          |> withParam("PR_BUILD", "true")
+          |> withInputMapping("pay-ci", "ci")
+      }
+    }
+    when (config.tests.length > 1) {
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          for (test in config.tests) {
+            runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 3) |> withInputMapping("pay-ci", "ci")
+          }
+        }
+      }
+    } else {
+      for (test in config.tests) {
+        runCodeBuild("run-\(test)-e2e-tests", "\(test).json", 1) |> withInputMapping("pay-ci", "ci")
+      }
+    }
+    putStatus("\(config.job_name)-pull-request", "e2e tests", "success")
+  }
+}
+
+local function updateCardidSubmodule() = new TaskStep {
+  task = "update-submodule"
+  config {
+    image_resource { 
+      // Sample output has a name property, but image_resource is anonymous according
+      // to https://github.com/alphagov/pkl-concourse-pipeline/blob/pkl-concourse-pipeline%400.0.4/src/TaskConfig.pkl#L6
+      type = "registry-image"
+      source {
+        ["repository"] = "governmentdigitalservice/pay-concourse-runner"
+      }
+    }
+    inputs = new Listing { 
+      new TaskConfig.Input { name = "src" }
+    }
+    outputs = new Listing { 
+      new TaskConfig.Output { name = "src" }
+    }
+    params = new {
+      ["GH_ACCESS_TOKEN"] = "((github-access-token))"
+    }
+    platform = "linux"
+    // TODO extract to file
+    run {
+      path = "bash"
+      dir = "src"
+      args = new Listing {
+        "-ec"
+        """
+    # rewrite the submodule url for https to add the token.
+    # The risk of setting the token in the url is mitigated since these files are not committed,
+    # the container is ephemeral and anyone with access to read the files could read the token from
+    # environment variable. Furthermore we redact the token from the files after the update.
+    sed -i "s/https:\\/\\/github.com/https:\\/\\/${GH_ACCESS_TOKEN}@github.com\\//" .gitmodules
+    git submodule init -q data
+    git submodule update data
+    sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
+    sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
+    """
+      }
+    }
+  }
+}
+
+local function prepareCodeBuild(project: String, taskFile: String, tag: String): TaskStep = new {
+  task = "prepare-codebuild"
+  file = "ci/ci/tasks/\(taskFile)" // TODO ci->pay-ci
+  params = new {
+    ["PROJECT_UNDER_TEST"] = project
+    when (tag.length > 0) {
+      ["RELEASE_TAG_UNDER_TEST"] = tag
+    }
+    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+  }
+}
+
+local function runCodeBuild(taskName: String, config: String, attemptCount: Int): TaskStep = new {
+  task = taskName
+  file = "ci/ci/tasks/run-codebuild.yml" // TODO ci->pay-ci
+  when (attemptCount != 1) {
+    attempts = attemptCount
+  }
+  params = new {
+    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(config)"
+    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+  }
+}
+
+local function withParam(key: String, value: String) = new Mixin {
+  params { [key] = value }
+}
+
+local function withInputMapping(from: String, to: String) = new Mixin {
+  input_mapping = new { [from] = to } // TODO remove when ci->pay-ci
+}
+
 
 local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
   type = "git"
@@ -344,4 +420,3 @@ local function githubRepo(_name: String, repo: String) = new Pipeline.Resource {
     ["uri"] = "https://github.com/alphagov/\(repo)"
     }
 }
-*/

--- a/ci/scripts/check-pipelines-and-tasks.sh
+++ b/ci/scripts/check-pipelines-and-tasks.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+
+apk add git shellcheck
+go install github.com/alphagov/paas-cf/tools/pipecleaner@latest
+
+cd /tmp/
+
+echo "c7d331052a6bf552b017adf5288b8e162346157c  fly-7.6.0-linux-amd64.tgz" > fly-7.6.0-linux-amd64.tgz.sha1
+wget -c https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-linux-amd64.tgz -O fly-7.6.0-linux-amd64.tgz
+sha1sum -c fly-7.6.0-linux-amd64.tgz.sha1
+tar -O -zxf fly-7.6.0-linux-amd64.tgz > /usr/local/bin/fly
+chmod u+x /usr/local/bin/fly
+
+cd -
+
+pipecleaner --rubocop=false ci/tasks/*.yml
+
+find ci/pipelines -name '*.yml' | while read -r PIPELINE; do
+  echo "Validating: $PIPELINE"
+  fly validate-pipeline -c "$PIPELINE"
+  echo
+done

--- a/ci/scripts/update-cardid-submodule.sh
+++ b/ci/scripts/update-cardid-submodule.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+# rewrite the submodule url for https to add the token.
+# The risk of setting the token in the url is mitigated since these files are not committed,
+# the container is ephemeral and anyone with access to read the files could read the token from
+# environment variable. Furthermore we redact the token from the files after the update.
+sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+git submodule init -q data
+git submodule update data
+sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
+sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config

--- a/ci/tasks/check-pipelines-and-tasks.yml
+++ b/ci/tasks/check-pipelines-and-tasks.yml
@@ -6,6 +6,7 @@ image_resource:
     repository: golang
     tag: 1.20-alpine
 inputs:
+  - name: pay-ci
   - name: src
 run:
   path: sh

--- a/ci/tasks/check-pipelines-and-tasks.yml
+++ b/ci/tasks/check-pipelines-and-tasks.yml
@@ -10,4 +10,4 @@ inputs:
 run:
   path: sh
   dir: src
-  args: ["../pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]
+  args: ["pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]

--- a/ci/tasks/check-pipelines-and-tasks.yml
+++ b/ci/tasks/check-pipelines-and-tasks.yml
@@ -10,4 +10,4 @@ inputs:
 run:
   path: sh
   dir: src
-  args: ["pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]
+  args: ["../pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]

--- a/ci/tasks/check-pipelines-and-tasks.yml
+++ b/ci/tasks/check-pipelines-and-tasks.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: golang
+    tag: 1.20-alpine
+inputs:
+  - name: src
+run:
+  path: sh
+  dir: src
+  args: ["pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]

--- a/ci/tasks/update-cardid-submodule.yml
+++ b/ci/tasks/update-cardid-submodule.yml
@@ -5,6 +5,7 @@ image_resource:
   source:
     repository: governmentdigitalservice/pay-concourse-runner
 inputs:
+  - name: pay-ci
   - name: src
 params:
   GH_ACCESS_TOKEN: ((github-access-token))
@@ -13,4 +14,4 @@ outputs:
 run:
   path: ash
   dir: src
-  args: ["pay-ci/ci/scripts/update-cardid-submodule.sh"]
+  args: ["../pay-ci/ci/scripts/update-cardid-submodule.sh"]

--- a/ci/tasks/update-cardid-submodule.yml
+++ b/ci/tasks/update-cardid-submodule.yml
@@ -1,0 +1,18 @@
+---
+config:
+  container_limits: {}
+  platform: linux
+  image_resource:
+    type: registry-image
+    source:
+      repository: governmentdigitalservice/pay-concourse-runner
+  inputs:
+    - name: src
+  params:
+    GH_ACCESS_TOKEN: ((github-access-token))
+  outputs:
+    - name: src
+  run:
+    path: ash
+    dir: src
+    args: ["pay-ci/ci/scripts/update-cardid-submodule.sh"]

--- a/ci/tasks/update-cardid-submodule.yml
+++ b/ci/tasks/update-cardid-submodule.yml
@@ -1,18 +1,16 @@
 ---
-config:
-  container_limits: {}
-  platform: linux
-  image_resource:
-    type: registry-image
-    source:
-      repository: governmentdigitalservice/pay-concourse-runner
-  inputs:
-    - name: src
-  params:
-    GH_ACCESS_TOKEN: ((github-access-token))
-  outputs:
-    - name: src
-  run:
-    path: ash
-    dir: src
-    args: ["pay-ci/ci/scripts/update-cardid-submodule.sh"]
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentdigitalservice/pay-concourse-runner
+inputs:
+  - name: src
+params:
+  GH_ACCESS_TOKEN: ((github-access-token))
+outputs:
+  - name: src
+run:
+  path: ash
+  dir: src
+  args: ["pay-ci/ci/scripts/update-cardid-submodule.sh"]


### PR DESCRIPTION
Re-implement the PR pipeline in Pkl. Makes these changes, which, I hope, are all an improvement.

* change filename base from `pr` to `pr-ci`, matching the pipeline name.
* replace bespoke "deploy pipeline" with the standard one from `common/`.
* calls the `pay-ci` resource `pay-ci` rather than `ci`, making `input_mapping` (mostly) redundant.
* breaks out embedded scripts into their own tasks and files.
* makes future removal of the cardid submodule very easy.
* calls frontend and connector `frontend` and `connector` rather than `card-frontend` and `card-connector`.

The only other changes should be trivial enforcements of consistency, like numbers of retries on CodeBuild jobs.

[Here is a successful cardid build (with submodule)](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/cardid-e2e/builds/580)
[Here is a successful adminusers build](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/adminusers-e2e/builds/1550).

**NOTE** before this is merged, the reference to the branch needs changing to `master`.