### PR TITLE
pp-12812: Refactor of image retag to use shared code

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -46,7 +46,7 @@ class RetagMultiArchImageInECR extends Pipeline.TaskStep {
   hidden sourceTag: String = "((.:candidate-image-tag))"
   hidden account: "dev" | "test" | "staging" | "production" | "deploy" = "test"
 
-  task = "retag-candidate-as-\(if (newTag.contains("release")) "release" else newTag)-in-ecr"
+  task = "retag-candidate-as-\(if (newTag.contains("release")) "release" else if (newTag.contains("perf")) "perf" else newTag)-in-ecr"
   file = "pay-ci/ci/tasks/manifest-retag.yml"
   params = new {
     ["DOCKER_LOGIN_ECR"] = "1"

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -64,7 +64,7 @@ class RetagMultiArchImageInDockerhubAsLatestMaster extends Pipeline.TaskStep {
   hidden newTag: String = "latest-master"
   hidden sourceTag: String = "((.:candidate_image_tag))"
 
-  task = "retag-candidate-as-\(newTag)-in-dockerhub"
+  task = "retag-candidate-as-release-in-dockerhub"
   file = "pay-ci/ci/tasks/manifest-retag.yml"
   params = new {
     ["SOURCE_MANIFEST"] = "\(repo):\(sourceTag)"

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -51,8 +51,8 @@ class RetagMultiArchImageInECR extends Pipeline.TaskStep {
   params = new {
     ["DOCKER_LOGIN_ECR"] = "1"
     ["AWS_ACCOUNT_ID"] = "((pay_aws_\(account)_account_id))"
-    ["SOURCE_MANIFEST"] = "((pay_aws_\(account)_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):\(sourceTag)"
-    ["NEW_MANIFEST"] = "((pay_aws_\(account)_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):\(newTag)"
+    ["SOURCE_MANIFEST"] = "((pay_aws_\(account)_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(repo):\(sourceTag)"
+    ["NEW_MANIFEST"] = "((pay_aws_\(account)_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(repo):\(newTag)"
     ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
     ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
     ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -61,7 +61,6 @@ class RetagMultiArchImageInECR extends Pipeline.TaskStep {
 
 class RetagMultiArchImageInDockerhubAsLatestMaster extends Pipeline.TaskStep {
   hidden repo: String
-  hidden newTag: String = "latest-master"
   hidden sourceTag: String = "((.:candidate-image-tag))"
 
   task = "retag-candidate-as-release-in-dockerhub"

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -43,7 +43,7 @@ function multiArchCandidateBuild(appName: String): Listing<Pipeline.Step> = new 
 class RetagMultiArchImageInECR extends Pipeline.TaskStep {
   hidden repo: String
   hidden newTag: String
-  hidden sourceTag: String = "((.:candidate_image_tag))"
+  hidden sourceTag: String = "((.:candidate-image-tag))"
   hidden account: "dev" | "test" | "staging" | "production" | "deploy" = "test"
 
   task = "retag-candidate-as-\(if (newTag.contains("release")) "release" else newTag)-in-ecr"
@@ -62,7 +62,7 @@ class RetagMultiArchImageInECR extends Pipeline.TaskStep {
 class RetagMultiArchImageInDockerhubAsLatestMaster extends Pipeline.TaskStep {
   hidden repo: String
   hidden newTag: String = "latest-master"
-  hidden sourceTag: String = "((.:candidate_image_tag))"
+  hidden sourceTag: String = "((.:candidate-image-tag))"
 
   task = "retag-candidate-as-release-in-dockerhub"
   file = "pay-ci/ci/tasks/manifest-retag.yml"

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -39,3 +39,35 @@ function multiArchCandidateBuild(appName: String): Listing<Pipeline.Step> = new 
   }
   new RunCodeBuildStep { _appName = appName arch = "manifest" }
 }
+
+class RetagMultiArchImageInECR extends Pipeline.TaskStep {
+  hidden repo: String
+  hidden newTag: String
+  hidden sourceTag: String = "((.:candidate_image_tag))"
+  hidden account: "dev" | "test" | "staging" | "production" | "deploy" = "test"
+
+  task = "retag-candidate-as-\(if (newTag.contains("release")) "release" else newTag)-in-ecr"
+  file = "pay-ci/ci/tasks/manifest-retag.yml"
+  params = new {
+    ["DOCKER_LOGIN_ECR"] = "1"
+    ["AWS_ACCOUNT_ID"] = "((pay_aws_\(account)_account_id))"
+    ["SOURCE_MANIFEST"] = "((pay_aws_\(account)_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):\(sourceTag)"
+    ["NEW_MANIFEST"] = "((pay_aws_\(account)_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):\(newTag)"
+    ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
+    ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
+    ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
+  }
+}
+
+class RetagMultiArchImageInDockerhubAsLatestMaster extends Pipeline.TaskStep {
+  hidden repo: String
+  hidden newTag: String = "latest-master"
+  hidden sourceTag: String = "((.:candidate_image_tag))"
+
+  task = "retag-candidate-as-\(newTag)-in-dockerhub"
+  file = "pay-ci/ci/tasks/manifest-retag.yml"
+  params = new {
+    ["SOURCE_MANIFEST"] = "\(repo):\(sourceTag)"
+    ["NEW_MANIFEST"] = "\(repo):latest-master"
+  }
+}

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -3,6 +3,7 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_metrics.pkl"
+import "../common/shared_resources_for_multi_arch_builds.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
@@ -284,7 +285,11 @@ local function getJobToRetagImageForNextEnv(app): Job = new {
     loadVarWithJsonFormat("retag-role", "assume-retag-role/assume-role.json")
     copyImagesToEUWest(app)
 
-    retagCandidateAsPerfInECR(app, false)
+    new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR {
+      repo = app.getECRRepo()
+      sourceTag = "((.:release-number))-candidate"
+      newTag = "((.:perf-tag))"
+    }
   }
   on_success = shared_resources_for_metrics.paySendAppReleaseMetric(true, "production-2")
   on_failure = shared_resources_for_metrics.paySendAppReleaseMetric(false, "production-2")
@@ -356,7 +361,11 @@ local function getJobToRetagImageForDBMigrations(app): Job = new {
     }
     loadVarWithJsonFormat("retag-role", "assume-retag-role/assume-role.json")
     copyImagesToEUWest(app)
-    retagCandidateAsPerfInECR(app, true)
+    new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR {
+      repo = app.getECRRepo()
+      sourceTag = "((.:release-number))-candidate"
+      newTag = "((.:perf-db-tag))"
+    }
   }
   on_success = shared_resources_for_metrics.paySendAppReleaseMetric(true, "production-2")
   on_failure = shared_resources_for_metrics.paySendAppReleaseMetric(false, "production-2")
@@ -649,24 +658,6 @@ local function copyImagesToEUWest(app: PayApp): TaskStep = new TaskStep {
     ["DESTINATION_AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
     ["DESTINATION_AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
     ["DESTINATION_REGION"] = "eu-west-1"
-  }
-}
-
-local function retagCandidateAsPerfInECR(app: PayApp, dbMigration: Boolean): TaskStep = new TaskStep {
-  task = "retag-candidate-as-perf-in-ecr"
-  file = "pay-ci/ci/tasks/manifest-retag.yml"
-  params {
-    ["DOCKER_LOGIN_ECR"] = "1"
-    ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-    ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-    when (dbMigration) {
-      ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:perf-db-tag))"
-    } else {
-      ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:perf-tag))"
-    }
-    ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:release-number))-candidate"
   }
 }
 

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -15,7 +15,6 @@ local typealias MetricsConfig = shared_resources_for_deploy_pipelines.MetricsCon
 
 local payScheduledTask = shared_resources_for_deploy_pipelines.payScheduledTask
 local allPayApplications = shared_resources_for_deploy_pipelines.allPayApplications
-local payApplicationsWithDB = shared_resources_for_deploy_pipelines.payApplicationsWithDB
 
 local awsEnvVars = Map("account", "staging",
   "environment", "staging-2")
@@ -301,87 +300,6 @@ local function getJobToPushToNextEnv(app): Job = new {
   on_failure = shared_resources_for_metrics.paySendAppReleaseMetric(false, "staging-2")
 }
 
-local function getJobToRetagImageForNextEnv(app): Job = new {
-  when (app.name == "notifications") {
-    name = "retag-\(app.name)-for-test-perf"
-  } else {
-    name = "retag-\(app.name)-image-for-test-perf"
-  }
-
-  plan = new {
-    new InParallelStep {
-      in_parallel = new InParallelConfig {
-        steps = new Listing<Step> {
-          new GetStep {
-            get = "\(app.name)-ecr-registry-staging"
-            params {
-              ["skip_download"] = true
-              ["format"] = "oci"
-            }
-            trigger = true
-            when (app.name != "adot") {
-              passed {
-                when (app.pact_tag) {
-                  "\(app.name)-pact-tag"
-                } else {
-                  when (app.smoke_test) {
-                    "smoke-test-\(app.name)-on-staging"
-                  } else {
-                    when (app.override_app_to_deploy != null) {
-                      when (app.override_app_to_deploy == "scheduled-tasks") {
-                        "deploy-\(app.override_app_to_deploy)"
-                      } else {
-                        "deploy-\(app.override_app_to_deploy)-to-staging"
-                      }
-                    } else {
-                      "deploy-\(app.name)-to-staging"
-                    }
-                  }
-                }
-              }
-            }
-          }
-          getStep("pay-ci", false)
-        }
-      }
-    }
-    new InParallelStep {
-      in_parallel = new InParallelConfig {
-        steps = new Listing<Step> {
-          parseReleaseTag(app.name, false)
-          new TaskStep {
-            task = "parse-perf-release-tag"
-            file = "pay-ci/ci/tasks/parse-perf-release-tag.yml"
-            input_mapping {
-              ["ecr-repo"] = "\(app.name)-ecr-registry-staging"
-            }
-          }
-        }
-      }
-    }
-    new InParallelStep {
-      in_parallel = new InParallelConfig {
-        steps = new Listing<Step> {
-          loadVar("app_name", "ecr-release-info/app_name")
-          loadVar("app_release_number", "ecr-release-info/release-number")
-          loadVar("release-number", "ecr-release-info/release-number")
-          loadVar("perf-tag", "parse-perf-release-tag/tag")
-
-          assumeRetagRole()
-          shared_resources.generateDockerCredsConfigStep
-        }
-      }
-    }
-
-    loadVarWithJsonFormat("retag-role", "assume-retag-role/assume-role.json")
-    copyImagesToProd(app)
-
-    retagCandidateAsPerfInECR(app, false)
-  }
-  on_success = shared_resources_for_metrics.paySendAppReleaseMetric(true, "staging-2")
-  on_failure = shared_resources_for_metrics.paySendAppReleaseMetric(false, "staging-2")
-}
-
 local function getJobForDBMigrations(app): Job = new {
   name = "\(app.name)-db-migration-staging"
   plan {
@@ -400,58 +318,6 @@ local function getJobForDBMigrations(app): Job = new {
     "#govuk-pay-activity", true, "staging-2")
   on_failure = shared_resources_for_slack_notifications.paySlackNotificationForDBMigrationStatus(
     "#govuk-pay-announce", false, "staging-2")
-}
-
-local function getJobToRetagImageForDBMigrations(app): Job = new {
-  name = "retag-\(app.name)-image-for-test-perf-db"
-  plan {
-    new InParallelStep {
-      in_parallel = new InParallelConfig {
-        steps {
-          (getStepWithTriggerAndPassed("\(app.name)-ecr-registry-staging", "\(app.name)-db-migration-staging")) {
-            params {
-              ["skip_download"] = true
-              ["format"] = "oci"
-            }
-          }
-          getStep("pay-ci", false)
-        }
-      }
-    }
-    new InParallelStep {
-      in_parallel = new InParallelConfig {
-        steps {
-          parseReleaseTag(app.name, false)
-
-          new TaskStep {
-            task = "parse-perf-db-release-tag"
-            file = "pay-ci/ci/tasks/parse-perf-db-release-tag.yml"
-            input_mapping {
-              ["ecr-repo"] = "\(app.name)-ecr-registry-staging"
-            }
-          }
-        }
-      }
-    }
-    new InParallelStep {
-      in_parallel = new InParallelConfig {
-        steps {
-          loadVar("app_name", "ecr-release-info/app_name")
-          loadVar("app_release_number", "ecr-release-info/release-number")
-          loadVar("release-number", "ecr-release-info/release-number")
-          loadVar("perf-db-tag", "parse-perf-db-release-tag/tag")
-          assumeRetagRole()
-
-          shared_resources.generateDockerCredsConfigStep
-        }
-      }
-    }
-    loadVarWithJsonFormat("retag-role", "assume-retag-role/assume-role.json")
-    copyImagesToProd(app)
-    retagCandidateAsPerfInECR(app, true)
-  }
-  on_success = shared_resources_for_metrics.paySendAppReleaseMetric(true, "staging-2")
-  on_failure = shared_resources_for_metrics.paySendAppReleaseMetric(false, "staging-2")
 }
 
 local function getJobToDeployScheduledTasks(): Job = new {
@@ -714,18 +580,6 @@ local class AssumeRoleTask extends TaskStep {
   }
 }
 
-local function assumeRetagRole(): TaskStep = new TaskStep {
-  task = "assume-retag-role"
-  file = "pay-ci/ci/tasks/assume-role.yml"
-  output_mapping {
-    ["assume-role"] = "assume-retag-role"
-  }
-  params {
-    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/concourse"
-    ["AWS_ROLE_SESSION_NAME"] = "retag-ecr-image-as-perf"
-  }
-}
-
 local function copyImagesToProd(app: PayApp): TaskStep = new TaskStep {
   task = "copy-images-to-prod"
   file = "pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml"
@@ -741,24 +595,6 @@ local function copyImagesToProd(app: PayApp): TaskStep = new TaskStep {
     ["DESTINATION_AWS_ACCESS_KEY_ID"] = "((.:write-to-prod-ecr-role.AWS_ACCESS_KEY_ID))"
     ["DESTINATION_AWS_SECRET_ACCESS_KEY"] = "((.:write-to-prod-ecr-role.AWS_SECRET_ACCESS_KEY))"
     ["DESTINATION_AWS_SESSION_TOKEN"] = "((.:write-to-prod-ecr-role.AWS_SESSION_TOKEN))"
-  }
-}
-
-local function retagCandidateAsPerfInECR(app: PayApp, dbMigration: Boolean): TaskStep = new TaskStep {
-  task = "retag-candidate-as-perf-in-ecr"
-  file = "pay-ci/ci/tasks/manifest-retag.yml"
-  params {
-    ["DOCKER_LOGIN_ECR"] = "1"
-    ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-    ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-    when (dbMigration) {
-      ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:perf-db-tag))"
-    } else {
-      ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:perf-tag))"
-    }
-    ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:release-number))-candidate"
   }
 }
 

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -256,41 +256,10 @@ local function getBuildAndPushCandidateJob(app): Job = new {
       new InParallelStep {
         in_parallel = new InParallelConfig {
           steps = new Listing<Step> {
-            new TaskStep {
-              task = "retag-candidate-as-release-in-ecr"
-              file = "pay-ci/ci/tasks/manifest-retag.yml"
-              params {
-                ["DOCKER_LOGIN_ECR"] = "1"
-                ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-                ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
-                ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:release-tag))"
-                ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-                ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-                ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-              }
-            }
-            new TaskStep {
-              task = "retag-candidate-as-latest-in-ecr"
-              file = "pay-ci/ci/tasks/manifest-retag.yml"
-              params {
-                ["DOCKER_LOGIN_ECR"] = "1"
-                ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-                ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
-                ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):latest"
-                ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-                ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-                ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-              }
-            }
+            new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "((.:release_tag))" }
+            new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "latest" }
             when (app.is_a_java_or_node_app == true || app.name == "adot" || app.name == "nginx-proxy" || app.name == "egress") {
-              new TaskStep {
-                task = "retag-candidate-as-release-in-dockerhub"
-                file = "pay-ci/ci/tasks/manifest-retag.yml"
-                params {
-                  ["SOURCE_MANIFEST"] = "\(app.getDockerRepo()):((.:candidate-image-tag))"
-                  ["NEW_MANIFEST"] = "\(app.getDockerRepo()):latest-master"
-                }
-              }
+              new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = app.getDockerRepo() }
             }
           }
         }
@@ -388,41 +357,10 @@ local function getRunE2ETestsJob(app): Job = new {
     new InParallelStep {
       in_parallel = new InParallelConfig {
         steps = new Listing<Step> {
-          new TaskStep {
-            task = "retag-candidate-as-release-in-ecr"
-            file = "pay-ci/ci/tasks/manifest-retag.yml"
-            params {
-              ["DOCKER_LOGIN_ECR"] = "1"
-              ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-              ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
-              ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:release_image_tag))"
-              ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-              ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-              ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-            }
-          }
-          new TaskStep {
-            task = "retag-candidate-as-latest-in-ecr"
-            file = "pay-ci/ci/tasks/manifest-retag.yml"
-            params {
-              ["DOCKER_LOGIN_ECR"] = "1"
-              ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-              ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
-              ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):latest"
-              ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-              ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-              ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-            }
-          }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "((.:release_image_tag))" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "latest" }
           when (app.is_a_java_or_node_app == true || app.name == "adot" || app.name == "nginx-proxy") {
-            new TaskStep {
-              task = "retag-candidate-as-release-in-dockerhub"
-              file = "pay-ci/ci/tasks/manifest-retag.yml"
-              params {
-                ["SOURCE_MANIFEST"] = "\(app.getDockerRepo()):((.:candidate-image-tag))"
-                ["NEW_MANIFEST"] = "\(app.getDockerRepo()):latest-master"
-              }
-            }
+            new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = app.getDockerRepo() }
           }
         }
       }
@@ -510,41 +448,10 @@ local function getAdotIntegrationTest(app): Job = new {
     new InParallelStep {
       in_parallel = new InParallelConfig {
         steps = new Listing<Step> {
-          new TaskStep {
-            task = "retag-candidate-as-release-in-ecr"
-            file = "pay-ci/ci/tasks/manifest-retag.yml"
-            params {
-              ["DOCKER_LOGIN_ECR"] = "1"
-              ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-              ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
-              ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:release_image_tag))"
-              ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-              ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-              ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-            }
-          }
-          new TaskStep {
-            task = "retag-candidate-as-latest-in-ecr"
-            file = "pay-ci/ci/tasks/manifest-retag.yml"
-            params {
-              ["DOCKER_LOGIN_ECR"] = "1"
-              ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-              ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):((.:candidate-image-tag))"
-              ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/\(app.getECRRepo()):latest"
-              ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-              ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-              ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-            }
-          }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "((.:release_image_tag))" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "latest" }
           when (app.is_a_java_or_node_app == true || app.name == "adot" || app.name == "nginx-proxy") {
-            new TaskStep {
-              task = "retag-candidate-as-release-in-dockerhub"
-              file = "pay-ci/ci/tasks/manifest-retag.yml"
-              params {
-                ["SOURCE_MANIFEST"] = "\(app.getDockerRepo()):((.:candidate-image-tag))"
-                ["NEW_MANIFEST"] = "\(app.getDockerRepo()):latest-master"
-              }
-            }
+            new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = app.getDockerRepo() }
           }
         }
       }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -256,7 +256,7 @@ local function getBuildAndPushCandidateJob(app): Job = new {
       new InParallelStep {
         in_parallel = new InParallelConfig {
           steps = new Listing<Step> {
-            new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "((.:release_tag))" }
+            new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "((.:release-tag))" }
             new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = app.getECRRepo() newTag = "latest" }
             when (app.is_a_java_or_node_app == true || app.name == "adot" || app.name == "nginx-proxy" || app.name == "egress") {
               new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = app.getDockerRepo() }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -559,16 +559,6 @@ local function getAdotIntegrationTest(app): Job = new {
     new MetricsConfig { put_metrics = false })
 }
 
-local function getTaskToRunCodeBuild(app: PayApp, architecture: String) = new TaskStep {
-  task = "run-codebuild-\(app.name)-\(architecture)"
-  attempts = 3
-  file = "pay-ci/ci/tasks/run-codebuild.yml"
-  params {
-    ["PATH_TO_CONFIG"] = "../../../../run-codebuild-configuration/\(app.name)-\(architecture).json"
-    ...shared_resources_for_deploy_pipelines.getAWSAssumeRoleCreds()
-  }
-}
-
 local function getJobToDeployApp(app): Job = new {
   name = "deploy-\(app.name)"
   serial = true
@@ -1006,17 +996,6 @@ local function sendSlackNotification(config: SlackNotificationConfig) = new {
     shared_resources_for_slack_notifications.paySlackNotification(config)
   } else {
     shared_resources_for_slack_notifications.paySlackNotificationForAppDeployment(config)
-  }
-}
-
-local function putGrafanaAnnotation() = new PutStep {
-  put = "grafana-annotation"
-  params {
-    ["tags"] = new Listing {
-      "((.:app_name))"
-      "deploy-to-test"
-    }
-    ["template"] = "released ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} release ((.:app_release_number)) (build ${BUILD_ID})"
   }
 }
 

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -141,12 +141,12 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          shared_test.loadVar("candidate_image_tag", "endtoend-candidate-ecr-registry-test/tag")
+          shared_test.loadVar("candidate-image-tag", "endtoend-candidate-ecr-registry-test/tag")
           shared_test.loadAssumeRoleVar
         }
       }
 
-      shared_test.prepareCodeBuild("endtoend", "prepare-e2e-codebuild.yml", "((.:candidate_image_tag))")
+      shared_test.prepareCodeBuild("endtoend", "prepare-e2e-codebuild.yml", "((.:candidate-image-tag))")
 
       new InParallelStep {
         in_parallel = new Listing {
@@ -234,12 +234,12 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          shared_test.loadVar("candidate_image_tag", "reverse-proxy-candidate-ecr-registry-test/tag")
+          shared_test.loadVar("candidate-image-tag", "reverse-proxy-candidate-ecr-registry-test/tag")
           shared_test.loadAssumeRoleVar
         }
       }
 
-      shared_test.prepareCodeBuild("reverse-proxy", "prepare-e2e-codebuild.yml", "((.:candidate_image_tag))")
+      shared_test.prepareCodeBuild("reverse-proxy", "prepare-e2e-codebuild.yml", "((.:candidate-image-tag))")
 
       new InParallelStep {
         in_parallel = new Listing {
@@ -345,7 +345,7 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          shared_test.loadVar("candidate_image_tag", "stubs-candidate-ecr-registry-test/tag")
+          shared_test.loadVar("candidate-image-tag", "stubs-candidate-ecr-registry-test/tag")
           shared_test.loadAssumeRoleVar
           shared_test.loadVarJson("retag-role", "assume-retag-role/assume-role.json")
           shared_test.loadVarJson("write-to-deploy-role", "assume-write-to-deploy-role/assume-role.json")
@@ -354,7 +354,7 @@ jobs = new {
         }
       }
 
-      shared_test.prepareCodeBuild("stubs", "prepare-e2e-codebuild.yml", "((.:candidate_image_tag))")
+      shared_test.prepareCodeBuild("stubs", "prepare-e2e-codebuild.yml", "((.:candidate-image-tag))")
 
       new InParallelStep {
         in_parallel = new Listing {

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -267,13 +267,9 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          retagCandidateInEcr("reverse-proxy", "((.:release_image_tag))", "release")
-          retagCandidateInEcr("reverse-proxy", "latest", "latest")
-          retagCandidateInDockerHub(
-            "governmentdigitalservice/pay-reverse-proxy",
-            "((.:candidate_image_tag))",
-            "release"
-          )
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "reverse-proxy" newTag = "((.:release_image_tag))" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "reverse-proxy" newTag = "latest" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-stubs" }
         }
       }
     }
@@ -369,13 +365,9 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          retagCandidateInEcr("stubs", "((.:release_image_tag))", "release")
-          retagCandidateInEcr("stubs", "latest", "latest")
-          retagCandidateInDockerHub(
-            "governmentdigitalservice/pay-stubs",
-            "((.:candidate_image_tag))",
-            "release"
-          )
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "stubs" newTag = "((.:release_image_tag))" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "stubs" newTag = "latest" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-stubs" }
           copyMultiarchImageToAccount("stubs")
         }
       }
@@ -444,29 +436,6 @@ local assumeWriteToDeployRole: TaskStep = new {
   params = new {
     ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_dev_worker_ecr_access"
     ["AWS_ROLE_SESSION_NAME"] = "write-ecr-to-deploy"
-  }
-}
-
-local function retagCandidateInDockerHub(repo: String, tag: String, taskTag: String): TaskStep = new {
-  task = "retag-candidate-as-\(taskTag)-in-dockerhub"
-  file = "pay-ci/ci/tasks/manifest-retag.yml"
-  params = new {
-    ["SOURCE_MANIFEST"] = "\(repo):\(tag)"
-    ["NEW_MANIFEST"] = "\(repo):latest-master"
-  }
-}
-
-local function retagCandidateInEcr(repo: String, tag: String, taskTag: String): TaskStep = new {
-  task = "retag-candidate-as-\(taskTag)-in-ecr"
-  file = "pay-ci/ci/tasks/manifest-retag.yml"
-  params = new {
-    ["DOCKER_LOGIN_ECR"] = "1"
-    ["AWS_ACCOUNT_ID"] = "((pay_aws_test_account_id))"
-    ["SOURCE_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):((.:candidate_image_tag))"
-    ["NEW_MANIFEST"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com/govukpay/\(repo):\(tag)"
-    ["AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-    ["AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-    ["AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
   }
 }
 

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -267,8 +267,8 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "reverse-proxy" newTag = "((.:release_image_tag))" }
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "reverse-proxy" newTag = "latest" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/reverse-proxy" newTag = "((.:release_image_tag))" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/reverse-proxy" newTag = "latest" }
           new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-reverse-proxy" }
         }
       }
@@ -365,8 +365,8 @@ jobs = new {
 
       new InParallelStep {
         in_parallel = new Listing {
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "stubs" newTag = "((.:release_image_tag))" }
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "stubs" newTag = "latest" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/stubs" newTag = "((.:release_image_tag))" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/stubs" newTag = "latest" }
           new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-stubs" }
           copyMultiarchImageToAccount("stubs")
         }

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -269,7 +269,7 @@ jobs = new {
         in_parallel = new Listing {
           new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "reverse-proxy" newTag = "((.:release_image_tag))" }
           new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "reverse-proxy" newTag = "latest" }
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-stubs" }
+          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-reverse-proxy" }
         }
       }
     }


### PR DESCRIPTION
Extract the manifest retag code into the shared multi arch module.

I renamed the candidate_image_tag variable in e2e helpers since that's the only place where it was different and that allowed me to standardise the shared code more.

Although the yaml for deploy-to-production is different, it's just a reordering of some keys and the actual pipeline is no changes.