### PR TITLE
BAU: Fix pkl pipeline changes paths

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/pkl_pipeline_changes.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/pkl_pipeline_changes.pkl
@@ -15,7 +15,7 @@ resources = new {
   (shared_resources.payGithubPullRequestResource("pkl-pipeline-pr", "pay-ci")) {
     source {
       ["paths"] = new Listing<String> {
-        "ci/pkl-pipelines/**/*.pkl"
+        "ci/pkl-pipelines/"
       }
     }
   }


### PR DESCRIPTION
The pkl pipeline changes job doesn't run when things are more than 1 level deep.


https://github.com/alphagov/pay-ci/blob/master/ci/pkl-pipelines/common/shared_pipelines/pkl_pipeline_changes.pkl#L18

```
      ["paths"] = new Listing<String> {
        "ci/pkl-pipelines/**/*.pkl"
      }
```

Does not work as I expected, it does not go more than 1 level deep, so it works for

* `ci/pkl-pipelines/pay-dev/foo.pkl`
* `ci/pkl-pipelines/common/bar.pkl`

bit it does not work for
* `ci/pkl-pipelines/common/shared_pipelines/baz.pkl`

According to the [docs of the github-pr resource](https://github.com/cloudfoundry-community/github-pr-resource) this can be a prefix as well as a glob pattern

```
Only produce new versions if the PR includes changes to files that match one or more glob patterns or prefixes.
```

So switch the paths definition to a prefix, this means we might produce an extra comment on a PR that isn't intended, but it's better than not producing them on PRs where it is needed.

Case in point, we wont get any comments on this PR!

