### PR TITLE
PP-12582-break-out-pr-script

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1168,41 +1168,7 @@ jobs:
     - <<: *put-test-pending-status
       put: ci-pull-request
     - task: check-pipelines-and-tasks
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source:
-            repository: golang
-            tag: 1.20-alpine
-        inputs:
-          - name: src
-        run:
-          path: sh
-          dir: src
-          args:
-            - -ec
-            - |
-              apk add git shellcheck
-              go install github.com/alphagov/paas-cf/tools/pipecleaner@latest
-
-              cd /tmp/
-
-              echo "c7d331052a6bf552b017adf5288b8e162346157c  fly-7.6.0-linux-amd64.tgz" > fly-7.6.0-linux-amd64.tgz.sha1
-              wget -c https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-linux-amd64.tgz -O fly-7.6.0-linux-amd64.tgz
-              sha1sum -c fly-7.6.0-linux-amd64.tgz.sha1
-              tar -O -zxf fly-7.6.0-linux-amd64.tgz > /usr/local/bin/fly
-              chmod u+x /usr/local/bin/fly
-
-              cd -
-
-              pipecleaner --rubocop=false ci/tasks/*.yml
-
-              find ci/pipelines -name '*.yml' | while read -r PIPELINE; do
-                echo "Validating: $PIPELINE"
-                fly validate-pipeline -c "$PIPELINE"
-                echo
-              done
+      file: ci/ci/tasks/check-pipelines-and-tasks.yml
       on_failure:
         <<: *put-test-failed-status
         put: ci-pull-request

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -639,34 +639,7 @@ jobs:
         - <<: *put-e2e-pending-status
           put: cardid-pull-request
         - task: update-submodule
-          config:
-            container_limits: {}
-            platform: linux
-            image_resource:
-              type: registry-image
-              source:
-                repository: governmentdigitalservice/pay-concourse-runner
-            inputs:
-              - name: src
-            params:
-              GH_ACCESS_TOKEN: ((github-access-token))
-            outputs:
-              - name: src
-            run:
-              path: bash
-              dir: src
-              args:
-                - -ec
-                - |
-                  # rewrite the submodule url for https to add the token.
-                  # The risk of setting the token in the url is mitigated since these files are not committed,
-                  # the container is ephemeral and anyone with access to read the files could read the token from
-                  # environment variable. Furthermore we redact the token from the files after the update.
-                  sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
-                  git submodule init -q data
-                  git submodule update data
-                  sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
-                  sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config
+          file: tasks/update-cardid-submodule.yml
       - <<: *generate-docker-creds-config
       - <<: *build-docker-image
         params:

--- a/ci/scripts/check-pipelines-and-tasks.sh
+++ b/ci/scripts/check-pipelines-and-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ec
+#!/bin/sh -e
 
 apk add git shellcheck
 go install github.com/alphagov/paas-cf/tools/pipecleaner@latest

--- a/ci/scripts/check-pipelines-and-tasks.sh
+++ b/ci/scripts/check-pipelines-and-tasks.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -ec
+
+apk add git shellcheck
+go install github.com/alphagov/paas-cf/tools/pipecleaner@latest
+
+cd /tmp/
+
+echo "c7d331052a6bf552b017adf5288b8e162346157c  fly-7.6.0-linux-amd64.tgz" > fly-7.6.0-linux-amd64.tgz.sha1
+wget -c https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-linux-amd64.tgz -O fly-7.6.0-linux-amd64.tgz
+sha1sum -c fly-7.6.0-linux-amd64.tgz.sha1
+tar -O -zxf fly-7.6.0-linux-amd64.tgz > /usr/local/bin/fly
+chmod u+x /usr/local/bin/fly
+
+cd -
+
+pipecleaner --rubocop=false ci/tasks/*.yml
+
+find ci/pipelines -name '*.yml' | while read -r PIPELINE; do
+  echo "Validating: $PIPELINE"
+  fly validate-pipeline -c "$PIPELINE"
+  echo
+done

--- a/ci/scripts/update-cardid-submodule.sh
+++ b/ci/scripts/update-cardid-submodule.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+# rewrite the submodule url for https to add the token.
+# The risk of setting the token in the url is mitigated since these files are not committed,
+# the container is ephemeral and anyone with access to read the files could read the token from
+# environment variable. Furthermore we redact the token from the files after the update.
+sed -i "s/https:\/\/github.com/https:\/\/${GH_ACCESS_TOKEN}@github.com\//" .gitmodules
+git submodule init -q data
+git submodule update data
+sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .gitmodules
+sed -i "s/${GH_ACCESS_TOKEN}/token_redacted/" .git/config

--- a/ci/tasks/check-pipelines-and-tasks.yml
+++ b/ci/tasks/check-pipelines-and-tasks.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: golang
+    tag: 1.20-alpine
+inputs:
+  - name: src
+run:
+  path: sh
+  dir: src
+  args: ["../pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]

--- a/ci/tasks/check-pipelines-and-tasks.yml
+++ b/ci/tasks/check-pipelines-and-tasks.yml
@@ -10,4 +10,4 @@ inputs:
 run:
   path: sh
   dir: src
-  args: ["../pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]
+  args: ["pay-ci/ci/scripts/check-pipelines-and-tasks.sh"]

--- a/ci/tasks/update-cardid-submodule.yml
+++ b/ci/tasks/update-cardid-submodule.yml
@@ -1,0 +1,18 @@
+---
+config:
+  container_limits: {}
+  platform: linux
+  image_resource:
+    type: registry-image
+    source:
+      repository: governmentdigitalservice/pay-concourse-runner
+  inputs:
+    - name: src
+  params:
+    GH_ACCESS_TOKEN: ((github-access-token))
+  outputs:
+    - name: src
+  run:
+    path: ash
+    dir: src
+    args: ["pay-ci/ci/scripts/update-cardid-submodule.sh"]


### PR DESCRIPTION
Move embedded shell scripts to external tasks and scripts. This is to make the pipeline a little bit cleaner for its conversion to Pkl.