### PR TITLE
PP-12758 Install docker-scout

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -24,6 +24,10 @@ RUN apk add --no-cache \
 
 RUN apk add --virtual build-dependencies build-base
 
+ENV DOCKER_HOME=/root/.docker
+RUN mkdir -p /root/.docker/cli-plugins
+RUN curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/v1.10.0/install.sh | sh -s --
+
 RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.86.0/pact-1.86.0-linux-x86_64.tar.gz \
     && tar xzf pact-1.86.0-linux-x86_64.tar.gz \
     && rm -f pact-1.86.0-linux-x86_64.tar.gz


### PR DESCRIPTION
## WHAT
- Install docker-scout in concourse-runner as per https://github.com/docker/scout-cli?tab=readme-ov-file#script-installation so we can run interval vulnerability scans
- Had to set DOCKER_HOME and RUN mkdir as otherwise build is failing with error `docker is not installed; refusing to install to '/root/.docker/cli-plugins' `

- Build output
<img width="965" alt="image" src="https://github.com/alphagov/pay-ci/assets/40598480/40962f33-2ca5-4ec3-a40e-7f96ae0d8ddb">
