### PR TITLE
PP-12812: Make manifest check support scratch images

### DIFF
--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -45,9 +45,17 @@ jobs:
             #   image_name:tag
             #   image_name:tag@sha256:<sha>
             #   image_name@sha256
+            #   scratch
             #
             IMAGE=$(cut -f 1 -d "@" <<<"$BASE_CONTAINER_DEFINITION")
             DIGEST=$(cut -f 2 -d "@" <<<"$BASE_CONTAINER_DEFINITION")
+
+            shopt -s nocasematch
+            if [[ "$IMAGE" == "scratch" ]]; then
+              echo "Scratch container, no manifest to check"
+              continue
+            fi
+            shopt -u nocasematch
 
             if [ -z "$DIGEST" ]; then
               echo


### PR DESCRIPTION
We're introducing use of scratch container bases for some containers. This change updates the manifest check to allow for scratch images.

You can [see a working execution of this test](https://github.com/alphagov/pay-aws-bastion/actions/runs/10454911480/job/28948663783?pr=2) (run using this branch). This check checked both the build container definition and the scratch definition (which is also the reason we want to run this on Dockerfiles which end with a scratch container)

![Screenshot 2024-08-19 at 15 07 21](https://github.com/user-attachments/assets/f02ae357-65ad-45e8-943b-eeef1580692b)
