### PR TITLE
PP-12665: Use pay pool instead of built-in pool type

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -8,6 +8,10 @@ hidden pools_to_init = new Listing<String> {}
 
 hidden concourseTeamName = "UPDATE_ME"
 
+resource_types {
+  shared_resources_for_lock_pools.payPoolResourceType
+}
+
 resources {
   new {
     name = "lock-pool-repo"

--- a/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_lock_pools.pkl
@@ -1,9 +1,18 @@
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
 
+payPoolResourceType = new Pipeline.ResourceType {
+  name = "pay-pool"
+  type = "registry-image"
+  source = new {
+    ["repository"] = "governmentdigitalservice/pay-pool-resource"
+    ["tag"] = "latest"
+  }
+}
+
 class LockPoolResource extends Pipeline.Resource {
   hidden pool: String
   name = "lock-pool-\(pool)"
-  type = "pool"
+  type = "pay-pool"
   icon = "pool"
   source {
     ["branch"] = "pool"

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -22,7 +22,8 @@ local awsEnvVars = Map("account", "production",
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
   shared_resources_for_metrics.prometheusPushgatewayResourceType
-  shared_resources_for_annotations.grafanaAnnotationResourceType 
+  shared_resources_for_annotations.grafanaAnnotationResourceType
+  shared_resources_for_lock_pools.payPoolResourceType
 }
 
 resources = new {

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -22,7 +22,8 @@ local awsEnvVars = Map("account", "staging",
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
   shared_resources_for_metrics.prometheusPushgatewayResourceType
-  shared_resources_for_annotations.grafanaAnnotationResourceType 
+  shared_resources_for_annotations.grafanaAnnotationResourceType
+  shared_resources_for_lock_pools.payPoolResourceType
 }
 
 resources = new {

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -64,7 +64,8 @@ local testEnvConfigForApps: Mapping<Identifier, AdditionalAppConfigForTestEnv> =
 resource_types {
   shared_resources_for_slack_notifications.slackNotificationResourceType
   shared_resources_for_metrics.prometheusPushgatewayResourceType
-  shared_resources_for_annotations.grafanaAnnotationResourceType 
+  shared_resources_for_annotations.grafanaAnnotationResourceType
+  shared_resources_for_lock_pools.payPoolResourceType
 }
 
 local function withTagRegex(regex: String) = new Mixin {


### PR DESCRIPTION
Use the pay pool resource instead of the built in pool resource

After warning the devs I applied this in deploy-to-test, I launched deploy-adminsers and deploy-cardid, adminusers claimed the lock, and I was able to cancel cardid while it was waiting for the lock:

https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-cardid/builds/492

🥳 