### PR TITLE
PP-12835: Update pact broker version

### DIFF
--- a/ci/docker/pact-broker/Dockerfile
+++ b/ci/docker/pact-broker/Dockerfile
@@ -1,1 +1,1 @@
-FROM pactfoundation/pact-broker:2.54.0.0
+FROM pactfoundation/pact-broker:2.119.1-pactbroker2.110.0@sha256:6eed4ef1457bc34c9768d4cbfab83f34f7e16ed9acac1ac8fe7012ac381101cf


### PR DESCRIPTION
 locally I ran up a pact broker of our current version (2.54.0.0), ran consumer tests for products-ui and ledger, and provider tests for connector and products and everything is happy on the current version (connector of course complains some consumers haven't got any pacts published, but the ledger ones all pass)

Then I updated the pact broker to the very latest version (keeping the same local postgres db), it started up, migrated the db, and I can still successfully run all the tests and publish all the pacts again
