### PR TITLE
Use PayGitHubResource Class

### DIFF
--- a/ci/pkl-pipelines/common/PayResources.pkl
+++ b/ci/pkl-pipelines/common/PayResources.pkl
@@ -10,6 +10,16 @@ class PayGitHubResource extends Resources.GitResource {
   }
 }
 
+class PayInfraGitHubResource extends Resources.GitResource {
+  name = "pay-infra"
+  source = new {
+    branch = "master"
+    uri = "https://github.com/alphagov/pay-infra"
+    username = "alphagov-pay-ci-concourse"
+    password = "((github-access-token))"
+  }
+}
+
 class PayGitHubPullRequestResource extends Pipeline.Resource {
   type = "pull-request"
   icon = "github"

--- a/ci/pkl-pipelines/common/pipeline_self_update.pkl
+++ b/ci/pkl-pipelines/common/pipeline_self_update.pkl
@@ -1,15 +1,20 @@
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
 
 import "./shared_resources.pkl"
+import "./PayResources.pkl"
 
-function PayPipelineSelfUpdateResource(pkl_pipeline_file: String, branch: String) = (shared_resources.payGithubResourceWithBranch("pipeline-source", "pay-ci", branch)) {
+function PayPipelineSelfUpdateResource(pkl_pipeline_file: String, _branch: String) =
+  new PayResources.PayGitHubResource {
+    name = "pipeline-source"
+    repoName = "pay-ci"
     source {
-      ["paths"] = new Listing<String> {
+      branch = _branch
+      paths = new {
         "ci/pkl-pipelines/\(pkl_pipeline_file)"
         "ci/pkl-pipelines/common/**"
       }
     }
-}
+  }
 
 payPipelineSelfUpdateGroup: Pipeline.Group = new {
   name = "update-pipeline"

--- a/ci/pkl-pipelines/common/shared_resources.pkl
+++ b/ci/pkl-pipelines/common/shared_resources.pkl
@@ -19,13 +19,7 @@ payCiGitHubResource: PayResources.PayGitHubResource = new  {
   }
 }
 
-payInfraGitHubResource: PayResources.PayGitHubResource = new  {
-  name = "pay-infra"
-  repoName = "pay-infra"
-  source {
-    branch = "master"
-  }
-}
+payInfraGitHubResource: PayResources.PayInfraGitHubResource = new  {}
 
 function payDockerHubResource(resource_name: String, repo: String, tag: String): Pipeline.Resource = new {
   name = resource_name

--- a/ci/pkl-pipelines/common/shared_resources.pkl
+++ b/ci/pkl-pipelines/common/shared_resources.pkl
@@ -47,32 +47,6 @@ function payDockerHubResourceAsPayResource(resource_name: String, repo: String, 
   }
 }
 
-function payGithubResourceAsPayResource(resource_name: String, repo: String, repo_branch: String): PayResources.PayGitHubResource = new {
-  name = resource_name
-  repoName = repo
-  source {
-    when (repo_branch.length > 0) {
-      branch = repo_branch
-    }
-  }
-}
-
-function payGithubResource(resource_name: String, repo: String) = payGithubResourceWithBranch(resource_name, repo, "")
-
-function payGithubResourceWithBranch(resource_name: String, repo: String, repo_branch: String): Pipeline.Resource = new {
-  name = resource_name
-  type = "git"
-  icon = "github"
-  source = new {
-    ["uri"] = "https://github.com/alphagov/\(repo)"
-    when (repo_branch.length > 0) {
-      ["branch"] = repo_branch
-    }
-    ["username"] = "alphagov-pay-ci-concourse"
-    ["password"] = "((github-access-token))"
-  }
-}
-
 function payECRResource(resource_name: String, repo: String, aws_account_id: String): Pipeline.Resource = payECRResourceWithVariant(resource_name, repo, aws_account_id, "")
 
 function payECRResourceWithVariant(resource_name: String, repo: String, aws_account_id: String, variant: String): Pipeline.Resource = new {

--- a/ci/pkl-pipelines/pay-deploy/concourse-resources.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-resources.pkl
@@ -3,6 +3,7 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/PayResources.pkl"
 
 local class ConcourseResource {
   name: String
@@ -20,9 +21,15 @@ resource_types {
 
 resources {
   for (concourse_resource in concourse_resources) {
-    (shared_resources.payGithubResourceWithBranch("\(concourse_resource.name)-git-release", concourse_resource.name, concourse_resource.git_branch)) {
-      source { ["tag_regex"] = "alpha_release-(.*)" }
+    new PayResources.PayGitHubResource {
+      name = "\(concourse_resource.name)-git-release"
+      repoName = concourse_resource.name
+      source {
+        branch = concourse_resource.git_branch
+        tag_regex = "alpha_release-(.*)"
+      }
     }
+
     shared_resources.payDockerHubResource(
       "\(concourse_resource.name)-dockerhub", "governmentdigitalservice/pay-\(concourse_resource.name)", "latest"
     )

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -7,6 +7,7 @@ import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
 import "../common/shared_resources_for_annotations.pkl"
+import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -30,7 +31,13 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/deploy-to-production.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new PayResources.PayGitHubResource {
+    name = "pay-infra"
+    repoName = "pay-infra"
+    source {
+      branch = "master"
+    }
+  }
 
   for (app in allPayApplications) {
     shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-prod",

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -31,13 +31,7 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/deploy-to-production.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  new PayResources.PayGitHubResource {
-    name = "pay-infra"
-    repoName = "pay-infra"
-    source {
-      branch = "master"
-    }
-  }
+  new PayResources.PayInfraGitHubResource{}
 
   for (app in allPayApplications) {
     shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-prod",

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -7,6 +7,7 @@ import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_annotations.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
+import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -30,7 +31,13 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/deploy-to-staging.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new PayResources.PayGitHubResource {
+    name = "pay-infra"
+    repoName = "pay-infra"
+    source {
+      branch = "master"
+    }
+  }
   new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-staging" }
   new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test-staging" }
 

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -31,13 +31,7 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/deploy-to-staging.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  new PayResources.PayGitHubResource {
-    name = "pay-infra"
-    repoName = "pay-infra"
-    source {
-      branch = "master"
-    }
-  }
+  new PayResources.PayInfraGitHubResource {}
   new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-staging" }
   new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test-staging" }
 

--- a/ci/pkl-pipelines/pay-deploy/detect-secrets.pkl
+++ b/ci/pkl-pipelines/pay-deploy/detect-secrets.pkl
@@ -2,12 +2,16 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
+import "../common/PayResources.pkl"
 
 resources = new {
   shared_resources.payCiGitHubResource
-  (shared_resources.payGithubResourceWithBranch("detect-secrets-src", "pay-ci", "master")) {
+  new PayResources.PayGitHubResource {
+    name = "detect-secrets-src"
+    repoName = "pay-ci"
     source {
-      ["paths"] = new Listing<String> { "ci/docker/detect-secrets/*" }
+      branch = "master"
+      paths = new { "ci/docker/detect-secrets/*" }
     }
   }
   shared_resources.payDockerHubResource("detect-secrets-registry-image", "governmentdigitalservice/pay-detect-secrets", "latest")

--- a/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
@@ -3,6 +3,7 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/PayResources.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
 
@@ -12,7 +13,13 @@ resource_types {
 resources {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/infra-drift-detector.pkl", "master")
   shared_resources.payCiGitHubResource
-  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new PayResources.PayGitHubResource {
+    name = "pay-infra"
+    repoName = "pay-infra"
+    source {
+      branch = "master"
+    }
+  }
   shared_resources.slackNotificationResource
   new {
     name = "every-15-minutes"

--- a/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
@@ -13,13 +13,7 @@ resource_types {
 resources {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/infra-drift-detector.pkl", "master")
   shared_resources.payCiGitHubResource
-  new PayResources.PayGitHubResource {
-    name = "pay-infra"
-    repoName = "pay-infra"
-    source {
-      branch = "master"
-    }
-  }
+  new PayResources.PayInfraGitHubResource {}
   shared_resources.slackNotificationResource
   new {
     name = "every-15-minutes"

--- a/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
+++ b/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
@@ -24,13 +24,7 @@ resources {
     }
   }
   shared_resources.payCiGitHubResource
-  new PayResources.PayGitHubResource {
-    name = "pay-infra"
-    repoName = "pay-infra"
-    source {
-      branch = "master"
-    }
-  }
+  new PayResources.PayInfraGitHubResource {}
   shared_resources.payECRResource("pact-broker-ecr-registry-deploy", "govukpay/pact-broker", "pay_aws_deploy_account_id")
   shared_resources.slackNotificationResource
 }

--- a/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
+++ b/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
@@ -5,6 +5,7 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/PayResources.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
 
@@ -14,13 +15,22 @@ resource_types {
 
 resources {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-deploy/pact-broker.pkl", "master")
-  (shared_resources.payGithubResourceWithBranch("pact-broker-src", "pay-ci", "master")) {
+  new PayResources.PayGitHubResource {
+    name = "pact-broker-src"
+    repoName = "pay-ci"
     source {
-      ["paths"] = new Listing<String> { "ci/docker/pact-broker/*" }
+      branch = "master"
+      paths = new {"ci/docker/pact-broker/*"}
     }
   }
   shared_resources.payCiGitHubResource
-  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new PayResources.PayGitHubResource {
+    name = "pay-infra"
+    repoName = "pay-infra"
+    source {
+      branch = "master"
+    }
+  }
   shared_resources.payECRResource("pact-broker-ecr-registry-deploy", "govukpay/pact-broker", "pay_aws_deploy_account_id")
   shared_resources.slackNotificationResource
 }

--- a/ci/pkl-pipelines/pay-deploy/prometheus-pushgateway.pkl
+++ b/ci/pkl-pipelines/pay-deploy/prometheus-pushgateway.pkl
@@ -4,6 +4,7 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/shared_resources.pkl"
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/PayResources.pkl"
 
 local pushGatewayVersion = "v1.9.0"
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -20,8 +21,12 @@ resources = new {
     check_every = "1h"
   } |> asArm()
   shared_resources.payCiGitHubResource
-  (shared_resources.payGithubResource("prometheus-pushgateway-resource-release", "pay-prometheus-pushgateway-resource")) {
-    source { ["tag_regex"] = "alpha_release-(.*)" }
+  new PayResources.PayGitHubResource {
+    name = "prometheus-pushgateway-resource-release"
+    repoName = "pay-prometheus-pushgateway-resource"
+    source {
+      tag_regex = "alpha_release-(.*)"
+    }
   }
   shared_resources.slackNotificationResource
 }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -6,6 +6,7 @@ import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_annotations.pkl"
+import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -27,7 +28,13 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/deploy-to-perf.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new PayResources.PayGitHubResource {
+    name = "pay-infra"
+    repoName = "pay-infra"
+    source {
+      branch = "master"
+    }
+  }
 
   shared_resources.payECRResourceWithVariant("adot-ecr-registry-perf", "govukpay/adot", "pay_aws_test_account_id", "perf")
   for (app in allPayApplications) {

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -28,14 +28,7 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/deploy-to-perf.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  new PayResources.PayGitHubResource {
-    name = "pay-infra"
-    repoName = "pay-infra"
-    source {
-      branch = "master"
-    }
-  }
-
+  new PayResources.PayInfraGitHubResource {}
   shared_resources.payECRResourceWithVariant("adot-ecr-registry-perf", "govukpay/adot", "pay_aws_test_account_id", "perf")
   for (app in allPayApplications) {
     when (app.name != "adot") {

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -73,13 +73,7 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/deploy-to-test.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  new PayResources.PayGitHubResource {
-    name = "pay-infra"
-    repoName = "pay-infra"
-    source {
-     branch = "master"
-    }
-  }
+  new PayResources.PayInfraGitHubResource {}
   new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-test" }
   new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test-test" }
 

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -9,6 +9,7 @@ import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
 import "../common/shared_resources_for_annotations.pkl"
+import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -68,21 +69,29 @@ resource_types {
   shared_resources_for_lock_pools.payPoolResourceType
 }
 
-local function withTagRegex(regex: String) = new Mixin {
-  source { ["tag_regex"] = regex }
-}
-
 resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/deploy-to-test.pkl", "master")
   shared_resources_for_metrics.prometheusPushgatewayResource
   shared_resources.payCiGitHubResource
-  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new PayResources.PayGitHubResource {
+    name = "pay-infra"
+    repoName = "pay-infra"
+    source {
+     branch = "master"
+    }
+  }
   new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-test" }
   new shared_resources_for_lock_pools.LockPoolResource { pool = "smoke-test-test" }
 
   for (app in allPayApplications) {
-    shared_resources.payGithubResourceWithBranch("\(app.name)-git-release", app.getGithubRepo(),
-      getTestEnvConfig(app.name).github_branch) |> withTagRegex(getTestEnvConfig(app.name).tag_regex)
+    new PayResources.PayGitHubResource {
+      name = "\(app.name)-git-release"
+      repoName = app.getGithubRepo()
+      source {
+        branch = getTestEnvConfig(app.name).github_branch
+        tag_regex = getTestEnvConfig(app.name).tag_regex
+      }
+    }
 
     shared_resources.payECRResourceWithVariant("\(app.name)-ecr-registry-test",
       app.getECRRepo(), "pay_aws_test_account_id", "release")

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -5,6 +5,7 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_test_pipelines.pkl" as shared_test
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/PayResources.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
 
@@ -12,14 +13,30 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/e2e-helpers.pkl", "master")
   shared_resources.payCiGitHubResource
 
-  shared_resources.payGithubResourceWithBranch("endtoend-git-release", "pay-endtoend", "master")
-  |> withTagRegex("alpha_release-(.*)")
-
-  shared_resources.payGithubResourceWithBranch("stubs-git-release", "pay-stubs", "master")
-  |> withTagRegex("alpha_release-(.*)")
-
-  shared_resources.payGithubResourceWithBranch("reverse-proxy-git-release", "pay-scripts", "master")
-  |> withTagRegex("reverse_proxy_alpha_release-(.*)")
+  new PayResources.PayGitHubResource {
+    name = "endtoend-git-release"
+    repoName = "pay-endtoend"
+    source {
+      branch = "master"
+      tag_regex = "alpha_release-(.*)"
+    }
+  }
+  new PayResources.PayGitHubResource {
+    name = "stubs-git-release"
+    repoName = "pay-stubs"
+    source {
+      branch = "master"
+      tag_regex = "alpha_release-(.*)"
+    }
+  }
+  new PayResources.PayGitHubResource {
+    name = "reverse-proxy-git-release"
+    repoName = "pay-scripts"
+    source {
+      branch = "master"
+      tag_regex = "reverse_proxy_alpha_release-(.*)"
+    }
+  }
 
   shared_resources.payECRResource(
     "endtoend-ecr-registry-test", "govukpay/endtoend", "pay_aws_test_account_id"

--- a/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
@@ -13,13 +13,7 @@ resource_types {
 resources {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/infra-drift-detector.pkl", "master")
   shared_resources.payCiGitHubResource
-  new PayResources.PayGitHubResource {
-    name = "pay-infra"
-    repoName = "pay-infra"
-    source {
-      branch = "master"
-    }
-  }
+  new PayResources.PayInfraGitHubResource {}
   shared_resources.slackNotificationResource
   new {
     name = "every-15-minutes"

--- a/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
@@ -3,6 +3,7 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/PayResources.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
 
@@ -12,7 +13,13 @@ resource_types {
 resources {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/infra-drift-detector.pkl", "master")
   shared_resources.payCiGitHubResource
-  shared_resources.payGithubResourceWithBranch("pay-infra", "pay-infra", "master")
+  new PayResources.PayGitHubResource {
+    name = "pay-infra"
+    repoName = "pay-infra"
+    source {
+      branch = "master"
+    }
+  }
   shared_resources.slackNotificationResource
   new {
     name = "every-15-minutes"

--- a/ci/pkl-pipelines/pay-dev/perf-tests.pkl
+++ b/ci/pkl-pipelines/pay-dev/perf-tests.pkl
@@ -5,6 +5,7 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_test_pipelines.pkl" as shared_test
 import "../common/shared_resources_for_times.pkl" as shared_times
+import "../common/PayResources.pkl"
 
 local databases = new Mapping<String, String> {
   ["adminusers"] = "test-perf-1-adminusers-rds-0"
@@ -34,11 +35,14 @@ resources = new {
 
   shared_resources.payCiGitHubResource
   shared_resources.payGithubPullRequestResource("pay-perftests-pr", "pay-perftests")
-  shared_resources.payGithubResourceWithBranch(
-    "perf-tests-git-release",
-    "pay-perftests",
-    "master"
-  ) |> withTagRegex("alpha_release-(.*)")
+  new PayResources.PayGitHubResource {
+    name = "perf-tests-git-release"
+    repoName = "pay-perftests"
+    source {
+      branch = "master"
+      tag_regex = "alpha_release-(.*)"
+    }
+  }
 
   shared_resources.payECRResource(
     "pull-request-builds-ecr",


### PR DESCRIPTION
The use of objects/classes seems favoured by the pkl maintainers over functions [1]. It also allows us to make greater use of the type safety, simpler maintenance and simpler syntax.

[1]: https://github.com/apple/pkl/discussions/487#discussioncomment-9382697


### NOTES ###
Continues on the path to align on using classes/objects (in this case `PayGitHubResource`) rather than a function as started in https://github.com/alphagov/pay-ci/pull/1282. The net affect should be no changes, so although this PR includes many files, it _should_ be simple to review...