### PR TITLE
PP-13158: Allow running and displaying a vuln scan without Jira story

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
+++ b/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
@@ -25,6 +25,25 @@ jobs = new {
   pipeline_self_update.PayPipelineSelfUpdateJob("pay-deploy/internal-vulnerability-scan.pkl")
 
   new {
+    name = "run-internal-vulnerability-without-creating-jira-ticket"
+    plan {
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "pay-ci" }
+        }
+      }
+      assumeReadFromStagingEcrRole()
+      new LoadVarStep {
+        load_var = "assume-read-from-staging-ecr-role"
+        file = "assume-read-from-staging-ecr-role/assume-role.json"
+        format = "json"
+      }
+      runVulnerabilityScan()
+      displayVulnerabilityScan()
+    }
+  }
+
+  new {
     name = "run-vulnerability-scan"
     plan {
       new InParallelStep {
@@ -40,6 +59,7 @@ jobs = new {
         format = "json"
       }
       runVulnerabilityScan()
+      displayVulnerabilityScan()
       createJiraStory()
     }
 
@@ -94,6 +114,11 @@ local function runVulnerabilityScan(): TaskStep = new TaskStep {
     ["DOCKERHUB_USERNAME"] = "((docker-username))"
     ["DOCKERHUB_ACCESS_TOKEN"] = "((docker-access-token))"
   }
+}
+
+local function displayVulnerabilityScan(): TaskStep = new TaskStep {
+  task = "display-vulnerability-scan"
+  file = "pay-ci/ci/tasks/display-vulnerability-scan-result.yml"
 }
 
 local function createJiraStory(): TaskStep = new TaskStep {

--- a/ci/scripts/run-vulnerability-scan/display-vulnerability-scan-result.sh
+++ b/ci/scripts/run-vulnerability-scan/display-vulnerability-scan-result.sh
@@ -1,0 +1,13 @@
+#!/bin/ash
+# shellcheck shell=dash
+set -euo pipefail
+
+FILE_NAME=$(ls reports)
+
+echo "Vulnerability scan report file name: $FILE_NAME .."
+echo "Vulnerability scan result (CSV):"
+echo "======================================================================="
+echo
+cat "reports/$FILE_NAME"
+echo
+echo "======================================================================="

--- a/ci/tasks/display-vulnerability-scan-result.yml
+++ b/ci/tasks/display-vulnerability-scan-result.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: alping
+    tag: latest
+inputs:
+  - name: reports
+  - name: pay-ci
+run:
+  path: /bin/sh
+  args: ["pay-ci/ci/scripts/run-vulnerability-scan/display-vulnerability-scan-result.sh"]

--- a/ci/tasks/display-vulnerability-scan-result.yml
+++ b/ci/tasks/display-vulnerability-scan-result.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: alping
+    repository: alpine
     tag: latest
 inputs:
   - name: reports


### PR DESCRIPTION
To allow for less noisy rescans add the ability to run a scan and just print the results. I also got it to display the scan in the version of the job that creates a jira story.

You can see the result of applying and running this here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/internal-vulnerability-scan/jobs/run-internal-vulnerability-without-creating-jira-ticket/builds/2