### PR TITLE
PP-12730 Make JDK 21 default version for Java tests

### DIFF
--- a/.github/workflows/_run-app-as-provider-contract-tests.yml
+++ b/.github/workflows/_run-app-as-provider-contract-tests.yml
@@ -9,7 +9,7 @@ on:
       java_version:
         type: string
         required: false
-        default: 11
+        default: 21
         description: JDK version to setup and run tests. Defaults to 11
     secrets:
       pact_broker_username:

--- a/.github/workflows/_run-java-tests-and-publish-pacts.yml
+++ b/.github/workflows/_run-java-tests-and-publish-pacts.yml
@@ -11,8 +11,8 @@ on:
       java_version:
         type: string
         required: false
-        default: 11
-        description: JDK version to setup and run tests. Defaults to 11
+        default: 21
+        description: JDK version to setup and run tests. Defaults to 21
       check_for_openapi_file_changes:
         type: boolean
         required: false

--- a/.github/workflows/_run-provider-pact-tests-for-consumer.yml
+++ b/.github/workflows/_run-provider-pact-tests-for-consumer.yml
@@ -14,7 +14,7 @@ on:
       java_version:
         type: string
         required: false
-        default: 11
+        default: 21
     secrets:
       pact_broker_username:
         required: true


### PR DESCRIPTION
## WHAT
- Make JDK 21 the default version for all Java apps as all except Ledger are on Java 21. Ledger can still run tests with JDK21 where target release 11 and will soon be on Java21.