### PR TITLE
PP-12812: Add bastion deployment pipelines

### DIFF
--- a/ci/pkl-pipelines/common/shared_pipelines/bastion.pkl
+++ b/ci/pkl-pipelines/common/shared_pipelines/bastion.pkl
@@ -1,0 +1,188 @@
+extends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+
+import "../pipeline_self_update.pkl"
+import "../shared_resources.pkl"
+import "../shared_resources_for_deploy_pipelines.pkl" as shared_deploy
+import "../shared_resources_for_multi_arch_builds.pkl"
+import "../shared_resources_for_slack_notifications.pkl" as shared_slack
+import "../shared_resources_for_terraform.pkl"
+
+hidden bastion_envs: Listing<BastionEnv>
+hidden concourse_team_name: String
+
+class BastionEnv {
+  environment: String
+  with_build: Boolean = false
+  account: shared_resources.AWSAccountName = environment.split("-")[0] as shared_resources.AWSAccountName
+  push_to_account_after_deploy: shared_resources.AWSAccountName?
+  tf_root = "pay-infra/provisioning/terraform/deployments/\(account)/\(environment)/environment/bastion"
+}
+
+hidden any_build_envs = bastion_envs.toList().any((env) -> env.with_build)
+hidden aws_accounts = bastion_envs.toList().map((env) -> env.account).distinct.sort()
+
+local bastion_image: shared_resources_for_multi_arch_builds.ImageToMultiArchBuild = new {
+  name = "bastion"
+  github_repo = "pay-aws-bastion"
+  branch = "main"
+  codebuild_project_name = "aws-bastion"
+  retag_after_build = true
+}
+
+resource_types {
+  shared_slack.slackNotificationResourceType
+}
+
+resources {
+  shared_resources.payCiGitHubResource
+  shared_resources.payInfraGitHubResource
+  shared_slack.slackNotificationResource
+  for (aws_account in aws_accounts) {
+    shared_resources.payECRResourceWithVariant("bastion-ecr-registry-\(aws_account)", "govukpay/bastion", "pay_aws_\(aws_account)_account_id", "release")
+  }
+  pipeline_self_update.PayPipelineSelfUpdateResource("\(concourse_team_name)/bastion.pkl", "master")
+  when (any_build_envs) {
+    new shared_resources_for_multi_arch_builds.MultiArchBuildGithubSourceResource { image = bastion_image }
+  }
+}
+
+jobs {
+  for (bastion_env in bastion_envs) {
+    when (bastion_env.with_build) {
+      new shared_resources_for_multi_arch_builds.MultiArchCandidateBuildJob { image = bastion_image }
+    }
+
+    deploy_bastion_image_in_account_job(bastion_env)
+
+    when (bastion_env.push_to_account_after_deploy != null) {
+      push_bastion_image_to_account_job(bastion_env, bastion_env.push_to_account_after_deploy)
+    }
+  }
+
+  pipeline_self_update.PayPipelineSelfUpdateJob("\(concourse_team_name)/bastion.pkl")
+}
+
+local function deploy_bastion_image_in_account_job(bastion_env: BastionEnv) = new Job {
+  name = "deploy-bastion-to-\(bastion_env.environment)"
+  plan {
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new GetStep {
+          get = "bastion-ecr-registry-\(bastion_env.account)"
+          trigger = true
+          params {
+            ["skip_download"] = true
+          }
+        }
+        new GetStep { get = "pay-ci" }
+        new GetStep { get = "pay-infra" }
+      }
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        new shared_resources.AssumeConcourseRoleTask {
+          role_name = "pay-concourse-bastion-deploy-\(bastion_env.environment)"
+          aws_account_name = bastion_env.account
+          output_name = "assume-role"
+          session_name = "deploy-bastion-\(bastion_env.environment)"
+        }
+      }
+    }
+    new InParallelStep {
+      in_parallel = new Listing<Step> {
+        shared_resources.loadVarJson("role", "assume-role/assume-role.json")
+        shared_resources.loadVar("application_image_tag", "bastion-ecr-registry-\(bastion_env.account)/tag")
+      }
+    }
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(bastion_env.tf_root)
+    new shared_deploy.TerraformInitStep { terraform_root = bastion_env.tf_root }
+    new shared_deploy.TerraformApplyStep {
+      terraform_root = bastion_env.tf_root
+      terraform_variables {
+        new shared_deploy.TerraformApplyVariable { name = "application_image_tag"; value = "((.:application_image_tag))" }
+      }
+    }
+  }
+  on_failure = shared_slack.paySlackNotification(
+    new shared_slack.SlackNotificationConfig {
+      message = "Failed to deploy bastion image to \(bastion_env.account)"
+      slack_channel_for_failure = "#govuk-pay-starling"
+    }
+  )
+  on_success = shared_slack.paySlackNotification(
+    new shared_slack.SlackNotificationConfig {
+      is_a_success = true
+      message = "Deployed bastion image to \(bastion_env.account)"
+    }
+  )
+}
+
+local function push_bastion_image_to_account_job(bastion_env: BastionEnv, account_to_push_to: shared_resources.AWSAccountName) = new Job {
+  name = "push-bastion-to-\(account_to_push_to)-ecr"
+
+  plan = new {
+    new InParallelStep {
+      in_parallel = new InParallelConfig {
+        steps = new Listing<Step> {
+          new GetStep {
+            get = "bastion-ecr-registry-\(bastion_env.account)"
+            params { ["skip_download"] = true }
+            trigger = true
+            passed { "deploy-bastion-to-\(bastion_env.environment)" }
+          }
+          new GetStep { get = "pay-ci" }
+        }
+      }
+    }
+    new shared_resources.ParseECRReleaseTagTask { ecr_repo = "bastion-ecr-registry-\(bastion_env.account)" }
+    new InParallelStep {
+      in_parallel = new InParallelConfig {
+        steps = new Listing<Step> {
+          shared_resources.loadVar("release_number", "ecr-release-info/release-number")
+
+          new shared_resources.AssumeConcourseRoleTask {
+            aws_account_name = bastion_env.account
+            output_name = "copy-from-role"
+          }
+          new shared_resources.AssumeConcourseRoleTask {
+            aws_account_name = account_to_push_to
+            output_name = "copy-to-role"
+          }
+        }
+      }
+    }
+
+    new InParallelStep {
+      in_parallel = new InParallelConfig {
+        steps = new Listing<Step> {
+          shared_resources.loadVarJson("copy-from-role", "copy-from-role/assume-role.json")
+          shared_resources.loadVarJson("copy-to-role", "copy-to-role/assume-role.json")
+        }
+      }
+    }
+
+    new TaskStep {
+      task = "push-bastion-images-to-\(account_to_push_to)"
+      file = "pay-ci/ci/tasks/copy-multiarch-image-to-other-account.yml"
+      privileged = true
+      params {
+        ["ECR_REPO_NAME"] = "govukpay/bastion"
+        ["RELEASE_NUMBER"] = "((.:release_number))"
+        ["SOURCE_ECR_REGISTRY"] = "((pay_aws_\(bastion_env.account)_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+        ["DESTINATION_ECR_REGISTRY"] = "((pay_aws_\(account_to_push_to)_account_id)).dkr.ecr.eu-west-1.amazonaws.com"
+        ["SOURCE_AWS_ACCESS_KEY_ID"] = "((.:copy-from-role.AWS_ACCESS_KEY_ID))"
+        ["SOURCE_AWS_SECRET_ACCESS_KEY"] = "((.:copy-from-role.AWS_SECRET_ACCESS_KEY))"
+        ["SOURCE_AWS_SESSION_TOKEN"] = "((.:copy-from-role.AWS_SESSION_TOKEN))"
+        ["DESTINATION_AWS_ACCESS_KEY_ID"] = "((.:copy-to-role.AWS_ACCESS_KEY_ID))"
+        ["DESTINATION_AWS_SECRET_ACCESS_KEY"] = "((.:copy-to-role.AWS_SECRET_ACCESS_KEY))"
+        ["DESTINATION_AWS_SESSION_TOKEN"] = "((.:copy-to-role.AWS_SESSION_TOKEN))"
+      }
+    }
+  }
+  on_failure = shared_slack.paySlackNotification(
+    new shared_slack.SlackNotificationConfig {
+      message = "Failed to push bastion image from \(bastion_env.account) to \(account_to_push_to)"
+      slack_channel_for_failure = "#govuk-pay-starling"
+    }
+  )
+}

--- a/ci/pkl-pipelines/common/shared_resources.pkl
+++ b/ci/pkl-pipelines/common/shared_resources.pkl
@@ -190,17 +190,29 @@ class ParseECRCandidateTagTask extends Pipeline.TaskStep {
   }
 }
 
+class ParseECRReleaseTagTask extends Pipeline.TaskStep {
+  hidden ecr_repo: String
+
+  task = "parse-ecr-release-info"
+  file = "pay-ci/ci/tasks/parse-ecr-release-tag.yml"
+  input_mapping {
+    ["ecr-image"] = ecr_repo
+  }
+}
+
 class AssumeConcourseRoleTask extends Pipeline.TaskStep {
   hidden aws_account_name: AWSAccountName = "test"
+  hidden role_name: String = "concourse"
   hidden output_name: Pipeline.Identifier = "assume-retag-role"
+  hidden session_name: String = "retag-ecr-image"
 
-  task = "assume-retag-role"
+  task = output_name
   file = "pay-ci/ci/tasks/assume-role.yml"
   output_mapping = new {
     ["assume-role"] = output_name
   }
   params = new {
-    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_\(aws_account_name)_account_id)):role/concourse"
-    ["AWS_ROLE_SESSION_NAME"] = "retag-ecr-image"
+    ["AWS_ROLE_ARN"] = "arn:aws:iam::((pay_aws_\(aws_account_name)_account_id)):role/\(role_name)"
+    ["AWS_ROLE_SESSION_NAME"] = session_name
   }
 }

--- a/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
@@ -191,8 +191,81 @@ function deployApplicationTask(app: PayApplication, awsEnvVars: Map,
   }
 }
 
-function getAWSAssumeRoleCreds() = new Mapping<String, String> {
+const function getAWSAssumeRoleCreds() = new Mapping<String, String> {
   ["AWS_ACCESS_KEY_ID"] = "((.:role.AWS_ACCESS_KEY_ID))"
   ["AWS_SECRET_ACCESS_KEY"] = "((.:role.AWS_SECRET_ACCESS_KEY))"
   ["AWS_SESSION_TOKEN"] = "((.:role.AWS_SESSION_TOKEN))"
+}
+
+open class TerraformInitStep extends Pipeline.TaskStep {
+  hidden terraform_root: String
+
+  task = "terraform-init"
+  config {
+    platform = "linux"
+    image_resource {
+      type = "registry-image"
+      source {
+        ["repository"] = "hashicorp/terraform"
+        ["tag"] = "((.:terraform-version))"
+      }
+    }
+    inputs = new {
+      new { name = "pay-infra" }
+    }
+    outputs = new {
+      new { name = "pay-infra" }
+    }
+    params = new {
+      ...getAWSAssumeRoleCreds()
+      ["AWS_REGION"] = "eu-west-1"
+    }
+    run {
+      dir = terraform_root
+      path = "terraform"
+      args {
+        "init"
+      }
+    }
+  }
+}
+
+open class TerraformApplyVariable {
+  name: String
+  value: String
+}
+
+open class TerraformApplyStep extends Pipeline.TaskStep {
+  hidden terraform_root: String
+  hidden terraform_variables: Listing<TerraformApplyVariable>
+
+  task = "terraform-apply"
+  config {
+    platform = "linux"
+    image_resource {
+      type = "registry-image"
+      source {
+        ["repository"] = "hashicorp/terraform"
+        ["tag"] = "((.:terraform-version))"
+      }
+    }
+    inputs = new {
+      new { name = "pay-infra" }
+    }
+    params = new {
+      ...getAWSAssumeRoleCreds()
+      ["AWS_REGION"] = "eu-west-1"
+      for (var in terraform_variables) {
+        ["TF_VAR_\(var.name)"] = var.value
+      }
+    }
+    run {
+      dir = terraform_root
+      path = "terraform"
+      args {
+        "apply"
+        "-auto-approve"
+      }
+    }
+  }
 }

--- a/ci/pkl-pipelines/pay-deploy/bastion.pkl
+++ b/ci/pkl-pipelines/pay-deploy/bastion.pkl
@@ -1,0 +1,9 @@
+amends "../common/shared_pipelines/bastion.pkl"
+
+bastion_envs = new Listing<BastionEnv> {
+  new { environment = "staging-2"; push_to_account_after_deploy = "production" }
+  new { environment = "production-2"; push_to_account_after_deploy = "deploy" }
+  new { environment = "deploy-tooling" }
+}
+
+concourse_team_name = "pay-deploy"

--- a/ci/pkl-pipelines/pay-dev/bastion.pkl
+++ b/ci/pkl-pipelines/pay-dev/bastion.pkl
@@ -1,31 +1,12 @@
-amends "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+amends "../common/shared_pipelines/bastion.pkl"
 
-import "../common/pipeline_self_update.pkl"
-import "../common/shared_resources.pkl"
-import "../common/shared_resources_for_multi_arch_builds.pkl"
-import "../common/shared_resources_for_slack_notifications.pkl"
-
-local bastion_image: shared_resources_for_multi_arch_builds.ImageToMultiArchBuild = new {
-  name = "bastion"
-  github_repo = "pay-aws-bastion"
-  branch = "main"
-  codebuild_project_name = "aws-bastion"
-  retag_after_build = true
+bastion_envs = new Listing<BastionEnv> {
+  new {
+    environment = "test-12"
+    with_build = true
+    push_to_account_after_deploy = "staging"
+  }
+  new { environment = "test-perf-1" }
 }
 
-resource_types {
-  shared_resources_for_slack_notifications.slackNotificationResourceType
-}
-
-resources {
-  shared_resources.payCiGitHubResource
-  shared_resources_for_slack_notifications.slackNotificationResource
-  pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/bastion.pkl", "master")
-  new shared_resources_for_multi_arch_builds.MultiArchBuildGithubSourceResource { image = bastion_image }
-}
-
-jobs {
-  new shared_resources_for_multi_arch_builds.MultiArchCandidateBuildJob { image = bastion_image }
-
-  pipeline_self_update.PayPipelineSelfUpdateJob("pay-dev/bastion.pkl")
-}
+concourse_team_name = "pay-dev"


### PR DESCRIPTION
Add bastion deployment pipelines which go:
```
pay-dev:

build in test -> deploy in test-12 -> push to staging
              -> deploy in test-perf-1


pay-deploy:

deploy in staging -> push to prod -> deploy in prod -> push to deploy -> deploy in deploy  
```

Rather than making a new deploy-x yaml and script I just used the fact the hashicorp terraform container can be configured more easily via some simple env vars, which saves on task yamls and extra scripts

Given there must be a pipeline in each team I refactored the existing stuff to be in a shared pipeline which is configured with a small amount of config in each teams pipeline

I appled these and you can see all jobs working as expected:

[pay-dev/bastion](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/bastion)
[pay-deploy/bastion](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/bastion)

Note: This PR requires https://github.com/alphagov/pay-infra/pull/4979