### PR TITLE
Pp 12812/dynamically load tf version

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_terraform.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_terraform.pkl
@@ -1,0 +1,14 @@
+import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+
+import "./shared_resources.pkl"
+
+function LoadTerraformVersionForTFRootSteps(terraform_root: String): Listing<Pipeline.Step> = new {
+  new Pipeline.TaskStep {
+    task = "find-terraform-version"
+    file = "pay-ci/ci/tasks/find-terraform-version.yml"
+    params {
+      ["TERRAFORM_ROOT"] = terraform_root
+    }
+  }
+  shared_resources.loadVar("terraform-version", "terraform-version/.terraform-version")
+}

--- a/ci/scripts/find-terraform-version.sh
+++ b/ci/scripts/find-terraform-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env ash
+# shellcheck shell=dash
+
+set -euo pipefail
+
+TERRAFORM_ROOT=${TERRAFORM_ROOT:-./pay-infra}
+
+if [ ! -d "$TERRAFORM_ROOT" ]; then
+  echo "Error, the terraform root directory specified '$TERRAFORM_ROOT' does not exist"
+  exit 1
+fi
+
+if [ ! -d "terraform-version" ]; then
+  echo "Error: The terraform-version output directory is missing, you probably need to specify it as an output in the task"
+  exit 1
+fi
+
+CURRENT_PATH="$TERRAFORM_ROOT"
+
+while [ ! -f "$CURRENT_PATH/.terraform-version" ]; do
+  echo "$CURRENT_PATH/.terraform-version does not exist"
+
+  if [ "$(basename "$CURRENT_PATH")" = "pay-infra" ]; then
+    echo "Error, checked all directories from $TERRAFORM_ROOT upwards to pay-infra and did not find a .terraform-version file"
+    exit 1
+  fi
+
+  CURRENT_PATH=$(dirname "$CURRENT_PATH")
+done
+
+echo "$CURRENT_PATH/.terraform-version found"
+
+tee -a terraform-version/.terraform-version < "$CURRENT_PATH/.terraform-version"

--- a/ci/tasks/find-terraform-version.yml
+++ b/ci/tasks/find-terraform-version.yml
@@ -1,0 +1,18 @@
+---
+inputs:
+  - name: pay-ci
+  - name: pay-infra
+outputs:
+  - name: terraform-version
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: alpine
+    tag: latest
+params:
+  TERRAFORM_ROOT:
+run:
+  path: ash
+  args:
+    - pay-ci/ci/scripts/find-terraform-version.sh


### PR DESCRIPTION
I need to add a new deploy-bastion.yml task. All the deploy-<app> tasks hardcode the terraform version, and I'm making that problem worse.

We really need to be updating our terraform version more often but right now it's a huge pain, so I'm adding (thanks to pkl it's easy) loading the terraform version from the .terraform-version file.

All the terraform is run using the hashicorp/terraform docker image, so we can easily vary the tag loaded by loaded var

The script I've added, you tell it where the TF root is, and it reverse recurses up the tree right to `pay-infra/` looking for .terraform-version files (the same way tfenv does). As soon as it finds one it stops and outputs it.

The shared pkl lets you add it easily to an existing pipeline like:
```pkl
jobs {
  new {
    name = "deploy-bastion"
    plan {
      new GetStep { get = "pay-ci" }
      new GetStep {get = "pay-infra" }

      ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/test/test-12/environment/bastion")

      ...SNIP DEPLOY...
    }
  }
}
```

I'll follow up this with an update which uses it everywhere instead of hard coding the version

I temporarily modified the bastion pipeline to exercise this. [It finds and uses the default fine](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/bastion/jobs/deploy-bastion/builds/2):
![Screenshot 2024-08-23 at 11 58 32](https://github.com/user-attachments/assets/0036ab37-c859-4af1-9aa8-06c8eeb33ea4)

And then I also added a dummy branch to pay-infra putting a .terraform-version file in the test-12/environment folder specifying 1.9.5 and [you can see that also worked](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/bastion/jobs/deploy-bastion/builds/3):
![Screenshot 2024-08-23 at 11 59 23](https://github.com/user-attachments/assets/490d242a-9f97-4ac8-b08e-d27a5c16e3a1)

