### PR TITLE
PP-13049: Retag egress in dockerhub as release

### DIFF
--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -304,7 +304,7 @@ local function getBuildAndPushCandidateJob(app): Job = new {
                 ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
               }
             }
-            when (app.is_a_java_or_node_app == true || app.name == "adot" || app.name == "nginx-proxy") {
+            when (app.is_a_java_or_node_app == true || app.name == "adot" || app.name == "nginx-proxy" || app.name == "egress") {
               new TaskStep {
                 task = "retag-candidate-as-release-in-dockerhub"
                 file = "pay-ci/ci/tasks/manifest-retag.yml"


### PR DESCRIPTION
Devs need to be able to run the egress proxy as part of pay local. This means it needs to be in dockerhub. I've already opened a PR for the candidate images to be pushed to dockerhub. This PR will tag those post-build as latest & release
