### PR TITLE
incident-2024-09-02: Allow disabling version rollback check for apps

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
@@ -3,6 +3,12 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 
 import "./shared_resources_for_multi_arch_builds.pkl"
 
+class EnforceVersionCheckConfig {
+  production: Boolean = true
+  staging: Boolean = true
+  test: Boolean = true
+}
+
 class PayApplication {
   name: String
   is_a_java_or_node_app: Boolean = false
@@ -14,6 +20,7 @@ class PayApplication {
   use_app_specific_deploy_task: Boolean = false
   smoke_test: Boolean = true
   pact_tag: Boolean = false
+  enforce_version_check: EnforceVersionCheckConfig = new {}
   multi_arch_build_image: shared_resources_for_multi_arch_builds.ImageToMultiArchBuild = new {
     name = outer.name
     github_repo = getGithubRepo()

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -128,7 +128,9 @@ local function getJobToDeployApp(app: shared_resources_for_deploy_pipelines.PayA
     assumeRole("terraform-prod-assume-role")
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
 
-    checkReleaseVersions(app)
+    when (app.enforce_version_check.production) {
+      checkReleaseVersions(app)
+    }
 
     ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(app.getTerraformRootPath("production-2"))
 

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -116,7 +116,9 @@ local function getJobToDeployApp(app: shared_resources_for_deploy_pipelines.PayA
     assumeRole("terraform-staging-assume-role")
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
 
-    checkReleaseVersions(app)
+    when (app.enforce_version_check.staging) {
+      checkReleaseVersions(app)
+    }
 
     ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(app.getTerraformRootPath("staging-2"))
 

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -485,7 +485,9 @@ local function getJobToDeployApp(app: shared_resources_for_deploy_pipelines.PayA
 
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
 
-    checkReleaseVersions(app)
+    when (app.enforce_version_check.test) {
+      checkReleaseVersions(app)
+    }
 
     ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps(app.getTerraformRootPath("test-12"))
 


### PR DESCRIPTION
When we deploy, we occasionally need to be able to disable the rollback version check, this is to allow us to deploy an old version in an emergency.

When we migrated to pkl we didn't make it easy to disable the check.

This PR enables configuring on a per-app per-env basis whether the version check should be performed. It defaults to enabled for everything.

The following change would disable it for connector in production, but is not set in this PR:

```
 $ git diff
diff --git a/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl b/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
index 4d0fade..cdd2a41 100644
--- a/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_deploy_pipelines.pkl
@@ -49,7 +49,7 @@ class MetricsConfig {
 local payApps: Listing<PayApplication> = new Listing<PayApplication> {
   new { name = "adminusers"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
   new { name = "cardid"; pact_tag = true; is_a_java_or_node_app = true }
-  new { name = "connector"; has_db = true; pact_tag = true; is_a_java_or_node_app = true }
+  new { name = "connector"; has_db = true; pact_tag = true; is_a_java_or_node_app = true; enforce_version_check { production = false } }
   new { name = "egress"; use_app_specific_deploy_task = true }
   new { name = "frontend"; use_app_specific_deploy_task = true; pact_tag = true;is_a_java_or_node_app = true }
   new { name = "ledger"; has_db = true; pact_tag = true ; is_a_java_or_node_app = true }
```

The above change would cause the following change in the pipeline:

```diff
$ pkl eval pay-deploy/deploy-to-production.pkl | fly-pay-deploy set-pipeline -p deploy-to-production -c - -d
jobs:
  job deploy-connector-to-prod has changed:
  ensure:
    attempts: 3
    params:
      release: claim-deploy-application-production-lock
    put: release-deploy-application-production-lock
    resource: lock-pool-deploy-application-production
  name: deploy-connector-to-prod
  on_failure:
    in_parallel:
      steps:
      - params:
          channel: '#govuk-pay-announce'
          icon_emoji: ':fargate:'
          text: "((.:failure_snippet)) \n - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse
            build #$BUILD_NAME>"
          username: pay-concourse
        put: slack-notification
      - attempts: 3
        params:
          job: deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/failure
          labels:
            app: ((.:app_name))
            concourse_job: $BUILD_JOB_NAME
            environment: production-2
            instance: concourse
            outcome: failure
            pipeline: $BUILD_PIPELINE_NAME
          metric: deployment_pipeline_app_release_number
          value: ((.:app_release_number))
        put: send-app-release-number-metric
        resource: prometheus-pushgateway
      - attempts: 3
        params:
          job: deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/failure
          labels:
            app: ((.:app_name))
            concourse_job: $BUILD_JOB_NAME
            environment: production-2
            instance: concourse
            outcome: failure
            pipeline: $BUILD_PIPELINE_NAME
            sidecar: nginx
          metric: deployment_pipeline_sidecar_release_number
          value: ((.:nginx_release_number))
        put: send-nginx-release-number-metric
        resource: prometheus-pushgateway
      - attempts: 3
        params:
          job: deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/failure
          labels:
            app: ((.:app_name))
            concourse_job: $BUILD_JOB_NAME
            environment: production-2
            instance: concourse
            outcome: failure
            pipeline: $BUILD_PIPELINE_NAME
            sidecar: adot
          metric: deployment_pipeline_sidecar_release_number
          value: ((.:adot_release_number))
        put: send-adot-release-number-metric
        resource: prometheus-pushgateway
  on_success:
    in_parallel:
      steps:
      - params:
          channel: '#govuk-pay-announce'
          icon_emoji: ':fargate:'
          text: "((.:success_snippet)) \n - <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse
            build #$BUILD_NAME>"
          username: pay-concourse
        put: slack-notification
      - attempts: 3
        params:
          job: deployment_pipeline_app_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/outcome/success
          labels:
            app: ((.:app_name))
            concourse_job: $BUILD_JOB_NAME
            environment: production-2
            instance: concourse
            outcome: success
            pipeline: $BUILD_PIPELINE_NAME
          metric: deployment_pipeline_app_release_number
          value: ((.:app_release_number))
        put: send-app-release-number-metric
        resource: prometheus-pushgateway
      - attempts: 3
        params:
          job: deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/nginx/outcome/success
          labels:
            app: ((.:app_name))
            concourse_job: $BUILD_JOB_NAME
            environment: production-2
            instance: concourse
            outcome: success
            pipeline: $BUILD_PIPELINE_NAME
            sidecar: nginx
          metric: deployment_pipeline_sidecar_release_number
          value: ((.:nginx_release_number))
        put: send-nginx-release-number-metric
        resource: prometheus-pushgateway
      - attempts: 3
        params:
          job: deployment_pipeline_sidecar_release_number/pipeline/$BUILD_PIPELINE_NAME/concourse_job/$BUILD_JOB_NAME/app/((.:app_name))/sidecar/adot/outcome/success
          labels:
            app: ((.:app_name))
            concourse_job: $BUILD_JOB_NAME
            environment: production-2
            instance: concourse
            outcome: success
            pipeline: $BUILD_PIPELINE_NAME
            sidecar: adot
          metric: deployment_pipeline_sidecar_release_number
          value: ((.:adot_release_number))
        put: send-adot-release-number-metric
        resource: prometheus-pushgateway
  plan:
  - in_parallel:
      steps:
      - get: connector-ecr-registry-prod
        trigger: true
      - get: adot-ecr-registry-prod
        trigger: true
      - get: nginx-proxy-ecr-registry-prod
        trigger: true
      - get: pay-infra
      - get: pay-ci
  - attempts: 10
    params:
      claim: deploy-application-production-lock
    put: claim-deploy-application-production-lock
    resource: lock-pool-deploy-application-production
    timeout: 10m
  - in_parallel:
      steps:
      - file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
        input_mapping:
          ecr-image: connector-ecr-registry-prod
        task: parse-connector-ecr-release-tag
      - file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
        input_mapping:
          ecr-image: adot-ecr-registry-prod
        output_mapping:
          ecr-release-info: adot-release-info
        task: parse-adot-ecr-release-tag
      - file: pay-ci/ci/tasks/parse-ecr-release-tag.yml
        input_mapping:
          ecr-image: nginx-proxy-ecr-registry-prod
        output_mapping:
          ecr-release-info: nginx-release-info
        task: parse-nginx-proxy-ecr-release-tag
  - in_parallel:
      steps:
      - file: connector-ecr-registry-prod/tag
        load_var: application_image_tag
      - file: adot-ecr-registry-prod/tag
        load_var: adot_image_tag
      - file: nginx-proxy-ecr-registry-prod/tag
        load_var: nginx_image_tag
  - file: pay-ci/ci/tasks/create-notification-snippets.yml
    params:
      ACTION_NAME: Deployment
      ADOT_IMAGE_TAG: ((.:adot_image_tag))
      APP_NAME: connector
      APPLICATION_IMAGE_TAG: ((.:application_image_tag))
      ENV: production-2
      NGINX_IMAGE_TAG: ((.:nginx_image_tag))
    task: create-notification-snippets
  - in_parallel:
      steps:
      - file: snippet/app_name
        load_var: app_name
      - file: snippet/app_release_number
        load_var: app_release_number
      - file: snippet/adot_release_number
        load_var: adot_release_number
      - file: snippet/nginx_release_number
        load_var: nginx_release_number
      - file: snippet/success
        load_var: success_snippet
      - file: snippet/failure
        load_var: failure_snippet
      - file: snippet/start
        load_var: start_snippet
  - params:
      channel: '#govuk-pay-announce'
      icon_emoji: ':fargate:'
      text: "((.:start_snippet)) \n\n <https://pay-cd.deploy.payments.service.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse
        build #$BUILD_NAME>"
      username: pay-concourse
    put: slack-notification
  - file: pay-ci/ci/tasks/get-git-sha-for-release-tag.yml
    params:
      APP_NAME: connector
      APPLICATION_IMAGE_TAG: ((.:application_image_tag))
      GITHUB_TOKEN: ((github-access-token))
    task: get-git-sha-for-release-tag
  - file: git-sha/git-sha
    load_var: git-sha
  - file: pay-ci/ci/tasks/check-pact-compatibility.yml
    params:
      APP_NAME: connector
      GIT_SHA: ((.:git-sha))
      PACT_TAG: production-fargate
    task: check-pact-compatibility
  - file: pay-ci/ci/tasks/assume-role.yml
    params:
      AWS_ROLE_ARN: arn:aws:iam::((pay_aws_prod_account_id)):role/concourse
      AWS_ROLE_SESSION_NAME: terraform-prod-assume-role
    task: assume-role
  - file: assume-role/assume-role.json
    format: json
    load_var: role
- - file: pay-ci/ci/tasks/check-release-versions.yml
-   params:
-     ADOT_IMAGE_TAG: ((.:adot_image_tag))
-     APP_NAME: connector
-     APPLICATION_IMAGE_TAG: ((.:application_image_tag))
-     AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
-     AWS_REGION: eu-west-1
-     AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
-     AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
-     CLUSTER_NAME: production-2-fargate
-     NGINX_IMAGE_TAG: ((.:nginx_image_tag))
-   task: check-release-versions
  - file: pay-ci/ci/tasks/find-terraform-version.yml
    params:
      TERRAFORM_ROOT: pay-infra/provisioning/terraform/deployments/production/production-2/microservices_v2/connector
    task: find-terraform-version
  - file: terraform-version/.terraform-version
    load_var: terraform-version
  - file: pay-ci/ci/tasks/deploy-app-with-adot.yml
    params:
      ACCOUNT: production
      ADOT_IMAGE_TAG: ((.:adot_image_tag))
      APP_NAME: connector
      APPLICATION_IMAGE_TAG: ((.:application_image_tag))
      AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
      AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
      AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
      ENVIRONMENT: production-2
      NGINX_IMAGE_TAG: ((.:nginx_image_tag))
    task: deploy-to-prod
  - attempts: 3
    params:
      tags:
      - deploy-to-production
      - ((.:app_name))
      template: released ${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME} release ((.:app_release_number))
        (build ${BUILD_ID})
    put: grafana-annotation
  - file: pay-ci/ci/tasks/wait-for-deploy.yml
    params:
      ADOT_IMAGE_TAG: ((.:adot_image_tag))
      APP_NAME: connector
      APPLICATION_IMAGE_TAG: ((.:application_image_tag))
      AWS_ACCESS_KEY_ID: ((.:role.AWS_ACCESS_KEY_ID))
      AWS_SECRET_ACCESS_KEY: ((.:role.AWS_SECRET_ACCESS_KEY))
      AWS_SESSION_TOKEN: ((.:role.AWS_SESSION_TOKEN))
      ENVIRONMENT: production-2
      NGINX_IMAGE_TAG: ((.:nginx_image_tag))
    task: wait-for-deploy
  serial: true

pipeline name: deploy-to-production
```