### PR TITLE
BAU: Fix quarterly icon

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_times.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_times.pkl
@@ -39,7 +39,7 @@ cronResourceType: Pipeline.ResourceType = new {
 
 class PayCronResource extends Pipeline.Resource {
   type = "cron-resource"
-  icon = "calendar-clock-outline"
+  icon = "calendar-multiselect"
   source {
     ["location"] = "Europe/London"
   }


### PR DESCRIPTION
The icon I picked for this previously is a material design icon, but not one concourse supports. This changes it to one that is supported. I've applied this to test: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/internal-vulnerability-scan

![Screenshot 2024-07-24 at 14 47 34](https://github.com/user-attachments/assets/9900d465-e351-4777-8650-af299e83f40c)
