### PR TITLE
PP-12760: Send slack message on vuln scan

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
+++ b/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
@@ -43,14 +43,27 @@ jobs = new {
       createJiraStory()
     }
 
+    on_error = shared_resources_for_slack_notifications.paySlackNotification(
+      new SlackNotificationConfig { message = "A concourse error occurred when attempting run vulnerability scan"
+        slack_channel_for_failure = "#govuk-pay-starling #govuk-pay-pci" }
+    )
     on_failure = shared_resources_for_slack_notifications.paySlackNotification(
       new SlackNotificationConfig { message = "Failed to run vulnerability scan"
-        slack_channel_for_failure = "#govuk-pay-starling" }
+        slack_channel_for_failure = "#govuk-pay-starling #govuk-pay-pci" }
     )
-    on_success = shared_resources_for_slack_notifications.paySlackNotification(
-      new SlackNotificationConfig { is_a_success = true; message = "Internal vulnerability scan has been completed"
-        slack_channel_for_success = "#govuk-pay-starling" }
-    )
+    on_success = new DoStep {
+      do {
+        new LoadVarStep {
+          load_var = "jira-story-link"
+          file = "jira-story/jira-story-link"
+        }
+        shared_resources_for_slack_notifications.paySlackNotification(
+          new SlackNotificationConfig { is_a_success = true; message = "Internal vulnerability scan has been completed - <((.:jira-story-link))>"
+            slack_channel_for_success = "#govuk-pay-pci" }
+        )
+      }
+
+    }
   }
 
 }


### PR DESCRIPTION
Update `internal-vulnerability-scan` to send appropriate slack messages on success, failure an error.

On success send to #govuk-pay-pci and include a link to the created Jira ticket. On failure and error send to both `#govuk-pay-starling` and `#govuk-pay-pci`