### PR TITLE
PP-12912 Updates to run internal vulnerability scan manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ ci/scripts/**/node_modules/*
 /venv
 /.venv
 actions/next-semver/node_modules
+
+ci/scripts/run-vulnerability-scan/reports

--- a/ci/scripts/run-vulnerability-scan/scan.sh
+++ b/ci/scripts/run-vulnerability-scan/scan.sh
@@ -6,9 +6,7 @@
 
 # The report will be stored in reports/vulnerability_scan_report-YYYY-MM-DD.csv
 
-if [ -z "${MANUAL_RUN+x}" ]; then
-  export MANUAL_RUN="false"
-fi
+MANUAL_RUN=${MANUAL_RUN:-false}
 
 if [ "$MANUAL_RUN" != "true" ]; then
   cleanup() {

--- a/ci/scripts/run-vulnerability-scan/scan.sh
+++ b/ci/scripts/run-vulnerability-scan/scan.sh
@@ -1,31 +1,56 @@
 #!/bin/ash
 # shellcheck shell=dash
 
-function cleanup {
-  echo "CLEANUP TRIGGERED"
-  clean_docker
-  stop_docker
-  echo "CLEANUP COMPLETE"
-}
-
-trap cleanup EXIT
-source /docker-helpers.sh
-
-start_docker
-
-set -euo pipefail
 # Script for scanning ECR docker vulnerabilities with "docker scout cves"
 # https://docs.docker.com/engine/reference/commandline/scout_cves/
 
 # The report will be stored in reports/vulnerability_scan_report-YYYY-MM-DD.csv
+
+if [ -z "${MANUAL_RUN+x}" ]; then
+  export MANUAL_RUN="false"
+fi
+
+if [ "$MANUAL_RUN" != "true" ]; then
+  cleanup() {
+    echo "CLEANUP TRIGGERED"
+    clean_docker
+    stop_docker
+    echo "CLEANUP COMPLETE"
+  }
+
+  trap cleanup EXIT
+  source /docker-helpers.sh
+
+  start_docker
+else
+  echo "Checking for required commands.."
+  for cmd in "aws" "docker" "docker scout"; do
+    # shellcheck disable=SC2086
+    if ! command -v $cmd &>/dev/null; then
+      echo "❌ '$cmd' command not found"
+      exit 1
+    else
+      echo "✅ $cmd"
+    fi
+  done
+
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  echo "Logging into ECR.."
+  aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com"
+fi
+
+set -euo pipefail
+
 ARCHITECTURE_TO_SCAN="linux/arm64"
 IMAGES=""
 
 mkdir -p reports
 REPORTS_DESTINATION="$(pwd)/reports"
 
-cd pay-ci/ci/scripts/run-vulnerability-scan
-mkdir -p reports
+if [ "$MANUAL_RUN" != "true" ]; then
+  cd pay-ci/ci/scripts/run-vulnerability-scan
+  mkdir -p reports
+fi
 
 # Get a all ECS clusters
 echo "Getting list of ECS clusters"
@@ -49,9 +74,11 @@ done
 
 IMAGES=$(echo "$IMAGES" | xargs -n1 | sort -u)
 
-aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY"
-# Log in to dockerhub to run `docker scout`
-echo "$DOCKERHUB_ACCESS_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+if [ "$MANUAL_RUN" != "true" ]; then
+  aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+  # Log in to dockerhub to run `docker scout`
+  echo "$DOCKERHUB_ACCESS_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+fi
 
 for IMAGE in $IMAGES; do
   SHORT_REPO_AND_TAG=$(echo "$IMAGE" | cut -d'/' -f 3)
@@ -75,9 +102,10 @@ echo
 
 # Clean up report JSON files once done
 echo "Removing JSON report files..."
-rm reports/*.json
+rm -f reports/*.json
 
-# Copy to pass the output to next task
-cp reports/* "$REPORTS_DESTINATION"
-
-stop_docker
+if [ "$MANUAL_RUN" != "true" ]; then
+  # Copy to pass the output to next task
+  cp reports/* "$REPORTS_DESTINATION"
+  stop_docker
+fi


### PR DESCRIPTION
## WHAT
- Updated internal vulnerability scan script so it can be run manually if needed

  - From the pay-ci root, run
     - `cd ci/scripts/run-vulnerability-scan`
     - `export MANUAL_RUN=true && aws-vault exec staging -- bash scan.sh`
  - Report will be in the `ci/scripts/run-vulnerability-scan/reports` folder

Concourse job still runs as expected https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/internal-vulnerability-scan/jobs/run-vulnerability-scan/builds/12