### PR TITLE
PP-12758 Upgrade concourse-runner JDK to 21

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
   python3 \
   ca-certificates \
   jq \
-  openjdk11 \
+  openjdk21 \
   npm \
   maven \
   tini \

--- a/ci/scripts/test-concourse-runner.sh
+++ b/ci/scripts/test-concourse-runner.sh
@@ -22,6 +22,7 @@ https://maven.apache.org/xsd/settings-1.0.0.xsd">
 </settings>
 EOF
 
+## Test docker by running app tests
 mvn --global-settings settings.xml clean verify
 
 stop_docker


### PR DESCRIPTION
## WHAT
- Upgrades concourse-runner JDK version to 21 as we no longer have any apps using Java 11.
- We can remove concourse-runner-with-21 and use concourse-runner everywhere.