### PR TITLE
BAU: Run concourse-runner tests with Java 21 again

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-runner.pkl
@@ -153,7 +153,7 @@ jobs = new {
       new InParallelStep {
         in_parallel = new Listing<Step> {
           new TestConcourseRunnerTask {
-            image = "concourse-runner-image-with-java-21"
+            image = "concourse-runner-with-java-21-image"
             task = "test-concourse-runner"
             repo = "adminusers-master"
           }


### PR DESCRIPTION
https://github.com/alphagov/pay-ci/pull/1245 didn't quite work as we mislabelled the image source.