### PR TITLE
BAU: Apply daily schedule to correct job

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/init_lock_pools.pkl
@@ -95,7 +95,15 @@ jobs {
   new Job {
     name = "initialise-pools"
     plan {
-      new GetStep { get = "pay-ci" }
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "pay-ci" }
+          new GetStep {
+            get = "every-day-at-2-30"
+            trigger = true
+          }
+        }
+      }
       new TaskStep {
         task = "init-pools"
         file = "pay-ci/ci/tasks/lock-pools/init-lock-pools.yml"
@@ -132,15 +140,7 @@ jobs {
     new Job {
       name = "force-release-\(pool_name)-lock"
       plan {
-        new InParallelStep {
-          in_parallel = new Listing<Step> {
-            new shared_resources_for_lock_pools.GetLockStep { pool = pool_name }
-            new GetStep {
-              get = "every-day-at-2-30"
-              trigger = true
-            }
-          }
-        }
+        new shared_resources_for_lock_pools.GetLockStep { pool = pool_name }
         new shared_resources_for_lock_pools.ReleaseLockStep {
           pool = pool_name
           params {


### PR DESCRIPTION
Sigh, I put the trigger on the wrong job, it was on the force unlock, instead of re-init.

I've applied this change to https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/init-lock-pools?group=initialise-pools and it is now correct.

So sorry for the need for a re-review