### PR TITLE
PP-12909: Run internal vulnerability scan quarterly

### DIFF
--- a/ci/pkl-pipelines/common/PayResources.pkl
+++ b/ci/pkl-pipelines/common/PayResources.pkl
@@ -42,3 +42,4 @@ class PayTimeResource extends Pipeline.Resource {
     ["location"] = "Europe/London"
   }
 }
+

--- a/ci/pkl-pipelines/common/shared_resources_for_times.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_times.pkl
@@ -27,3 +27,33 @@ function payIntervalResource(_name: String, interval: String): Pipeline.Resource
 function withLocation(timezone: String) = new Mixin {
   source { ["location"] = timezone }
 }
+
+cronResourceType: Pipeline.ResourceType = new {
+  name = "cron-resource"
+  type = "registry-image"
+  source = new {
+    ["repository"] = "governmentdigitalservice/pay-cron-resource"
+    ["tag"] = "latest"
+  }
+}
+
+class PayCronResource extends Pipeline.Resource {
+  type = "cron-resource"
+  icon = "calendar-clock-outline"
+  source {
+    ["location"] = "Europe/London"
+  }
+}
+
+quarterlyCronResource: Pipeline.Resource = new PayCronResource {
+  name = "quarterly"
+  source {
+    // At 00:00 on 1st of the month in March, June, September, and December.
+    ["expression"] = "0 0 1 MAR,JUN,SEP,DEC *"
+  }
+}
+
+getQuarterlyCronTrigger: Pipeline.GetStep = new {
+  get = "quarterly"
+  trigger = true
+}

--- a/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
+++ b/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
@@ -4,18 +4,21 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/shared_resources_for_times.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
 
 resource_types {
   shared_resources.pullRequestResourceType
   shared_resources.slackNotificationResourceType
+  shared_resources_for_times.cronResourceType
 }
 
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/internal-vulnerability-scan.pkl", "master")
   shared_resources.payCiGitHubResource
   shared_resources.slackNotificationResource
+  shared_resources_for_times.quarterlyCronResource
 }
 
 jobs = new {
@@ -24,7 +27,12 @@ jobs = new {
   new {
     name = "run-vulnerability-scan"
     plan {
-      new GetStep { get = "pay-ci" }
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "pay-ci" }
+          shared_resources_for_times.getQuarterlyCronTrigger
+        }
+      }
       assumeReadFromStagingEcrRole()
       new LoadVarStep {
         load_var = "assume-read-from-staging-ecr-role"


### PR DESCRIPTION
Use our fork of the cron resource https://github.com/alphagov/cron-resource to trigger the internal vulnerability scan to run quarterly

I set the cron expression to `39 14 19 JUL,MAR,JUN,SEP,DEC *` in order to test that this works. It triggered this run https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/internal-vulnerability-scan/jobs/run-vulnerability-scan/builds/4 which you can see triggered as expected
![Screenshot 2024-07-19 at 14 41 40](https://github.com/user-attachments/assets/1698d4ae-20e2-41a2-ba4f-70214b5695a7)

