### PR TITLE
PP-13257: Make start and stop DB more robust

### DIFF
--- a/ci/pkl-pipelines/pay-dev/perf-tests.pkl
+++ b/ci/pkl-pipelines/pay-dev/perf-tests.pkl
@@ -33,7 +33,11 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/perf-tests.pkl", "master")
   shared_resources.slackNotificationResource
 
-  shared_resources.payCiGitHubResource
+  (shared_resources.payCiGitHubResource) {
+    source {
+      branch = "pp-13257/make-start-stop-db-more-robust"
+    }
+  }
   shared_resources.payGithubPullRequestResource("pay-perftests-pr", "pay-perftests")
   new PayResources.PayGitHubResource {
     name = "perf-tests-git-release"
@@ -185,7 +189,11 @@ jobs = new {
           }
         }
       }
-      assumeRoleTask("test", "pay-cd-pay-dev-codebuild-executor-perf-tests-test-perf-1", "perf-tests-test-assume-role")
+      (assumeRoleTask("test", "pay-cd-pay-dev-codebuild-executor-perf-tests-test-perf-1", "perf-tests-test-assume-role")) {
+        params {
+          ["AWS_ROLE_DURATION"] = "18600"
+        }
+      }
       new InParallelStep {
         in_parallel = new InParallelConfig {
           steps {
@@ -511,7 +519,11 @@ local function timedDbScalingSetup(timeTrigger: String): Listing<Step> = new {
       }
     }
   }
-  assumeRoleTask("test", "pay-cd-pay-dev-codebuild-executor-perf-tests-test-perf-1", "perf-tests-test-assume-role")
+  (assumeRoleTask("test", "pay-cd-pay-dev-codebuild-executor-perf-tests-test-perf-1", "perf-tests-test-assume-role")) {
+    params {
+      ["AWS_ROLE_DURATION"] = "18600"
+    }
+  }
   new InParallelStep {
     in_parallel = new InParallelConfig {
       steps {

--- a/ci/pkl-pipelines/pay-dev/perf-tests.pkl
+++ b/ci/pkl-pipelines/pay-dev/perf-tests.pkl
@@ -33,11 +33,7 @@ resources = new {
   pipeline_self_update.PayPipelineSelfUpdateResource("pay-dev/perf-tests.pkl", "master")
   shared_resources.slackNotificationResource
 
-  (shared_resources.payCiGitHubResource) {
-    source {
-      branch = "pp-13257/make-start-stop-db-more-robust"
-    }
-  }
+  shared_resources.payCiGitHubResource
   shared_resources.payGithubPullRequestResource("pay-perftests-pr", "pay-perftests")
   new PayResources.PayGitHubResource {
     name = "perf-tests-git-release"

--- a/ci/pkl-pipelines/pay-dev/perf-tests.pkl
+++ b/ci/pkl-pipelines/pay-dev/perf-tests.pkl
@@ -494,7 +494,11 @@ local serviceScalingSetup = new Listing<Step> {
       }
     }
   }
-  assumeRoleTask("test", "pay-cd-pay-dev-codebuild-executor-perf-tests-test-perf-1", "perf-tests-test-assume-role")
+  (assumeRoleTask("test", "pay-cd-pay-dev-codebuild-executor-perf-tests-test-perf-1", "perf-tests-test-assume-role")) {
+    params {
+      ["AWS_ROLE_DURATION"] = "18600"
+    }
+  }
   new InParallelStep {
     in_parallel = new InParallelConfig {
       steps {

--- a/ci/scripts/start-rds-instance.sh
+++ b/ci/scripts/start-rds-instance.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function db_instance_state() {
+  aws rds describe-db-instances --db-instance-identifier "${RDS_INSTANCE_NAME}" --query "DBInstances[0].DBInstanceStatus" --output text
+}
+
+TOTAL_WAIT_TIME_IN_MINUTES=$((MAX_ATTEMPTS * 15 / 60))
+
+for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+  CURRENT_STATE=$(db_instance_state)
+
+  if [ "${CURRENT_STATE}" == "available" ]; then
+    echo "RDS instance ${RDS_INSTANCE_NAME} is available"
+    exit 0
+  elif [ "${CURRENT_STATE}" == "starting" ]; then
+    echo "RDS instance ${RDS_INSTANCE_NAME} is already starting up"
+  elif [ "${CURRENT_STATE}" == "stopped" ]; then
+    echo "Starting RDS instance ${RDS_INSTANCE_NAME}"
+    aws rds start-db-instance --db-instance-identifier "${RDS_INSTANCE_NAME}" >> /dev/null
+  elif [ "${CURRENT_STATE}" == "backing-up" ] || [ "${CURRENT_STATE}" == "configuring-enhanced-monitoring" ] || [ "${CURRENT_STATE}" == "rebooting" ]; then
+    echo "The RDS instance ${RDS_INSTANCE_NAME} is currently in state ${CURRENT_STATE}. We need to wait for that to complete."
+  else
+    echo "RDS instance ${RDS_INSTANCE_NAME} is not in a state that can be started." \
+      "It's currently in ${CURRENT_STATE}, manual intervention will be required to resolve this."
+    exit 1
+  fi
+
+  echo "Waiting 15 seconds before checking again. Attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+  sleep 15
+done
+
+echo "RDS instance ${RDS_INSTANCE_NAME} did not reach the available state within ${TOTAL_WAIT_TIME_IN_MINUTES} minutes"
+exit 1

--- a/ci/scripts/stop-rds-instance.sh
+++ b/ci/scripts/stop-rds-instance.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function db_instance_state() {
+  aws rds describe-db-instances --db-instance-identifier "${RDS_INSTANCE_NAME}" --query "DBInstances[0].DBInstanceStatus" --output text
+}
+
+TOTAL_WAIT_TIME_IN_MINUTES=$((MAX_ATTEMPTS * 15 / 60))
+
+for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+  CURRENT_STATE=$(db_instance_state)
+
+  if [ "${CURRENT_STATE}" == "stopped" ]; then
+    echo "The RDS instance ${RDS_INSTANCE_NAME} is stopped"
+    exit 0
+  elif [ "${CURRENT_STATE}" == "available" ]; then
+    echo "Stopping RDS instance ${RDS_INSTANCE_NAME}"
+    aws rds stop-db-instance --db-instance-identifier "${RDS_INSTANCE_NAME}" >> /dev/null
+  elif [ "${CURRENT_STATE}" == "stopping" ]; then
+    echo "The RDS instance ${RDS_INSTANCE_NAME} is currently stopping."
+  elif [ "${CURRENT_STATE}" == "backing-up" ] || [ "${CURRENT_STATE}" == "configuring-enhanced-monitoring" ] || [ "${CURRENT_STATE}" == "rebooting" ]; then
+    echo "The RDS instance ${RDS_INSTANCE_NAME} is currently in state ${CURRENT_STATE}. We need to wait for that to complete."
+  else
+    echo "RDS instance ${RDS_INSTANCE_NAME} is not in a state which can be stopped. " \
+      "It's currently in state ${CURRENT_STATE}, manual intervention will be required"
+    exit  1
+  fi
+
+  echo "Waiting 15 seconds before checking again. Attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+
+  sleep 15
+done
+
+echo "RDS instance ${RDS_INSTANCE_NAME} did not reach the stopped state within ${TOTAL_WAIT_TIME_IN_MINUTES} minutes"
+exit 1

--- a/ci/tasks/start-rds-instance.yml
+++ b/ci/tasks/start-rds-instance.yml
@@ -7,41 +7,7 @@ image_resource:
 params:
   RDS_INSTANCE_NAME:
   AWS_DEFAULT_REGION: eu-west-1
+  MAX_ATTEMPTS: 480 # 120 minutes (to account for databases backing up, and configuring enhanced monitoring)
 run:
   path: /bin/bash
-  args:
-    - -euo
-    - pipefail
-    - -c
-    - |
-      CURRENT_STATE=$(
-        aws rds describe-db-instances \
-          --db-instance-identifier "${RDS_INSTANCE_NAME}" \
-          --query "DBInstances[0].DBInstanceStatus" \
-          --output text
-      )
-
-      if [ "${CURRENT_STATE}" == "available" ]; then
-        echo "RDS instance ${RDS_INSTANCE_NAME} is already available"
-        exit 0
-      elif [ "${CURRENT_STATE}" == "starting" ]; then
-        echo "RDS instance ${RDS_INSTANCE_NAME} is already starting up"
-      elif [ "${CURRENT_STATE}" != "stopped" ]; then
-        echo "RDS instance ${RDS_INSTANCE_NAME} is not in a state that can be started." \
-          "It's currently in ${CURRENT_STATE}, manual intervention will be required to resolve this."
-
-        exit 1
-      else
-        echo "Starting RDS instance ${RDS_INSTANCE_NAME}"
-        aws rds start-db-instance --db-instance-identifier "${RDS_INSTANCE_NAME}" >> /dev/null
-      fi
-
-      # You can't change how long 'aws rds wait' waits, in total it waits for 30 minutes, but we want to
-      # wait for 60 minutes, so if it fails the first time we will run it again.
-      echo "Waiting for RDS instance ${RDS_INSTANCE_NAME} to be available"
-      if ! aws rds wait db-instance-available --db-instance-identifier "${RDS_INSTANCE_NAME}"; then
-        echo "Still not available after 30 minutes, waiting another 30 minutes"
-        aws rds wait db-instance-available --db-instance-identifier "${RDS_INSTANCE_NAME}"
-      fi
-
-      echo "RDS instance ${RDS_INSTANCE_NAME} is now available"
+  args: ["pay-ci/ci/scripts/start-rds-instance.sh"]

--- a/ci/tasks/start-rds-instance.yml
+++ b/ci/tasks/start-rds-instance.yml
@@ -8,6 +8,8 @@ params:
   RDS_INSTANCE_NAME:
   AWS_DEFAULT_REGION: eu-west-1
   MAX_ATTEMPTS: 480 # 120 minutes (to account for databases backing up, and configuring enhanced monitoring)
+inputs:
+  - name: pay-ci
 run:
   path: /bin/bash
   args: ["pay-ci/ci/scripts/start-rds-instance.sh"]

--- a/ci/tasks/stop-rds-instance.yml
+++ b/ci/tasks/stop-rds-instance.yml
@@ -7,50 +7,7 @@ image_resource:
 params:
   RDS_INSTANCE_NAME:
   AWS_DEFAULT_REGION: eu-west-1
-  MAX_ATTEMPTS: 240 # 60 minutes
+  MAX_ATTEMPTS: 480 # 120 minutes (to account for databases backing up, and configuring enhanced monitoring)
 run:
   path: /bin/bash
-  args:
-    - -euo
-    - pipefail
-    - -c
-    - |
-      function db_instance_state() {
-        aws rds describe-db-instances --db-instance-identifier "${RDS_INSTANCE_NAME}" --query "DBInstances[0].DBInstanceStatus" --output text
-      }
-
-      CURRENT_STATE=$(db_instance_state)
-
-      if [ "${CURRENT_STATE}" == "stopped" ]; then
-        echo "RDS instance ${RDS_INSTANCE_NAME} is already stopped"
-        exit 0
-      elif [ "${CURRENT_STATE}" == "stopping" ]; then
-        echo "RDS instance ${RDS_INSTANCE_NAME} is already stopping"
-      elif [ "${CURRENT_STATE}" != "available" ]; then
-        echo "RDS instance ${RDS_INSTANCE_NAME} is not in a state which can be stopped. " \
-          "It's currently in state ${CURRENT_STATE}, manual intervention will be required"
-        exit  1
-      else
-        echo "Stopping RDS instance ${RDS_INSTANCE_NAME}"
-        aws rds stop-db-instance --db-instance-identifier "${RDS_INSTANCE_NAME}" >> /dev/null
-      fi
-
-      TOTAL_WAIT_TIME_IN_MINUTES=$((MAX_ATTEMPTS * 15 / 60))
-
-      echo "Starting to wait up to ${TOTAL_WAIT_TIME_IN_MINUTES} minutes for RDS instance ${RDS_INSTANCE_NAME} to stop"
-
-      for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
-        CURRENT_STATE=$(db_instance_state)
-
-        if [ "${CURRENT_STATE}" == "stopped" ]; then
-          echo "The RDS instance ${RDS_INSTANCE_NAME} is now stopped"
-          exit 0
-        fi
-
-        echo "The RDS instance ${RDS_INSTANCE_NAME} is currently in state ${CURRENT_STATE}." \
-            "Waiting 15 seconds before checking again. Attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
-        sleep 15
-      done
-
-      echo "RDS instance ${RDS_INSTANCE_NAME} did not reach the stopped state within ${TOTAL_WAIT_TIME_IN_MINUTES} minutes"
-      exit 1
+  args: ["pay-ci/ci/scripts/stop-rds-instance.sh"]

--- a/ci/tasks/stop-rds-instance.yml
+++ b/ci/tasks/stop-rds-instance.yml
@@ -8,6 +8,8 @@ params:
   RDS_INSTANCE_NAME:
   AWS_DEFAULT_REGION: eu-west-1
   MAX_ATTEMPTS: 480 # 120 minutes (to account for databases backing up, and configuring enhanced monitoring)
+inputs:
+  - name: pay-ci
 run:
   path: /bin/bash
   args: ["pay-ci/ci/scripts/stop-rds-instance.sh"]


### PR DESCRIPTION
Start and stop db scripts both aren't as robust as we would hope.

After waiting for the db to be available with `aws rds wait db-instance-available --db-instance-identifier ...` the dbs are still sometimes in another state (like configuring enhanced monitoring, or backing up`.

On shutdown, since the dbs aren't online all that often in perf env they are sometimes configuring enhanced monitoring, rebooting, or backing up, when we try and shut them down.

So in all these cases we'll wait while it happens and just keep polling the state.

I've extracted the scripts into their own files (as agreed within the team as general practice).

Sometimes the STS tokens also time out, so set extended duration for everything that scales the databases


I ran scale up dbs https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-up-databases/builds/92

scale down dbs https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-down-databases/builds/78

and scale-and-run-all-simulations https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-and-run-all-simulations/builds/878