### PR TITLE
BAU: Remove unused lock pool

### DIFF
--- a/ci/pkl-pipelines/pay-dev/init-lock-pools.pkl
+++ b/ci/pkl-pipelines/pay-dev/init-lock-pools.pkl
@@ -2,7 +2,6 @@ amends "../common/shared_pipelines/init_lock_pools.pkl"
 
 pools_to_init {
   "deploy-application-test"
-  "perf-tests"
   "smoke-test-test"
 }
 


### PR DESCRIPTION
This lock pool isn't used. The perf tests pipeline is still using serial groups and is fine to keep doing so