### PR TITLE
PP-12812: Refactor bastion build to use shared code

### DIFF
--- a/ci/pkl-pipelines/common/PayResources.pkl
+++ b/ci/pkl-pipelines/common/PayResources.pkl
@@ -1,7 +1,7 @@
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Resources.pkl"
 
-class PayGitHubResource extends Resources.GitResource {
+open class PayGitHubResource extends Resources.GitResource {
   hidden repoName: String
   source = new {
     uri = "https://github.com/alphagov/\(repoName)"
@@ -10,7 +10,7 @@ class PayGitHubResource extends Resources.GitResource {
   }
 }
 
-class PayInfraGitHubResource extends Resources.GitResource {
+open class PayInfraGitHubResource extends Resources.GitResource {
   name = "pay-infra"
   source = new {
     branch = "master"
@@ -20,7 +20,7 @@ class PayInfraGitHubResource extends Resources.GitResource {
   }
 }
 
-class PayGitHubPullRequestResource extends Pipeline.Resource {
+open class PayGitHubPullRequestResource extends Pipeline.Resource {
   type = "pull-request"
   icon = "github"
   hidden repo: String
@@ -35,7 +35,7 @@ class PayGitHubPullRequestResource extends Pipeline.Resource {
   }
 }
 
-class PayDockerHubResource extends Resources.DockerImageResource {
+open class PayDockerHubResource extends Resources.DockerImageResource {
   type = "registry-image"
   icon = "docker"
   source = new {
@@ -45,11 +45,10 @@ class PayDockerHubResource extends Resources.DockerImageResource {
   }
 }
 
-class PayTimeResource extends Pipeline.Resource {
+open class PayTimeResource extends Pipeline.Resource {
   type = "time"
   icon = "alarm"
   source {
     ["location"] = "Europe/London"
   }
 }
-

--- a/ci/pkl-pipelines/common/shared_resources.pkl
+++ b/ci/pkl-pipelines/common/shared_resources.pkl
@@ -169,3 +169,38 @@ class AssumeRunCodeBuildRoleStep extends Pipeline.TaskStep {
 }
 
 LoadRunCodeBuildAssumedRoleVar: Pipeline.LoadVarStep = loadVarJson("role", "run-codebuild-assume-role/assume-role.json")
+
+class ParseGithubAlphaReleaseTagTask extends Pipeline.TaskStep {
+  hidden gitRelease: String
+
+  task = "parse-release-tag"
+  file = "pay-ci/ci/tasks/parse-release-tag.yml"
+  input_mapping {
+    ["git-release"] = gitRelease
+  }
+}
+
+class ParseECRCandidateTagTask extends Pipeline.TaskStep {
+  hidden ecr_repo: String
+
+  task = "parse-candidate-tag"
+  file = "pay-ci/ci/tasks/parse-candidate-tag.yml"
+  input_mapping {
+    ["ecr-repo"] = ecr_repo
+  }
+}
+
+class AssumeConcourseRoleTask extends Pipeline.TaskStep {
+  hidden aws_account_name: AWSAccountName = "test"
+  hidden output_name: Pipeline.Identifier = "assume-retag-role"
+
+  task = "assume-retag-role"
+  file = "pay-ci/ci/tasks/assume-role.yml"
+  output_mapping = new {
+    ["assume-role"] = output_name
+  }
+  params = new {
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_\(aws_account_name)_account_id)):role/concourse"
+    ["AWS_ROLE_SESSION_NAME"] = "retag-ecr-image"
+  }
+}

--- a/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
@@ -1,6 +1,8 @@
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/TaskConfig.pkl"
 
+import "./shared_resources_for_multi_arch_builds.pkl"
+
 class PayApplication {
   name: String
   is_a_java_or_node_app: Boolean = false
@@ -12,6 +14,12 @@ class PayApplication {
   use_app_specific_deploy_task: Boolean = false
   smoke_test: Boolean = true
   pact_tag: Boolean = false
+  multi_arch_build_image: shared_resources_for_multi_arch_builds.ImageToMultiArchBuild = new {
+    name = outer.name
+    github_repo = getGithubRepo()
+    dockerhub_repo = getDockerRepo()
+    ecr_repo = getECRRepo()
+  }
 
   function getECRRepo(): String = "govukpay/\(override_ecr_repo ?? name)"
   function getDockerRepo(): String = "governmentdigitalservice/pay-\(override_ecr_repo ?? name)"

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -2,6 +2,7 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "./shared_resources.pkl"
 import "./shared_resources_for_deploy_pipelines.pkl"
+import "../common/PayResources.pkl"
 import "../common/shared_resources_for_test_pipelines.pkl" as shared_test
 import "../common/shared_resources_for_slack_notifications.pkl" as shared_slack
 
@@ -15,6 +16,7 @@ open class ImageToMultiArchBuild {
   branch: String = "master"
   copy_release_to_deploy: Boolean = false
   retag_after_build: Boolean = false // At the end of a build candidate job, retag the image as release
+  release_tag_regex: String = "\(release_tag_prefix)alpha_release-(.*)"
 }
 
 class MultiArchCandidateBuildJob extends Pipeline.Job {
@@ -254,3 +256,22 @@ class AssumeRetagRoleStep extends Pipeline.TaskStep {
 }
 
 const LoadAssumedRetagRoleVar: Pipeline.LoadVarStep = shared_resources.loadVarJson("retag-role", "assume-retag-role/assume-role.json")
+
+class MultiArchBuildGithubSourceResource extends PayResources.PayGitHubResource {
+  hidden image: ImageToMultiArchBuild
+
+  name = "\(image.name)-git-release"
+  repoName = image.github_repo
+  source {
+    branch = image.branch
+    tag_regex = image.release_tag_regex
+  }
+}
+
+// I'd rather this be a class but that requires a giant refactor
+function multiArchCandidateECRRepoResource(image: ImageToMultiArchBuild): Pipeline.Resource = shared_resources.payECRResourceWithVariant(
+  "\(image.name)-candidate-ecr-registry-test",
+  "govukpay/\(image.name)",
+  "pay_aws_test_account_id",
+  "candidate"
+)

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -10,15 +10,17 @@ open class ImageToMultiArchBuild {
   github_repo: String
   dockerhub_repo: String = "governmentdigitalservice/pay-\(name)"
   ecr_repo: String = "govukpay/\(name)"
+  codebuild_project_name: String = name
   release_tag_prefix: String  = ""
   branch: String = "master"
   copy_release_to_deploy: Boolean = false
+  retag_after_build: Boolean = false // At the end of a build candidate job, retag the image as release
 }
 
 class MultiArchCandidateBuildJob extends Pipeline.Job {
   hidden image: ImageToMultiArchBuild
 
-  name = "build-and-push-\(image.name)-candidate"
+  name = "build-and-push-\(image.name)-\(if (image.retag_after_build) "release" else "candidate")"
 
   plan {
     new Pipeline.InParallelStep {
@@ -33,6 +35,9 @@ class MultiArchCandidateBuildJob extends Pipeline.Job {
         new shared_resources.ParseGithubAlphaReleaseTagTask { gitRelease = "\(image.name)-git-release" }
         shared_test.assumeCodeBuildRole("builder", "codebuild-assume-role")
         shared_resources.generateDockerCredsConfigStep
+        when (image.retag_after_build) {
+          new AssumeRetagRoleStep {}
+        }
       }
     }
 
@@ -44,10 +49,24 @@ class MultiArchCandidateBuildJob extends Pipeline.Job {
         shared_test.loadVar("candidate-image-tag", "tags/candidate-tag")
         shared_test.loadVar("date", "tags/date")
         shared_test.loadAssumeRoleVar
+        when (image.retag_after_build) {
+          shared_test.loadVar("release-image-tag", "tags/tags")
+          LoadAssumedRetagRoleVar
+        }
       }
     }
 
     ...multiArchCandidateBuild(image)
+
+    when (image.retag_after_build) {
+      new Pipeline.InParallelStep {
+        in_parallel = new Listing<Pipeline.Step> {
+          new RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "((.:release-image-tag))" }
+          new RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "latest" }
+          new RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-aws-bastion" }
+        }
+      }
+    }
   }
   on_failure = shared_slack.paySlackNotification(
     new shared_slack.SlackNotificationConfig { message = "Failed to build and push \(image.name)"
@@ -169,7 +188,7 @@ const function multiArchCandidateBuild(image: ImageToMultiArchBuild): Listing<Pi
     task = "prepare-codebuild"
     file = "pay-ci/ci/tasks/prepare-codebuild-multiarch.yml"
     params {
-      ["PROJECT_TO_BUILD"] = image.name
+      ["PROJECT_TO_BUILD"] = image.codebuild_project_name
       ...shared_resources_for_deploy_pipelines.getAWSAssumeRoleCreds()
       ["RELEASE_NUMBER"] = "((.:release-number))"
       ["RELEASE_NAME"] = "((.:release-name))"
@@ -181,12 +200,12 @@ const function multiArchCandidateBuild(image: ImageToMultiArchBuild): Listing<Pi
   new Pipeline.InParallelStep {
     in_parallel = new Pipeline.InParallelConfig {
       steps = new Listing<Pipeline.Step> {
-        new RunCodeBuildStep { _appName = image.name arch = "amd64" }
-        new RunCodeBuildStep { _appName = image.name arch = "armv8" }
+        new RunCodeBuildStep { _appName = image.codebuild_project_name arch = "amd64" }
+        new RunCodeBuildStep { _appName = image.codebuild_project_name arch = "armv8" }
       }
     }
   }
-  new RunCodeBuildStep { _appName = image.name arch = "manifest" }
+  new RunCodeBuildStep { _appName = image.codebuild_project_name arch = "manifest" }
 }
 
 class RetagMultiArchImageInECR extends Pipeline.TaskStep {
@@ -234,4 +253,4 @@ class AssumeRetagRoleStep extends Pipeline.TaskStep {
   }
 }
 
-LoadAssumedRetagRoleVar: Pipeline.LoadVarStep = shared_resources.loadVarJson("retag-role", "assume-retag-role/assume-role.json")
+const LoadAssumedRetagRoleVar: Pipeline.LoadVarStep = shared_resources.loadVarJson("retag-role", "assume-retag-role/assume-role.json")

--- a/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_multi_arch_builds.pkl
@@ -2,7 +2,154 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "./shared_resources.pkl"
 import "./shared_resources_for_deploy_pipelines.pkl"
+import "../common/shared_resources_for_test_pipelines.pkl" as shared_test
+import "../common/shared_resources_for_slack_notifications.pkl" as shared_slack
 
+open class ImageToMultiArchBuild {
+  name: String
+  github_repo: String
+  dockerhub_repo: String = "governmentdigitalservice/pay-\(name)"
+  ecr_repo: String = "govukpay/\(name)"
+  release_tag_prefix: String  = ""
+  branch: String = "master"
+  copy_release_to_deploy: Boolean = false
+}
+
+class MultiArchCandidateBuildJob extends Pipeline.Job {
+  hidden image: ImageToMultiArchBuild
+
+  name = "build-and-push-\(image.name)-candidate"
+
+  plan {
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing<Pipeline.Step> {
+        shared_test.getPayCi
+        shared_test.getStep("\(image.name)-git-release", true, false)
+      }
+    }
+
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing<Pipeline.Step> {
+        new shared_resources.ParseGithubAlphaReleaseTagTask { gitRelease = "\(image.name)-git-release" }
+        shared_test.assumeCodeBuildRole("builder", "codebuild-assume-role")
+        shared_resources.generateDockerCredsConfigStep
+      }
+    }
+
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing<Pipeline.Step> {
+        shared_test.loadVar("release-number", "tags/release-number")
+        shared_test.loadVar("release-name", "\(image.name)-git-release/.git/ref")
+        shared_test.loadVar("release-sha", "tags/release-sha")
+        shared_test.loadVar("candidate-image-tag", "tags/candidate-tag")
+        shared_test.loadVar("date", "tags/date")
+        shared_test.loadAssumeRoleVar
+      }
+    }
+
+    ...multiArchCandidateBuild(image)
+  }
+  on_failure = shared_slack.paySlackNotification(
+    new shared_slack.SlackNotificationConfig { message = "Failed to build and push \(image.name)"
+      slack_channel_for_failure = "#govuk-pay-starling" }
+  )
+  on_success = shared_slack.paySlackNotification(
+    new shared_slack.SlackNotificationConfig { is_a_success = true; message = "Built and pushed \(image.name)" }
+  )
+}
+
+open class MultiArchEndToEndTest extends Pipeline.Job {
+  hidden image: ImageToMultiArchBuild
+
+  name = "\(image.name)-e2e"
+  plan {
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing {
+        shared_test.getStep("\(image.name)-candidate-ecr-registry-test", true, true)
+        shared_test.getPayCi
+      }
+    }
+
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing {
+        shared_resources.generateDockerCredsConfigStep
+        new shared_resources.ParseECRCandidateTagTask { ecr_repo = "\(image.name)-candidate-ecr-registry-test" }
+        shared_test.assumeCodeBuildRole("executor", "e2e-test-assume-role")
+        new shared_resources.AssumeConcourseRoleTask {}
+        when (image.copy_release_to_deploy) {
+          new Pipeline.TaskStep {
+            task = "assume-write-to-deploy-role"
+            file = "pay-ci/ci/tasks/assume-role.yml"
+            output_mapping = new {
+              ["assume-role"] = "assume-write-to-deploy-role"
+            }
+            params = new {
+              ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_dev_worker_ecr_access"
+              ["AWS_ROLE_SESSION_NAME"] = "write-ecr-to-deploy"
+            }
+          }
+        }
+      }
+    }
+
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing {
+        shared_test.loadVar("candidate-image-tag", "\(image.name)-candidate-ecr-registry-test/tag")
+        shared_test.loadAssumeRoleVar
+        shared_test.loadVarJson("retag-role", "assume-retag-role/assume-role.json")
+        shared_test.loadVar("release_image_tag", "parse-candidate-tag/release-tag")
+        shared_test.loadVar("release_number", "parse-candidate-tag/release-number")
+        when (image.copy_release_to_deploy) {
+          shared_test.loadVarJson("write-to-deploy-role", "assume-write-to-deploy-role/assume-role.json")
+        }
+      }
+    }
+
+    shared_test.prepareCodeBuild(image.name, "prepare-e2e-codebuild.yml", "((.:candidate-image-tag))")
+
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing {
+        shared_test.runCodeBuild("run-codebuild-card", "card.json", 3)
+        shared_test.runCodeBuild("run-codebuild-products", "products.json", 1)
+        shared_test.runCodeBuild("run-codebuild-zap", "zap.json", 1)
+      }
+    }
+
+    new Pipeline.InParallelStep {
+      in_parallel = new Listing {
+        new RetagMultiArchImageInECR { repo = image.ecr_repo newTag = "((.:release_image_tag))" }
+        new RetagMultiArchImageInECR { repo = image.ecr_repo newTag = "latest" }
+        new RetagMultiArchImageInDockerhubAsLatestMaster { repo = image.dockerhub_repo }
+        when (image.copy_release_to_deploy) {
+          new Pipeline.TaskStep {
+            task = "copy-images-to-\(image.name)-ecr-registry-deploy"
+            file = "pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml"
+            privileged = true
+            params = new {
+              ["DESTINATION_AWS_ACCESS_KEY_ID"] = "((.:write-to-deploy-role.AWS_ACCESS_KEY_ID))"
+              ["DESTINATION_AWS_SECRET_ACCESS_KEY"] = "((.:write-to-deploy-role.AWS_SECRET_ACCESS_KEY))"
+              ["DESTINATION_AWS_SESSION_TOKEN"] = "((.:write-to-deploy-role.AWS_SESSION_TOKEN))"
+              ["DESTINATION_ECR_REGISTRY"] = "((pay_aws_deploy_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+              ["ECR_REPO_NAME"] = image.ecr_repo
+              ["RELEASE_NUMBER"] = "((.:release_number))"
+              ["SOURCE_AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
+              ["SOURCE_AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
+              ["SOURCE_AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
+              ["SOURCE_ECR_REGISTRY"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+            }
+          }
+        }
+      }
+    }
+  }
+  on_failure = shared_slack.paySlackNotification(
+    new shared_slack.SlackNotificationConfig { message = "\(image.name) failed post-merge e2e tests"
+      slack_channel_for_failure = "#govuk-pay-starling" }
+  )
+  on_success = shared_slack.paySlackNotification(
+    new shared_slack.SlackNotificationConfig { is_a_success = true; message = "\(image.name) passed post-merge e2e tests and was pushed as a final release" }
+  )
+}
 
 local class RunCodeBuildStep extends Pipeline.TaskStep {
   hidden _appName: String
@@ -17,12 +164,12 @@ local class RunCodeBuildStep extends Pipeline.TaskStep {
   }
 }
 
-function multiArchCandidateBuild(appName: String): Listing<Pipeline.Step> = new {
+const function multiArchCandidateBuild(image: ImageToMultiArchBuild): Listing<Pipeline.Step> = new {
   new Pipeline.TaskStep {
     task = "prepare-codebuild"
     file = "pay-ci/ci/tasks/prepare-codebuild-multiarch.yml"
     params {
-      ["PROJECT_TO_BUILD"] = appName
+      ["PROJECT_TO_BUILD"] = image.name
       ...shared_resources_for_deploy_pipelines.getAWSAssumeRoleCreds()
       ["RELEASE_NUMBER"] = "((.:release-number))"
       ["RELEASE_NAME"] = "((.:release-name))"
@@ -34,12 +181,12 @@ function multiArchCandidateBuild(appName: String): Listing<Pipeline.Step> = new 
   new Pipeline.InParallelStep {
     in_parallel = new Pipeline.InParallelConfig {
       steps = new Listing<Pipeline.Step> {
-        new RunCodeBuildStep { _appName = appName arch = "amd64" }
-        new RunCodeBuildStep { _appName = appName arch = "armv8" }
+        new RunCodeBuildStep { _appName = image.name arch = "amd64" }
+        new RunCodeBuildStep { _appName = image.name arch = "armv8" }
       }
     }
   }
-  new RunCodeBuildStep { _appName = appName arch = "manifest" }
+  new RunCodeBuildStep { _appName = image.name arch = "manifest" }
 }
 
 class RetagMultiArchImageInECR extends Pipeline.TaskStep {
@@ -72,7 +219,6 @@ class RetagMultiArchImageInDockerhubAsLatestMaster extends Pipeline.TaskStep {
     ["NEW_MANIFEST"] = "\(repo):latest-master"
   }
 }
-
 
 class AssumeRetagRoleStep extends Pipeline.TaskStep {
   hidden account: shared_resources.AWSAccountName = "test"

--- a/ci/pkl-pipelines/pay-dev/bastion.pkl
+++ b/ci/pkl-pipelines/pay-dev/bastion.pkl
@@ -4,7 +4,6 @@ import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_multi_arch_builds.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
-import "../common/PayResources.pkl"
 
 local bastion_image: shared_resources_for_multi_arch_builds.ImageToMultiArchBuild = new {
   name = "bastion"
@@ -20,66 +19,13 @@ resource_types {
 
 resources {
   shared_resources.payCiGitHubResource
-  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/bastion.pkl", "master")
-  new PayResources.PayGitHubResource {
-    name = "bastion-git-release"
-    repoName = "pay-aws-bastion"
-    source {
-      branch = "main"
-      tag_regex = "alpha_release-(.*)"
-    }
-  }
   shared_resources_for_slack_notifications.slackNotificationResource
+  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/bastion.pkl", "master")
+  new shared_resources_for_multi_arch_builds.MultiArchBuildGithubSourceResource { image = bastion_image }
 }
 
 jobs {
   new shared_resources_for_multi_arch_builds.MultiArchCandidateBuildJob { image = bastion_image }
 
-  // new {
-  //   name = "build-and-push-bastion"
-  //   plan {
-  //     new InParallelStep {
-  //       in_parallel = new Listing<Step> {
-  //         new GetStep { get = "bastion-git-release" trigger = true }
-  //         new GetStep { get = "pay-ci" }
-  //       }
-  //     }
-  //     new InParallelStep {
-  //       in_parallel = new Listing<Step> {
-  //         new TaskStep {
-  //           task = "parse-release-tag"
-  //           file = "pay-ci/ci/tasks/parse-release-tag.yml"
-  //           input_mapping {
-  //             ["git-release"] = "bastion-git-release"
-  //           }
-  //         }
-  //         new shared_resources_for_multi_arch_builds.AssumeRetagRoleStep {}
-  //         new shared_resources.AssumeRunCodeBuildRoleStep {}
-  //         shared_resources.generateDockerCredsConfigStep
-  //       }
-  //     }
-
-  //     new InParallelStep {
-  //       in_parallel = new Listing<Step> {
-  //         shared_resources.loadVar("release-number", "tags/release-number")
-  //         shared_resources.loadVar("release-name", "bastion-git-release/.git/ref")
-  //         shared_resources.loadVar("release-sha", "tags/release-sha")
-  //         shared_resources.loadVar("candidate-image-tag", "tags/candidate-tag")
-  //         shared_resources.loadVar("release-image-tag", "tags/tags")
-  //         shared_resources.loadVar("date", "tags/date")
-  //         shared_resources_for_multi_arch_builds.LoadAssumedRetagRoleVar
-  //         shared_resources.LoadRunCodeBuildAssumedRoleVar
-  //       }
-  //     }
-  //     ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild("aws-bastion")
-  //     new InParallelStep {
-  //       in_parallel = new Listing<Step> {
-  //         new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "((.:release-image-tag))" }
-  //         new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "latest" }
-  //         new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-aws-bastion" }
-  //       }
-  //     }
-  //   }
-  // }
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/bastion.pkl")
 }

--- a/ci/pkl-pipelines/pay-dev/bastion.pkl
+++ b/ci/pkl-pipelines/pay-dev/bastion.pkl
@@ -3,7 +3,20 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_multi_arch_builds.pkl"
+import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/PayResources.pkl"
+
+local bastion_image: shared_resources_for_multi_arch_builds.ImageToMultiArchBuild = new {
+  name = "bastion"
+  github_repo = "pay-aws-bastion"
+  branch = "main"
+  codebuild_project_name = "aws-bastion"
+  retag_after_build = true
+}
+
+resource_types {
+  shared_resources_for_slack_notifications.slackNotificationResourceType
+}
 
 resources {
   shared_resources.payCiGitHubResource
@@ -16,54 +29,57 @@ resources {
       tag_regex = "alpha_release-(.*)"
     }
   }
+  shared_resources_for_slack_notifications.slackNotificationResource
 }
 
 jobs {
-  new {
-    name = "build-and-push-bastion"
-    plan {
-      new InParallelStep {
-        in_parallel = new Listing<Step> {
-          new GetStep { get = "bastion-git-release" trigger = true }
-          new GetStep { get = "pay-ci" }
-        }
-      }
-      new InParallelStep {
-        in_parallel = new Listing<Step> {
-          new TaskStep {
-            task = "parse-release-tag"
-            file = "pay-ci/ci/tasks/parse-release-tag.yml"
-            input_mapping {
-              ["git-release"] = "bastion-git-release"
-            }
-          }
-          new shared_resources_for_multi_arch_builds.AssumeRetagRoleStep {}
-          new shared_resources.AssumeRunCodeBuildRoleStep {}
-          shared_resources.generateDockerCredsConfigStep
-        }
-      }
+  new shared_resources_for_multi_arch_builds.MultiArchCandidateBuildJob { image = bastion_image }
 
-      new InParallelStep {
-        in_parallel = new Listing<Step> {
-          shared_resources.loadVar("release-number", "tags/release-number")
-          shared_resources.loadVar("release-name", "bastion-git-release/.git/ref")
-          shared_resources.loadVar("release-sha", "tags/release-sha")
-          shared_resources.loadVar("candidate-image-tag", "tags/candidate-tag")
-          shared_resources.loadVar("release-image-tag", "tags/tags")
-          shared_resources.loadVar("date", "tags/date")
-          shared_resources_for_multi_arch_builds.LoadAssumedRetagRoleVar
-          shared_resources.LoadRunCodeBuildAssumedRoleVar
-        }
-      }
-      ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild("aws-bastion")
-      new InParallelStep {
-        in_parallel = new Listing<Step> {
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "((.:release-image-tag))" }
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "latest" }
-          new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-aws-bastion" }
-        }
-      }
-    }
-  }
+  // new {
+  //   name = "build-and-push-bastion"
+  //   plan {
+  //     new InParallelStep {
+  //       in_parallel = new Listing<Step> {
+  //         new GetStep { get = "bastion-git-release" trigger = true }
+  //         new GetStep { get = "pay-ci" }
+  //       }
+  //     }
+  //     new InParallelStep {
+  //       in_parallel = new Listing<Step> {
+  //         new TaskStep {
+  //           task = "parse-release-tag"
+  //           file = "pay-ci/ci/tasks/parse-release-tag.yml"
+  //           input_mapping {
+  //             ["git-release"] = "bastion-git-release"
+  //           }
+  //         }
+  //         new shared_resources_for_multi_arch_builds.AssumeRetagRoleStep {}
+  //         new shared_resources.AssumeRunCodeBuildRoleStep {}
+  //         shared_resources.generateDockerCredsConfigStep
+  //       }
+  //     }
+
+  //     new InParallelStep {
+  //       in_parallel = new Listing<Step> {
+  //         shared_resources.loadVar("release-number", "tags/release-number")
+  //         shared_resources.loadVar("release-name", "bastion-git-release/.git/ref")
+  //         shared_resources.loadVar("release-sha", "tags/release-sha")
+  //         shared_resources.loadVar("candidate-image-tag", "tags/candidate-tag")
+  //         shared_resources.loadVar("release-image-tag", "tags/tags")
+  //         shared_resources.loadVar("date", "tags/date")
+  //         shared_resources_for_multi_arch_builds.LoadAssumedRetagRoleVar
+  //         shared_resources.LoadRunCodeBuildAssumedRoleVar
+  //       }
+  //     }
+  //     ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild("aws-bastion")
+  //     new InParallelStep {
+  //       in_parallel = new Listing<Step> {
+  //         new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "((.:release-image-tag))" }
+  //         new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = "govukpay/bastion" newTag = "latest" }
+  //         new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = "governmentdigitalservice/pay-aws-bastion" }
+  //       }
+  //     }
+  //   }
+  // }
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/bastion.pkl")
 }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -196,7 +196,7 @@ jobs {
   getJobToDeployScheduledTasks()
 }
 
-local function getBuildAndPushCandidateJob(app): Job = new {
+local function getBuildAndPushCandidateJob(app: shared_resources_for_deploy_pipelines.PayApplication): Job = new {
   when (getTestEnvConfig(app.name).run_e2e_tests) {
     name = "build-and-push-\(app.name)-candidate"
   } else {
@@ -250,7 +250,7 @@ local function getBuildAndPushCandidateJob(app): Job = new {
       loadVarWithJsonFormat("retag-role", "assume-retag-role/assume-role.json")
     }
 
-    ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild(app.name)
+    ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild(app.multi_arch_build_image)
 
     when (getTestEnvConfig(app.name).run_e2e_tests == false && app.name != "adot") {
       new InParallelStep {

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -21,17 +21,7 @@ local images_to_copy_from_dockerhub_to_ecr = new Listing<ImageToCopyFromDockerhu
   new { name = "selenium-standalone-chrome-3-141-59" repo = "selenium/standalone-chrome" tag = "3.141.59" }
 }
 
-local class ImageToMultiArchBuild {
-  name: String
-  github_repo: String
-  dockerhub_repo: String = "governmentdigitalservice/pay-\(name)"
-  ecr_repo: String = "govukpay/\(name)"
-  release_tag_prefix: String  = ""
-  branch: String = "master"
-  copy_release_to_deploy: Boolean = false
-}
-
-local images_to_multi_arch_build = new Listing<ImageToMultiArchBuild> {
+local images_to_multi_arch_build = new Listing<shared_resources_for_multi_arch_builds.ImageToMultiArchBuild> {
   new { name = "reverse-proxy" github_repo = "pay-scripts" release_tag_prefix = "reverse_proxy_" }
   new { name = "stubs" github_repo = "pay-stubs" copy_release_to_deploy = true }
   new { name = "zap" github_repo = "pay-scripts" release_tag_prefix = "zap_"}
@@ -141,7 +131,7 @@ jobs = new {
       }
 
       shared_resources.generateDockerCredsConfigStep
-      parseReleaseTag("endtoend-git-release")
+      new shared_resources.ParseGithubAlphaReleaseTagTask { gitRelease = "endtoend-git-release" }
       shared_test.loadVar("release_number_tag", "tags/release-number")
       buildImage("build-endtoend-image", "endtoend-git-release")
       putCandidateImage("endtoend-candidate-ecr-registry-test")
@@ -171,7 +161,7 @@ jobs = new {
         }
       }
 
-      parseCandidateTag("endtoend-candidate-ecr-registry-test")
+      new shared_resources.ParseECRCandidateTagTask { ecr_repo = "endtoend-candidate-ecr-registry-test" }
       shared_test.loadVar("candidate_number_tag", "parse-candidate-tag/release-number")
       shared_test.assumeCodeBuildRole("executor", "e2e-test-assume-role")
 
@@ -218,9 +208,9 @@ jobs = new {
     )
   }
 
-  for (image in images_to_multi_arch_build) {
-    multiArchBuild(image)
-    multiArchEndToEndTest(image)
+  for (image_to_build in images_to_multi_arch_build) {
+    new shared_resources_for_multi_arch_builds.MultiArchCandidateBuildJob { image = image_to_build }
+    new shared_resources_for_multi_arch_builds.MultiArchEndToEndTest { image = image_to_build }
   }
 
   for (image_to_copy in images_to_copy_from_dockerhub_to_ecr) {
@@ -257,152 +247,6 @@ local function buildImage(taskName: String, context: String): TaskStep = new {
 local function putCandidateImage(putName: String): PutStep =
   putStep(putName, "image/image.tar", "tags/candidate-tag", true)
 
-local assumeRetagRole: TaskStep = new {
-  task = "assume-retag-role"
-  file = "pay-ci/ci/tasks/assume-role.yml"
-  output_mapping = new {
-    ["assume-role"] = "assume-retag-role"
-  }
-  params = new {
-    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_test_account_id)):role/concourse"
-    ["AWS_ROLE_SESSION_NAME"] = "retag-ecr-image-as-release"
-  }
-}
-
-local assumeWriteToDeployRole: TaskStep = new {
-  task = "assume-write-to-deploy-role"
-  file = "pay-ci/ci/tasks/assume-role.yml"
-  output_mapping = new {
-    ["assume-role"] = "assume-write-to-deploy-role"
-  }
-  params = new {
-    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_deploy_account_id)):role/concourse_dev_worker_ecr_access"
-    ["AWS_ROLE_SESSION_NAME"] = "write-ecr-to-deploy"
-  }
-}
-
-local function copyMultiarchImageToAccount(repo: String): TaskStep = new {
-  task = "copy-images-to-\(repo)-ecr-registry-deploy"
-  file = "pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml"
-  privileged = true
-  params = new {
-    ["DESTINATION_AWS_ACCESS_KEY_ID"] = "((.:write-to-deploy-role.AWS_ACCESS_KEY_ID))"
-    ["DESTINATION_AWS_SECRET_ACCESS_KEY"] = "((.:write-to-deploy-role.AWS_SECRET_ACCESS_KEY))"
-    ["DESTINATION_AWS_SESSION_TOKEN"] = "((.:write-to-deploy-role.AWS_SESSION_TOKEN))"
-    ["DESTINATION_ECR_REGISTRY"] = "((pay_aws_deploy_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
-    ["ECR_REPO_NAME"] = "govukpay/\(repo)"
-    ["RELEASE_NUMBER"] = "((.:release_number))"
-    ["SOURCE_AWS_ACCESS_KEY_ID"] = "((.:retag-role.AWS_ACCESS_KEY_ID))"
-    ["SOURCE_AWS_SECRET_ACCESS_KEY"] = "((.:retag-role.AWS_SECRET_ACCESS_KEY))"
-    ["SOURCE_AWS_SESSION_TOKEN"] = "((.:retag-role.AWS_SESSION_TOKEN))"
-    ["SOURCE_ECR_REGISTRY"] = "((pay_aws_test_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
-  }
-}
-
-local function multiArchBuild(image: ImageToMultiArchBuild): Job = new {
-  name = "build-and-push-\(image.name)-candidate"
-  plan {
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        shared_test.getPayCi
-        shared_test.getStep("\(image.name)-git-release", true, false)
-      }
-    }
-
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        parseReleaseTag("\(image.name)-git-release")
-        shared_test.assumeCodeBuildRole("builder", "codebuild-assume-role")
-        shared_resources.generateDockerCredsConfigStep
-      }
-    }
-
-    new InParallelStep {
-      in_parallel = new Listing<Step> {
-        shared_test.loadVar("release-number", "tags/release-number")
-        shared_test.loadVar("release-name", "\(image.name)-git-release/.git/ref")
-        shared_test.loadVar("release-sha", "tags/release-sha")
-        shared_test.loadVar("candidate-image-tag", "tags/candidate-tag")
-        shared_test.loadVar("date", "tags/date")
-        shared_test.loadAssumeRoleVar
-      }
-    }
-
-    ...shared_resources_for_multi_arch_builds.multiArchCandidateBuild(image.name)
-  }
-  on_failure = shared_resources_for_slack_notifications.paySlackNotification(
-    new SlackNotificationConfig { message = "Failed to build and push e2e helper \(image.name)"
-      slack_channel_for_failure = "#govuk-pay-starling" }
-  )
-  on_success = shared_resources_for_slack_notifications.paySlackNotification(
-    new SlackNotificationConfig { is_a_success = true; message = "Built and pushed e2e helper \(image.name)" }
-  )
-}
-
-local function multiArchEndToEndTest(image: ImageToMultiArchBuild): Job = new {
-  name = "\(image.name)-e2e"
-  plan {
-    new InParallelStep {
-      in_parallel = new Listing {
-        shared_test.getStep("\(image.name)-candidate-ecr-registry-test", true, true)
-        shared_test.getPayCi
-      }
-    }
-
-    new InParallelStep {
-      in_parallel = new Listing {
-        shared_resources.generateDockerCredsConfigStep
-        parseCandidateTag("\(image.name)-candidate-ecr-registry-test")
-        shared_test.assumeCodeBuildRole("executor", "e2e-test-assume-role")
-        assumeRetagRole
-        when (image.copy_release_to_deploy) {
-          assumeWriteToDeployRole
-        }
-      }
-    }
-
-    new InParallelStep {
-      in_parallel = new Listing {
-        shared_test.loadVar("candidate-image-tag", "\(image.name)-candidate-ecr-registry-test/tag")
-        shared_test.loadAssumeRoleVar
-        shared_test.loadVarJson("retag-role", "assume-retag-role/assume-role.json")
-        shared_test.loadVar("release_image_tag", "parse-candidate-tag/release-tag")
-        shared_test.loadVar("release_number", "parse-candidate-tag/release-number")
-        when (image.copy_release_to_deploy) {
-          shared_test.loadVarJson("write-to-deploy-role", "assume-write-to-deploy-role/assume-role.json")
-        }
-      }
-    }
-
-    shared_test.prepareCodeBuild(image.name, "prepare-e2e-codebuild.yml", "((.:candidate-image-tag))")
-
-    new InParallelStep {
-      in_parallel = new Listing {
-        shared_test.runCodeBuild("run-codebuild-card", "card.json", 3)
-        shared_test.runCodeBuild("run-codebuild-products", "products.json", 1)
-        shared_test.runCodeBuild("run-codebuild-zap", "zap.json", 1)
-      }
-    }
-
-    new InParallelStep {
-      in_parallel = new Listing {
-        new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = image.ecr_repo newTag = "((.:release_image_tag))" }
-        new shared_resources_for_multi_arch_builds.RetagMultiArchImageInECR { repo = image.ecr_repo newTag = "latest" }
-        new shared_resources_for_multi_arch_builds.RetagMultiArchImageInDockerhubAsLatestMaster { repo = image.dockerhub_repo }
-        when (image.copy_release_to_deploy) {
-          copyMultiarchImageToAccount(image.name)
-        }
-      }
-    }
-  }
-  on_failure = shared_resources_for_slack_notifications.paySlackNotification(
-    new SlackNotificationConfig { message = "e2e helper \(image.name) failed post-merge e2e tests"
-      slack_channel_for_failure = "#govuk-pay-starling" }
-  )
-  on_success = shared_resources_for_slack_notifications.paySlackNotification(
-    new SlackNotificationConfig { is_a_success = true; message = "e2e helper \(image.name) passed post-merge e2e tests and was pushed as a final release" }
-  )
-}
 
 local function copyImageToEcr(image: String, displayName: String): Job = new {
   name = "copy-\(image)"
@@ -417,22 +261,6 @@ local function copyImageToEcr(image: String, displayName: String): Job = new {
   on_success = shared_resources_for_slack_notifications.paySlackNotification(
     new SlackNotificationConfig { is_a_success = true; message = "Copied \(displayName) image from Docker Hub to ECR" }
   )
-}
-
-local function parseReleaseTag(gitRelease: String): TaskStep = new {
-  task = "parse-release-tag"
-  file = "pay-ci/ci/tasks/parse-release-tag.yml"
-  input_mapping {
-    ["git-release"] = gitRelease
-  }
-}
-
-local function parseCandidateTag(ecrRepo: String): TaskStep = new {
-  task = "parse-candidate-tag"
-  file = "pay-ci/ci/tasks/parse-candidate-tag.yml"
-  input_mapping {
-    ["ecr-repo"] = ecrRepo
-  }
 }
 
 local function withTag(tag: String) = new Mixin {

--- a/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
+++ b/ci/pkl-pipelines/pay-dev/e2e-helpers.pkl
@@ -43,14 +43,7 @@ resources = new {
   }
 
   for (image_to_build in images_to_multi_arch_build) {
-    new PayResources.PayGitHubResource {
-      name = "\(image_to_build.name)-git-release"
-      repoName = image_to_build.github_repo
-      source {
-        branch = image_to_build.branch
-        tag_regex = "\(image_to_build.release_tag_prefix)alpha_release-(.*)"
-      }
-    }
+    new shared_resources_for_multi_arch_builds.MultiArchBuildGithubSourceResource { image = image_to_build }
   }
 
   shared_resources.payECRResource(
@@ -66,12 +59,7 @@ resources = new {
   )
 
   for (image_to_build in images_to_multi_arch_build) {
-    shared_resources.payECRResourceWithVariant(
-      "\(image_to_build.name)-candidate-ecr-registry-test",
-      "govukpay/\(image_to_build.name)",
-      "pay_aws_test_account_id",
-      "candidate"
-    )
+    shared_resources_for_multi_arch_builds.multiArchCandidateECRRepoResource(image_to_build)
   }
 
   for (image_to_copy in images_to_copy_from_dockerhub_to_ecr) {


### PR DESCRIPTION
* Refactor the multi arch build jobs to be available in shared code
* Also extract some of the common parsing tasks to be available in shared code
* Use the shared multi arch build jobs to build the bastion

I've applied the bastion pipeline and you can see a successful build https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/bastion/jobs/build-and-push-bastion-release/builds/2

The e2e-helpers diff is just changnig the wording of the notifications slightly to make them more generalised (they always link to the specific build though, so it's only the fluff that's generalised, not the concrete actions)