### PR TITLE
Refactor Pay-Js To Use Class Rather Than Function

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/pay-js.pkl
+++ b/ci/pkl-pipelines/pay-deploy/pay-js.pkl
@@ -2,6 +2,7 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
+import "../common/PayResources.pkl"
 
 local class PayJsLibraryPipeline {
   name: String
@@ -23,12 +24,13 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/pay-js.pkl", "master")
   shared_resources.payCiGitHubResource
   for (jsLibrary in payJsLibraries) {
-    (shared_resources.payGithubResourceWithBranch("js-\(jsLibrary.name)-git-release", "pay-js-\(jsLibrary.name)", jsLibrary.source_branch)) {
+    new PayResources.PayGitHubResource {
+      name = "js-\(jsLibrary.name)-git-release"
+      repoName = "pay-js-\(jsLibrary.name)"
       source {
-        ["commit_filter"] = new Mapping<String, Listing<String>> {
-          ["exclude"] = new Listing {
-            "\\[automated release\\]"
-          }
+        branch = jsLibrary.source_branch
+        commit_filter = new {
+          exclude = new {"\\[automated release\\]"}
         }
       }
     }


### PR DESCRIPTION
Begin to align on the use of the `PayResources.PayGitHubResource` class rather than a function. The use of objects/classes seems favoured by the pkl maintainers over functions [1]. It also allows us to make greater use of the type safety, simpler maintenance and simpler syntax.

[1]:https://github.com/apple/pkl/discussions/487#discussioncomment-9382697

### NOTES ###
What are peoples' thoughts on this? If we're agreed then I don't mind doing some refactoring as it'll help me continue to get comfortable with `pkl`