### PR TITLE
PP-12908: Use Jira API username and token, and base64 encode it in the script

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
+++ b/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
@@ -89,7 +89,8 @@ local function createJiraStory(): TaskStep = new TaskStep {
   privileged = true
 
   params {
-    ["JIRA_API_BASE64_TOKEN"] = "((jira-api-base64-encoded-email-and-token))"
+    ["JIRA_API_USERNAME"] = "((jira-api-username))"
+    ["JIRA_API_TOKEN"] = "((jira-api-token))"
     ["JIRA_BASE_URL"] = "((jira-base-url))"
   }
 }

--- a/ci/scripts/run-vulnerability-scan/create-jira-issue.sh
+++ b/ci/scripts/run-vulnerability-scan/create-jira-issue.sh
@@ -6,6 +6,8 @@ FILE_NAME=$(ls reports)
 
 echo "Vulnerability scan report file name: $FILE_NAME .."
 
+JIRA_API_BASE64_TOKEN=$(echo "${JIRA_API_USERNAME}:${JIRA_API_TOKEN}" | base64)
+
 response=$(curl --fail --request POST \
   --url "$JIRA_BASE_URL/rest/api/3/issue" \
   --header "Authorization: Basic $JIRA_API_BASE64_TOKEN" \

--- a/ci/tasks/create-vulnerability-scan-jira-issue.yml
+++ b/ci/tasks/create-vulnerability-scan-jira-issue.yml
@@ -10,7 +10,8 @@ outputs:
   - name: jira-story
 params:
   JIRA_BASE_URL:
-  JIRA_API_BASE64_TOKEN:
+  JIRA_API_USERNAME:
+  JIRA_API_TOKEN:
 run:
   path: /bin/sh
   args: ["pay-ci/ci/scripts/run-vulnerability-scan/create-jira-issue.sh"]


### PR DESCRIPTION
When storing these details in pay-low-pass it will be a pain when rotating if we store the username, token, and api key, and also a base64 encoded concatenation of the username and api key. So instead accept JIRA_API_USERNAME and JIRA_API_TOKEN and base64 encode them in the script.