### PR TITLE
BAU-add-retries-to-sns-sub-check

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
@@ -125,6 +125,7 @@ for (env, time in Map("staging-2", "every-morning-at-six", "production-2", "ever
         new TaskStep {
           task = "assume-role"
           file = "pay-ci/ci/tasks/assume-role.yml"
+          attempts = 3
           params {
             when (env == "production") {
               ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_prod_account_id)):role/concourse"
@@ -139,6 +140,7 @@ for (env, time in Map("staging-2", "every-morning-at-six", "production-2", "ever
         new TaskStep {
           task = "check-sns-subscriptions"
           file = "pay-ci/ci/tasks/check-sns-subscriptions.yml"
+          attempts = 3
           params {
             ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
             ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"

--- a/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
@@ -111,6 +111,7 @@ for (env, time in Map("test-12", "every-morning-at-five", "test-perf-1", "every-
         new TaskStep {
           task = "assume-role"
           file = "pay-ci/ci/tasks/assume-role.yml"
+          attempts = 3
           params {
             ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_\(env)_account_id)):role/concourse"
             ["AWS_ROLE_SESSION_NAME"] = "zendesk-unsubscriber-assume-role"
@@ -120,6 +121,7 @@ for (env, time in Map("test-12", "every-morning-at-five", "test-perf-1", "every-
         new TaskStep {
           task = "check-sns-subscriptions"
           file = "pay-ci/ci/tasks/check-sns-subscriptions.yml"
+          attempts = 3
           params {
             ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
             ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"


### PR DESCRIPTION
We saw two failures on the assume-role step, so retry it. These tasks run very frequently, and if the state they check for occurs, they will fail repeatedly, so intermittent failures can be ignored. They also run quickly, so I think it's fine to add retries to the tests themselves. They make quite a few API calls, so the odd failure isn't impossible.
