### PR TITLE
PP-12908: Fix create-jira-story task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         files: ci/pipelines/.+\.(yml|yaml)$
         language: system
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: [ '--baseline', '.secrets.baseline' ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -66,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -335,5 +350,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-03T16:54:05Z"
+  "generated_at": "2024-07-22T11:01:24Z"
 }

--- a/ci/scripts/run-vulnerability-scan/create-jira-issue.sh
+++ b/ci/scripts/run-vulnerability-scan/create-jira-issue.sh
@@ -6,7 +6,7 @@ FILE_NAME=$(ls reports)
 
 echo "Vulnerability scan report file name: $FILE_NAME .."
 
-JIRA_API_BASE64_TOKEN=$(echo "${JIRA_API_USERNAME}:${JIRA_API_TOKEN}" | base64)
+JIRA_API_BASE64_TOKEN=$(echo "${JIRA_API_USERNAME}:${JIRA_API_TOKEN}" | base64 -w 0)
 
 response=$(curl --fail --request POST \
   --url "$JIRA_BASE_URL/rest/api/3/issue" \

--- a/ci/scripts/run-vulnerability-scan/create-jira-issue.sh
+++ b/ci/scripts/run-vulnerability-scan/create-jira-issue.sh
@@ -6,7 +6,7 @@ FILE_NAME=$(ls reports)
 
 echo "Vulnerability scan report file name: $FILE_NAME .."
 
-JIRA_API_BASE64_TOKEN=$(echo "${JIRA_API_USERNAME}:${JIRA_API_TOKEN}" | base64 -w 0)
+JIRA_API_BASE64_TOKEN=$(echo -n "${JIRA_API_USERNAME}:${JIRA_API_TOKEN}" | base64 -w 0)
 
 response=$(curl --fail --request POST \
   --url "$JIRA_BASE_URL/rest/api/3/issue" \

--- a/ci/tasks/create-vulnerability-scan-jira-issue.yml
+++ b/ci/tasks/create-vulnerability-scan-jira-issue.yml
@@ -6,6 +6,7 @@ image_resource:
     repository: governmentdigitalservice/pay-concourse-runner
 inputs:
   - name: reports
+  - name: pay-ci
 outputs:
   - name: jira-story
 params:


### PR DESCRIPTION
To use a script in pay-ci it needs pay-ci as an input

This ran successfully https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/internal-vulnerability-scan/jobs/run-vulnerability-scan/builds/9