### PR TITLE
BAU: Fix path for scheduled http tasks

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -395,7 +395,7 @@ local function getJobToDeployScheduledTasks(): Job = new {
       }
     }
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
-    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/production/production-2/management/scheduled_http_v2")
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/production/production-2/management/scheduled_http_v2")
     shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
       awsEnvVars, "deploy-to-prod")
   }

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -344,7 +344,7 @@ local function getJobToDeployScheduledTasks(): Job = new {
       }
     }
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
-    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/staging/staging-2/management/scheduled_http_v2")
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/staging/staging-2/management/scheduled_http_v2")
     shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
       awsEnvVars, "deploy-to-staging")
   }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -143,7 +143,7 @@ jobs {
         }
       }
       (loadVar("role", "assume-role/assume-role.json")) { format = "json" }
-      ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/test/test-perf-1/management/scheduled_http_v2")
+      ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/test/test-perf-1/management/scheduled_http_v2")
       shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
         awsEnvVars, "deploy-to-perf")
     }

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -693,7 +693,7 @@ local function getJobToDeployScheduledTasks(): Job = new {
       }
     }
     loadVarWithJsonFormat("role", "assume-role/assume-role.json")
-    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("provisioning/terraform/deployments/test/test-12/management/scheduled_http_v2")
+    ...shared_resources_for_terraform.LoadTerraformVersionForTFRootSteps("pay-infra/provisioning/terraform/deployments/test/test-12/management/scheduled_http_v2")
     shared_resources_for_deploy_pipelines.deployApplicationTask(payScheduledTask,
       awsEnvVars, "deploy-to-test")
   }


### PR DESCRIPTION
The path for finding the terraform version for scheduled http tasks was missing the preceding pay-infra. This caused deployment failure as seen here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-scheduled-tasks/builds/181

This PR fixes it for all envs. I applied the deploy-to-test pipeline and reran with the same inputs, and you can see a working deploy here: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/deploy-to-test/jobs/deploy-scheduled-tasks/builds/181.1