### PR TITLE
Pp 12835/fix pact broker image tag extraction

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
+++ b/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
@@ -91,30 +91,9 @@ jobs {
       shared_resources.generateDockerCredsConfigStep
       new TaskStep {
         task = "get-pact-broker-image-tag"
-        config {
-          platform = "linux"
-          image_resource {
-            type = "registry-image"
-            source {
-              ["repository"] = "alpine"
-              ["tag"] = "latest"
-            }
-          }
-          inputs = new Listing {
-            new TaskConfig.Input { name = "pact-broker-src" }
-          }
-          outputs = new Listing {
-            new TaskConfig.Output { name = "tags" }
-          }
-          run {
-            path = "ash"
-            args {
-              "-ec"
-              """
-              cat pact-broker-src/ci/docker/pact-broker/Dockerfile | grep -i FROM | head -n 1 | awk '{print $2;}' | cut -f 2 -d ":" | tee tags/tag
-              """
-            }
-          }
+        file = "pay-ci/ci/tasks/get-image-tag-from-dockerfile.yml"
+        input_mapping {
+          ["src"] = "pact-broker-src"
         }
       }
       new TaskStep {

--- a/ci/scripts/get-image-tag-from-dockerfile.sh
+++ b/ci/scripts/get-image-tag-from-dockerfile.sh
@@ -1,0 +1,27 @@
+#!/bin/ash
+# shellcheck shell=dash
+
+# Image definitions are going to be of one of the forms:
+#
+#   image_name:tag
+#   image_name:tag@sha256:<sha>
+#   image_name@sha256
+
+set -euo pipefail
+
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "Error: Dockerfile $DOCKERFILE not found"
+  exit 1
+fi
+
+BASE_IMAGE=$(grep "^FROM " "$DOCKERFILE" | awk '{ print $2; }' | sort | uniq)
+
+if [ "$(echo "$BASE_IMAGE" | wc -l)" -ne 1 ]; then
+  echo "Error: There's not exactly a single unique FROM line definition in the Dockerfile, can't extract a single tag"
+  exit 1
+fi
+
+IMAGE_AND_TAG=$(echo "$BASE_IMAGE" | cut -f 1 -d "@")
+TAG=$(echo "$IMAGE_AND_TAG" | cut -f 2 -d ":")
+
+echo "$TAG" | tee tags/tag

--- a/ci/tasks/get-image-tag-from-dockerfile.yml
+++ b/ci/tasks/get-image-tag-from-dockerfile.yml
@@ -1,0 +1,14 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+    tag: latest
+inputs:
+  - name: pay-ci
+  - name: src
+params:
+  DOCKERFILE: "src/Dockerfile"
+run:
+  path: sh
+  args: ['pay-ci/ci/scripts/get-image-tag-from-dockerfile.sh']


### PR DESCRIPTION
The pact broker image tag extraction doesn't work correctly now we are specifying an image sha.

I've used my own prior art from https://github.com/alphagov/pay-ci/blob/master/.github/workflows/_validate_docker_image_is_manifest.yml to ensure I've got a standards compliant tag extraction. Since it's quite generic I made it a generic task in case we need it again in the future.