### PR TITLE
BAU: Run concourse-runner tests with Java 21

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -153,7 +153,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing<Step> {
           new TestConcourseRunnerTask {
-            image = "concourse-runner-image"
+            image = "concourse-runner-image-with-java-21"
             task = "test-concourse-runner"
             repo = "adminusers-master"
           }


### PR DESCRIPTION
Leftover from the Java 21 upgrade - our guinea pig app (adminusers) is now on Java 21 so the old concourse-runner image test will fail.