### PR TITLE
Pp 12812: Use the tf version in pay-infra for all deployments

### DIFF
--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -108,7 +108,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.3.7
+              tag: "((.:terraform-version))"
           params:
             ENVIRONMENT: test
             SMOKE_TEST_VERSION: ((.:release_version))
@@ -159,7 +159,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.3.7
+              tag: "((.:terraform-version))"
           params:
             ENVIRONMENT: staging
             SMOKE_TEST_VERSION: ((.:release_version))
@@ -211,7 +211,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 1.3.7
+              tag: "((.:terraform-version))"
           params:
             ENVIRONMENT: production
             SMOKE_TEST_VERSION: ((.:release_version))

--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -149,6 +149,12 @@ jobs:
         params:
           <<: *aws_assumed_role_creds
           ENVIRONMENT: stag
+      - file: pay-ci/ci/tasks/find-terraform-version.yml
+        params:
+          TERRAFORM_ROOT: pay-infra/provisioning/terraform/deployments/deploy/deploy-7/management/smoke_tests
+        task: find-terraform-version
+      - file: terraform-version/.terraform-version
+        load_var: terraform-version
       - task: apply-the-terraform
         config:
           platform: linux
@@ -201,6 +207,12 @@ jobs:
         params:
           <<: *aws_assumed_role_creds
           ENVIRONMENT: prod        
+      - file: pay-ci/ci/tasks/find-terraform-version.yml
+        params:
+          TERRAFORM_ROOT: pay-infra/provisioning/terraform/deployments/deploy/deploy-7/management/smoke_tests
+        task: find-terraform-version
+      - file: terraform-version/.terraform-version
+        load_var: terraform-version
       - task: apply-the-terraform
         config:
           platform: linux

--- a/ci/pipelines/deploy-smoke-tests.yml
+++ b/ci/pipelines/deploy-smoke-tests.yml
@@ -92,6 +92,12 @@ jobs:
         params:
           <<: *aws_assumed_role_creds
           ENVIRONMENT: test
+      - file: pay-ci/ci/tasks/find-terraform-version.yml
+        params:
+          TERRAFORM_ROOT: pay-infra/provisioning/terraform/deployments/deploy/deploy-7/management/smoke_tests
+        task: find-terraform-version
+      - file: terraform-version/.terraform-version
+        load_var: terraform-version
       - task: apply-the-terraform
         config:
           platform: linux

--- a/ci/pipelines/stubs.yml
+++ b/ci/pipelines/stubs.yml
@@ -74,6 +74,12 @@ jobs:
         format: json
       - load_var: stubs_image_tag
         file: stubs-ecr-registry-deploy/tag
+      - file: pay-ci/ci/tasks/find-terraform-version.yml
+        params:
+          TERRAFORM_ROOT: pay-infra/provisioning/terraform/deployments/deploy/deploy-tooling/environment/stubs
+        task: find-terraform-version
+      - file: terraform-version/.terraform-version
+        load_var: terraform-version
       - task: deploy-stubs
         file: pay-ci/ci/tasks/deploy-stubs.yml
         params:

--- a/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
@@ -20,10 +20,16 @@ class PayApplication {
     dockerhub_repo = getDockerRepo()
     ecr_repo = getECRRepo()
   }
+  // We should change the webhooks egress directory
+  terraform_path_within_environment: String = "microservices_v2/\(if (name == "webhooks-egress") "webhooks_egress" else name)"
 
   function getECRRepo(): String = "govukpay/\(override_ecr_repo ?? name)"
   function getDockerRepo(): String = "governmentdigitalservice/pay-\(override_ecr_repo ?? name)"
   function getGithubRepo(): String = (override_github_repo ?? "pay-" + name)
+  function getTerraformRootPath(environment: String) = List(
+    "pay-infra", "provisioning", "terraform", "deployments",
+    environment.split("-")[0], environment, terraform_path_within_environment
+  ).join("/")
 }
 
 class MetricsConfig {

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -8,6 +8,7 @@ import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
 import "../common/shared_resources_for_annotations.pkl"
+import "../common/shared_resources_for_terraform.pkl"
 import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
@@ -106,7 +107,7 @@ jobs {
   getJobToDeployScheduledTasks()
 }
 
-local function getJobToDeployApp(app): Job = new {
+local function getJobToDeployApp(app: shared_resources_for_deploy_pipelines.PayApplication): Job = new {
   name = "deploy-\(app.name)-to-prod"
   serial = true
 
@@ -128,6 +129,8 @@ local function getJobToDeployApp(app): Job = new {
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
 
     checkReleaseVersions(app)
+
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(app.getTerraformRootPath("production-2"))
 
     shared_resources_for_deploy_pipelines.deployApplicationTask(app, awsEnvVars, "deploy-to-prod")
     shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-production")
@@ -390,6 +393,7 @@ local function getJobToDeployScheduledTasks(): Job = new {
       }
     }
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/production/production-2/management/scheduled_http_v2")
     shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
       awsEnvVars, "deploy-to-prod")
   }

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -7,6 +7,7 @@ import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_annotations.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
+import "../common/shared_resources_for_terraform.pkl"
 import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
@@ -95,7 +96,7 @@ jobs {
   getJobToDeployScheduledTasks()
 }
 
-local function getJobToDeployApp(app): Job = new {
+local function getJobToDeployApp(app: shared_resources_for_deploy_pipelines.PayApplication): Job = new {
   name = "deploy-\(app.name)-to-staging"
   serial = true
   plan = new {
@@ -116,6 +117,8 @@ local function getJobToDeployApp(app): Job = new {
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
 
     checkReleaseVersions(app)
+
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(app.getTerraformRootPath("staging-2"))
 
     shared_resources_for_deploy_pipelines.deployApplicationTask(app, awsEnvVars, "deploy-to-staging")
     shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-staging")
@@ -339,6 +342,7 @@ local function getJobToDeployScheduledTasks(): Job = new {
       }
     }
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/staging/staging-2/management/scheduled_http_v2")
     shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
       awsEnvVars, "deploy-to-staging")
   }

--- a/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-deploy/infra-drift-detector.pkl
@@ -3,6 +3,7 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/shared_resources_for_terraform.pkl"
 import "../common/PayResources.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -83,6 +84,7 @@ for (env, time in Map("staging-2", "every-morning-at-six", "production-2", "ever
         }
       }
       (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
+       ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/\(env.split("-")[0])/\(env)/environment/bastion/")
       new TaskStep {
         task = "check-for-drift"
         file = "pay-ci/ci/tasks/check-for-tf-drift.yml"

--- a/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
+++ b/ci/pkl-pipelines/pay-deploy/pact-broker.pkl
@@ -5,6 +5,7 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/shared_resources_for_terraform.pkl"
 import "../common/PayResources.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -50,6 +51,7 @@ jobs {
       }
       (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
       loadVar("pactbroker_image_tag", "pact-broker-ecr-registry-deploy/tag")
+      ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/deploy/deploy-tooling/environment/pactbroker")
       new TaskStep {
         task = "deploy-pact-broker"
         file = "pay-ci/ci/tasks/deploy-pact-broker.yml"

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -6,6 +6,7 @@ import "../common/shared_resources_for_metrics.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
 import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_annotations.pkl"
+import "../common/shared_resources_for_terraform.pkl"
 import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
@@ -91,6 +92,7 @@ jobs {
           }
           assumeRole("terraform-test-assume-role")
           (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
+          ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(app.getTerraformRootPath("test-perf-1"))
           shared_resources_for_deploy_pipelines.deployApplicationTask(app,
             awsEnvVars, "deploy-to-perf")
           shared_resources_for_annotations.paySendAppReleaseAnnotation("deploy-to-perf")
@@ -141,6 +143,7 @@ jobs {
         }
       }
       (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
+      ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/test/test-perf-1/management/scheduled_http_v2")
       shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
         awsEnvVars, "deploy-to-perf")
     }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -10,6 +10,7 @@ import "../common/shared_resources_for_deploy_pipelines.pkl"
 import "../common/shared_resources_for_lock_pools.pkl"
 import "../common/shared_resources_for_multi_arch_builds.pkl"
 import "../common/shared_resources_for_annotations.pkl"
+import "../common/shared_resources_for_terraform.pkl"
 import "../common/PayResources.pkl"
 
 local typealias PayApp = shared_resources_for_deploy_pipelines.PayApplication
@@ -466,7 +467,7 @@ local function getAdotIntegrationTest(app): Job = new {
     new MetricsConfig { put_metrics = false })
 }
 
-local function getJobToDeployApp(app): Job = new {
+local function getJobToDeployApp(app: shared_resources_for_deploy_pipelines.PayApplication): Job = new {
   name = "deploy-\(app.name)"
   serial = true
   plan = new {
@@ -481,9 +482,12 @@ local function getJobToDeployApp(app): Job = new {
     }
 
     assumeRole("terraform-test-assume-role")
+
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
 
     checkReleaseVersions(app)
+
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(app.getTerraformRootPath("test-12"))
 
     shared_resources_for_deploy_pipelines.deployApplicationTask(app, awsEnvVars, "deploy-to-test")
     shared_resources_for_deploy_pipelines.waitForDeployTask(app, "test-12")
@@ -687,6 +691,7 @@ local function getJobToDeployScheduledTasks(): Job = new {
       }
     }
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/test/test-12/management/scheduled_http_v2")
     shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
       awsEnvVars, "deploy-to-test")
   }

--- a/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
+++ b/ci/pkl-pipelines/pay-dev/infra-drift-detector.pkl
@@ -3,6 +3,7 @@ amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "../common/pipeline_self_update.pkl"
 import "../common/shared_resources.pkl"
 import "../common/shared_resources_for_slack_notifications.pkl"
+import "../common/shared_resources_for_terraform.pkl"
 import "../common/PayResources.pkl"
 
 local typealias SlackNotificationConfig = shared_resources_for_slack_notifications.SlackNotificationConfig
@@ -69,6 +70,7 @@ for (env, time in Map("test-12", "every-morning-at-five", "test-perf-1", "every-
         }
       }
       (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
+       ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/\(env.split("-")[0])/\(env)/environment/bastion/")
       new TaskStep {
         task = "check-for-drift"
         file = "pay-ci/ci/tasks/check-for-tf-drift.yml"

--- a/ci/tasks/deploy-app-with-adot.yml
+++ b/ci/tasks/deploy-app-with-adot.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-app.yml
+++ b/ci/tasks/deploy-app.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-egress.yml
+++ b/ci/tasks/deploy-egress.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-frontend-with-adot.yml
+++ b/ci/tasks/deploy-frontend-with-adot.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-pact-broker.yml
+++ b/ci/tasks/deploy-pact-broker.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-scheduled-tasks.yml
+++ b/ci/tasks/deploy-scheduled-tasks.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-stubs.yml
+++ b/ci/tasks/deploy-stubs.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/deploy-webhooks-egress.yml
+++ b/ci/tasks/deploy-webhooks-egress.yml
@@ -6,7 +6,7 @@ image_resource:
   type: registry-image
   source:
     repository: hashicorp/terraform
-    tag: 1.3.7
+    tag: "((.:terraform-version))"
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:


### PR DESCRIPTION
For all deployments, load the TF version, then use it instead of hardcoding for 1.3.7.

Where it's still a yml pipeline I just used the yml output generated in the pkl