### PR TITLE
PP-12812: Extract multi arch candidate build

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -2,15 +2,15 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "./shared_resources_for_deploy_pipelines.pkl"
 
-class RunCodeBuildStep extends Pipeline.TaskStep {
-  hidden appName: String
+local class RunCodeBuildStep extends Pipeline.TaskStep {
+  hidden _appName: String
   hidden arch: "amd64" | "armv8" | "manifest"
 
-  task = "run-codebuild-\(appName)-\(arch)"
+  task = "run-codebuild-\(_appName)-\(arch)"
   attempts = 3
   file = "pay-ci/ci/tasks/run-codebuild.yml"
   params {
-    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(appName)-\(arch).json"
+    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(_appName)-\(arch).json"
     ...shared_resources_for_deploy_pipelines.getAWSAssumeRoleCreds()
   }
 }
@@ -32,11 +32,10 @@ function multiArchCandidateBuild(appName: String): Listing<Pipeline.Step> = new 
   new Pipeline.InParallelStep {
     in_parallel = new Pipeline.InParallelConfig {
       steps = new Listing<Pipeline.Step> {
-        new RunCodeBuildStep { appName = this.appName arch = "amd64" }
-        new RunCodeBuildStep { appName = this.appName arch = "armv8" }
+        new RunCodeBuildStep { _appName = appName arch = "amd64" }
+        new RunCodeBuildStep { _appName = appName arch = "armv8" }
       }
     }
   }
-
-  new RunCodeBuildStep { appName = this.appName arch = "manifest" }
+  new RunCodeBuildStep { _appName = appName arch = "manifest" }
 }

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -1,0 +1,42 @@
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+
+import "./shared_resources_for_deploy_pipelines.pkl"
+
+class RunCodeBuildStep extends Pipeline.TaskStep {
+  hidden appName: String
+  hidden arch: "amd64" | "armv8" | "manifest"
+
+  task = "run-codebuild-\(appName)-\(arch)"
+  attempts = 3
+  file = "pay-ci/ci/tasks/run-codebuild.yml"
+  params {
+    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(appName)-\(arch).json"
+    ...shared_resources_for_deploy_pipelines.getAWSAssumeRoleCreds()
+  }
+}
+
+function multiArchCandidateBuild(appName: String): Listing<Pipeline.Step> = new {
+  new Pipeline.TaskStep {
+    task = "prepare-codebuild"
+    file = "pay-ci/ci/tasks/prepare-codebuild-multiarch.yml"
+    params {
+      ["PROJECT_TO_BUILD"] = appName
+      ...shared_resources_for_deploy_pipelines.getAWSAssumeRoleCreds()
+      ["RELEASE_NUMBER"] = "((.:release-number))"
+      ["RELEASE_NAME"] = "((.:release-name))"
+      ["RELEASE_SHA"] = "((.:release-sha))"
+      ["BUILD_DATE"] = "((.:date))"
+    }
+  }
+
+  new Pipeline.InParallelStep {
+    in_parallel = new Pipeline.InParallelConfig {
+      steps = new Listing<Pipeline.Step> {
+        new RunCodeBuildStep { appName = this.appName arch = "amd64" }
+        new RunCodeBuildStep { appName = this.appName arch = "armv8" }
+      }
+    }
+  }
+
+  new RunCodeBuildStep { appName = this.appName arch = "manifest" }
+}

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -8,6 +8,7 @@ import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
+import "../common/shared_resources_for_multi_arch_builds.pkl"
 import "../common/shared_resources_for_annotations.pkl"
 import "../common/PayResources.pkl"
 
@@ -249,30 +250,7 @@ local function getBuildAndPushCandidateJob(app): Job = new {
       loadVarWithJsonFormat("retag-role", "assume-retag-role/assume-role.json")
     }
 
-    new TaskStep {
-      task = "prepare-codebuild"
-      file = "pay-ci/ci/tasks/prepare-codebuild-multiarch.yml"
-      params {
-        ["PROJECT_TO_BUILD"] = app.name
-        ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
-        ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
-        ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
-        ["RELEASE_NUMBER"] = "((.:release-number))"
-        ["RELEASE_NAME"] = "((.:release-name))"
-        ["RELEASE_SHA"] = "((.:release-sha))"
-        ["BUILD_DATE"] = "((.:date))"
-      }
-    }
-
-    new InParallelStep {
-      in_parallel = new InParallelConfig {
-        steps = new Listing<Step> {
-          getTaskToRunCodeBuild(app, "amd64")
-          getTaskToRunCodeBuild(app, "armv8")
-        }
-      }
-    }
-    getTaskToRunCodeBuild(app, "manifest")
+    ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild(app.name)
 
     when (getTestEnvConfig(app.name).run_e2e_tests == false && app.name != "adot") {
       new InParallelStep {

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -3,6 +3,7 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
+import "../common/shared_resources_for_multi_arch_builds.pkl"
 import "../common/shared_resources_for_test_pipelines.pkl" as shared_test
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/PayResources.pkl"
@@ -205,14 +206,8 @@ jobs = new {
       }
 
       shared_test.loadAssumeRoleVar
-      prepareCodeBuildMultiarch("reverse-proxy")
       shared_resources.generateDockerCredsConfigStep
-      runCodeBuildMultiarch("reverse-proxy", 3)
-      shared_test.runCodeBuild(
-        "run-codebuild-reverse-proxy-manifest",
-        "reverse-proxy-manifest.json",
-        3
-      )
+      ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild("reverse-proxy")
     }
     on_failure = shared_resources_for_slack_notifications.paySlackNotification(
       new SlackNotificationConfig { message = "Failed to build and push e2e helper reverse-proxy"
@@ -320,9 +315,7 @@ jobs = new {
         }
       }
 
-      prepareCodeBuildMultiarch("stubs")
-      runCodeBuildMultiarch("stubs", 1)
-      shared_test.runCodeBuild("run-codebuild-stubs-manifest", "stubs-manifest.json", 1)
+      ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild("stubs")
     }
 
     on_failure = shared_resources_for_slack_notifications.paySlackNotification(

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -519,32 +519,6 @@ local function parseCandidateTag(ecrRepo: String): TaskStep = new {
   }
 }
 
-local function prepareCodeBuildMultiarch(project: String): TaskStep = new {
-  task = "prepare-codebuild"
-  file = "pay-ci/ci/tasks/prepare-codebuild-multiarch.yml"
-  params = new {
-    ["PROJECT_TO_BUILD"] = project
-    ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
-    ["RELEASE_NUMBER"] = "((.:release-number))"
-    ["RELEASE_NAME"] = "((.:release-name))"
-    ["RELEASE_SHA"] = "((.:release-sha))"
-    ["BUILD_DATE"] = "((.:date))"
-  }
-}
-
-local function runCodeBuildMultiarch(project: String, attempts: Int): InParallelStep = new {
-  in_parallel = new Listing {
-    shared_test.runCodeBuild("run-codebuild-\(project)-amd64", "\(project)-amd64.json", attempts)
-    shared_test.runCodeBuild("run-codebuild-\(project)-armv8", "\(project)-armv8.json", attempts)
-  }
-}
-
-local function withTagRegex(tag: String) = new Mixin {
-  source { ["tag_regex"] = tag }
-}
-
 local function withTag(tag: String) = new Mixin {
   source { ["tag"] = tag }
 }


### PR DESCRIPTION
I need to create 2 new multi arch builds, so I'm refactoring the current ones to use a shared component which I can reuse.

In this instance there will be a small change, that is to give some of the e2e helper builds 3 attempts, but I'd rather standardise on the builds rather than special case, especially where it isn't necessary.