### PR TITLE
Pp 13158/bump docker scout cli version

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -56,4 +56,4 @@ COPY ./docker-helpers.sh /
 COPY ./docker-wrapper /usr/local/bin/
 ENTRYPOINT [ "docker-wrapper" ]
 
-CMD "ash"
+CMD ["ash"]

--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --virtual build-dependencies build-base
 
 ENV DOCKER_HOME=/root/.docker
 RUN mkdir -p /root/.docker/cli-plugins
-RUN curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/v1.10.0/install.sh | sh -s --
+RUN curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/v1.13.0/install.sh | sh -s --
 
 RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.86.0/pact-1.86.0-linux-x86_64.tar.gz \
     && tar xzf pact-1.86.0-linux-x86_64.tar.gz \


### PR DESCRIPTION
Bump the version of docker scout cli
When I did a test build docker also gave me a warning about using CMD of the non-json format:

```
 1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 59)
```

In our case it doesn't matter, but I'd rather not have a noisy warning all the time, it will make it harder to heed warnings that do matter, so change it anyway.