### PR TITLE
BAU-fix-broken-metrics

### DIFF
--- a/ci/tasks/create-notification-snippets.yml
+++ b/ci/tasks/create-notification-snippets.yml
@@ -40,7 +40,7 @@ run:
       # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${NGINX_IMAGE_TAG}" ] && \
-      NGINX_RELEASE_NUMBER=$(echo "${NGINX_IMAGE_TAG}" | sed 's/-release//') && \
+      NGINX_RELEASE_NUMBER=$(echo "${NGINX_IMAGE_TAG}" | sed "s/-[a-z]*//") && \
       echo -n "${NGINX_RELEASE_NUMBER}" | tee -a snippet/nginx_release_number && \
       echo "- <https://github.com/alphagov/pay-nginx-proxy/releases/tag/alpha_release-${NGINX_RELEASE_NUMBER}|nginx-proxy v${NGINX_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
@@ -48,7 +48,7 @@ run:
       # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${ADOT_IMAGE_TAG}" ] && \
-      ADOT_RELEASE_NUMBER=$(echo "${ADOT_IMAGE_TAG}" | sed 's/-release//') && \
+      ADOT_RELEASE_NUMBER=$(echo "${ADOT_IMAGE_TAG}" | sed "s/-[a-z]*//") && \
       echo -n "${ADOT_RELEASE_NUMBER}" | tee -a snippet/adot_release_number && \
       echo "- <https://github.com/alphagov/pay-adot/releases/tag/alpha_release-${ADOT_RELEASE_NUMBER}|adot v${ADOT_IMAGE_TAG}>" | \
       tee -a snippet/failure || true
@@ -56,7 +56,7 @@ run:
       # Disable the shellcheck rule telling us this isn't an if-then-else. We know, and it's the desirable
       # shellcheck disable=SC2015
       [ -n "${NGINX_FORWARD_PROXY_IMAGE_TAG}" ] && \
-      NGINX_FORWARD_PROXY_RELEASE_NUMBER=$(echo "${NGINX_FORWARD_PROXY_IMAGE_TAG}" | sed 's/-release//') && \
+      NGINX_FORWARD_PROXY_RELEASE_NUMBER=$(echo "${NGINX_FORWARD_PROXY_IMAGE_TAG}" | sed "s/-[a-z]*//") && \
       echo -n "${NGINX_FORWARD_PROXY_RELEASE_NUMBER}" | tee -a snippet/nginx_forward_proxy_release_number && \
       echo "- <https://github.com/alphagov/pay-nginx-forward-proxy/releases/tag/${NGINX_FORWARD_PROXY_IMAGE_TAG}|nginx-forward-proxy v${NGINX_FORWARD_PROXY_IMAGE_TAG}>" | \
       tee -a snippet/failure || true


### PR DESCRIPTION
Releases are failing because `19-candidate` is not a metric. Rather than just stripping `-release` from tags, now strip dash-anything. Same for adot, nginx, and forward-proxy.