### PR TITLE
BAU: Reinit lock pools daily

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -42,6 +42,7 @@ resources {
   shared_resources.payCiGitHubResource
   shared_resources_for_times.payIntervalResource("every-15-minutes", "15m")
   shared_resources_for_times.payIntervalResource("every-5-minutes", "5m")
+  shared_resources_for_times.payDailyTimeResource("every-day-at-2-30", "2:30", "2:40")
   shared_resources_for_slack_notifications.slackNotificationResource
   pipeline_self_update.PayPipelineSelfUpdateResource("\(concourseTeamName)/init-lock-pools.pkl", "master")
 }
@@ -131,7 +132,15 @@ jobs {
     new Job {
       name = "force-release-\(pool_name)-lock"
       plan {
-        new shared_resources_for_lock_pools.GetLockStep { pool = pool_name }
+        new InParallelStep {
+          in_parallel = new Listing<Step> {
+            new shared_resources_for_lock_pools.GetLockStep { pool = pool_name }
+            new GetStep {
+              get = "every-day-at-2-30"
+              trigger = true
+            }
+          }
+        }
         new shared_resources_for_lock_pools.ReleaseLockStep {
           pool = pool_name
           params {


### PR DESCRIPTION
The lock pool repos get massive very quickly, reinit them every day to keep them trim and tidy

```diff
resources:
  resource every-day-at-2-30 has been added:
+ icon: alarm
+ name: every-day-at-2-30
+ source:
+   location: Europe/London
+   start: "2:30"
+   stop: "2:40"
+ type: time

jobs:
  job force-release-deploy-application-staging-lock has changed:
  name: force-release-deploy-application-staging-lock
  plan:
- - get: get-already-claimed-deploy-application-staging-lock
-   resource: lock-pool-deploy-application-staging
+ - in_parallel:
+     steps:
+     - get: get-already-claimed-deploy-application-staging-lock
+       resource: lock-pool-deploy-application-staging
+     - get: every-day-at-2-30
+       trigger: true
  - attempts: 3
    params:
      release: get-already-claimed-deploy-application-staging-lock
    put: release-deploy-application-staging-lock
    resource: lock-pool-deploy-application-staging

  job force-release-smoke-test-staging-lock has changed:
  name: force-release-smoke-test-staging-lock
  plan:
- - get: get-already-claimed-smoke-test-staging-lock
-   resource: lock-pool-smoke-test-staging
+ - in_parallel:
+     steps:
+     - get: get-already-claimed-smoke-test-staging-lock
+       resource: lock-pool-smoke-test-staging
+     - get: every-day-at-2-30
+       trigger: true
  - attempts: 3
    params:
      release: get-already-claimed-smoke-test-staging-lock
    put: release-smoke-test-staging-lock
    resource: lock-pool-smoke-test-staging

  job force-release-deploy-application-production-lock has changed:
  name: force-release-deploy-application-production-lock
  plan:
- - get: get-already-claimed-deploy-application-production-lock
-   resource: lock-pool-deploy-application-production
+ - in_parallel:
+     steps:
+     - get: get-already-claimed-deploy-application-production-lock
+       resource: lock-pool-deploy-application-production
+     - get: every-day-at-2-30
+       trigger: true
  - attempts: 3
    params:
      release: get-already-claimed-deploy-application-production-lock
    put: release-deploy-application-production-lock
    resource: lock-pool-deploy-application-production

  job force-release-smoke-test-production-lock has changed:
  name: force-release-smoke-test-production-lock
  plan:
- - get: get-already-claimed-smoke-test-production-lock
-   resource: lock-pool-smoke-test-production
+ - in_parallel:
+     steps:
+     - get: get-already-claimed-smoke-test-production-lock
+       resource: lock-pool-smoke-test-production
+     - get: every-day-at-2-30
+       trigger: true
  - attempts: 3
    params:
      release: get-already-claimed-smoke-test-production-lock
    put: release-smoke-test-production-lock
    resource: lock-pool-smoke-test-production

pipeline name: init-lock-pools

Dry-run mode was set, exiting.
```