### PR TITLE
PP-12778: Fix adot deploy pipeline

### DIFF
--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -275,7 +275,7 @@ local function getBuildAndPushCandidateJob(app): Job = new {
     }
     getTaskToRunCodeBuild(app, "manifest")
 
-    when (getTestEnvConfig(app.name).run_e2e_tests == false || app.name == "adot") {
+    when (getTestEnvConfig(app.name).run_e2e_tests == false && app.name != "adot") {
       new InParallelStep {
         in_parallel = new InParallelConfig {
           steps = new Listing<Step> {
@@ -486,6 +486,7 @@ local function getAdotIntegrationTest(app): Job = new {
             }
           }
           loadVar("candidate-image-tag", "adot-candidate/tag")
+          assumeRetagRole()
         }
       }
     }
@@ -522,39 +523,44 @@ local function getAdotIntegrationTest(app): Job = new {
         }
       }
     }
+
     new InParallelStep {
       in_parallel = new InParallelConfig {
-        steps {
-          new DoStep {
-            do = new Listing {
-              new PutStep {
-                put = "adot-ecr-registry-test"
-                params {
-                  ["image"] = "adot-candidate/image.tar"
-                  ["additional_tags"] = "parse-candidate-tag/release-tag"
-                }
-                get_params {
-                  ["skip_download"] = true
-                }
-              }
-              new PutStep {
-                put = "adot-latest"
-                params {
-                  ["image"] = "adot-candidate/image.tar"
-                }
-                get_params {
-                  ["skip_download"] = true
-                }
-              }
+        steps = new Listing<Step> {
+          new TaskStep {
+            task = "retag-candidate-as-release-in-ecr"
+            file = "pay-ci/ci/tasks/manifest-retag.yml"
+            params {
+              ["DOCKER_LOGIN_ECR"] = "1"
+              ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
+              ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
+              ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:release_image_tag))"
+              ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
+              ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
+              ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
             }
           }
-          new PutStep {
-            put = "adot-dockerhub"
+          new TaskStep {
+            task = "retag-candidate-as-latest-in-ecr"
+            file = "pay-ci/ci/tasks/manifest-retag.yml"
             params {
-              ["image"] = "adot-candidate/image.tar"
+              ["DOCKER_LOGIN_ECR"] = "1"
+              ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
+              ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
+              ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):latest"
+              ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
+              ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
+              ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
             }
-            get_params {
-              ["skip_download"] = true
+          }
+          when (app.is_a_java_or_node_app == true || app.name == "adot" || app.name == "nginx-proxy") {
+            new TaskStep {
+              task = "retag-candidate-as-release-in-dockerhub"
+              file = "pay-ci/ci/tasks/manifest-retag.yml"
+              params {
+                ["SOURCE_MANIFEST"] = "\(app.getDockerRepo()):((.:candidate-image-tag))"
+                ["NEW_MANIFEST"] = "\(app.getDockerRepo()):latest-master"
+              }
             }
           }
         }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -486,6 +486,12 @@ local function getAdotIntegrationTest(app): Job = new {
         }
       }
     }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        loadVarWithJsonFormat("retag-role", "assume-retag-role/assume-role.json")
+        loadVar("release_image_tag", "parse-candidate-tag/release-tag")
+      }
+    }
     new TaskStep {
       task = "run-toolbox-metric-tests"
       config {

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -93,10 +93,6 @@ resources = new {
     }
   }
 
-  shared_resources.payDockerHubResource("adot-dockerhub", "governmentdigitalservice/pay-adot", "latest-master")
-  (shared_resources.payECRResource("adot-latest", "govukpay/adot",
-    "pay_aws_test_account_id")) { source { ["tag"] = "latest" } }
-
   shared_resources_for_slack_notifications.slackNotificationResource
   (shared_resources_for_annotations.grafanaAnnotationResource) {
     source { ["tags"] = new Listing<String> { "release" "test-12" } }
@@ -706,9 +702,6 @@ local function getJobToPushImageToStaging(app): Job = new {
             }
             trigger = true
             passed {
-              when (app.name == "adot") {
-                "run-adot-integration-test"
-              }
               when (app.name == "nginx-forward-proxy") {
                 "smoke-test-frontend"
               }


### PR DESCRIPTION
The adot deploy pipeline is supposed to build and push a candidate, then deploy toolbox with the candidate, and then run the adot-integration test, once that passes it should be retagged as release. In the conversion to pkl we've lost that behaviour and instead the build-and-push-adot-candidate also retags as XX-release.

This is made worse by the adot-integration-test job doing a push of its local XX-candidate image (which is architecture specific) as XX-release, meaning we overwrite the XX-release manifest with an XX-release intel image.

This PR changes build-and-push-adot-candidate to not retag as release, and updates the adot-integration-test to retag instead of pushing an image

This also means removing the ecr latest and dockerhub latest resources (since they aren't accessed via a PUT anymore, but instead happen implicitly in our codebuild jobs), and also break the "passed" condition on push-adot-to-staging-ecr which references the ecr integration test image.

I had to apply this to test it:

The [build-and-push-adot-candidate-job](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/build-and-push-adot-candidate/builds/23) is now behaving correctly

It generated adot:17-candidate with sha256 8f31b35e527a5c2b2f6d3b8d9c747a5bb869535c59e65b0ae919d74a434f704b

Which triggered [deploy-toolbox](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-toolbox/builds/505)

Which once complete triggered [run-adot-integration-test](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/run-adot-integration-test/builds/46.1)

It created adot:17-release with sha256 8f31b35e527a5c2b2f6d3b8d9c747a5bb869535c59e65b0ae919d74a434f704b

Which triggered [push-adot-to-staging-ecr](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/push-adot-to-staging-ecr/builds/23)