### PR TITLE
PP-13142 Install session-manager-plugin

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -9,7 +9,9 @@ RUN apk add --no-cache \
   bash \
   curl \
   docker-compose \
+  dpkg \
   netcat-openbsd \
+  gcompat \
   git \
   python3 \
   ca-certificates \
@@ -51,6 +53,12 @@ RUN echo "$FLY_CLI_SHA256SUM  /tmp/fly" >> /tmp/fly.sha256 \
   && sha256sum -c /tmp/fly.sha256 \
   && mv /tmp/fly /usr/local/bin/ \
   && chmod 555 /usr/local/bin/fly
+
+RUN wget "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" \
+   && dpkg -x session-manager-plugin.deb session-manager-plugin \
+    && rm session-manager-plugin.deb
+RUN ln -s /session-manager-plugin/usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/
+RUN chmod +x /usr/local/bin/session-manager-plugin
 
 COPY ./docker-helpers.sh /
 COPY ./docker-wrapper /usr/local/bin/


### PR DESCRIPTION
## WHAT

- Installs session-manager-plugin in pay-concourse-runner to test bastion

- build works

```
➜  concourse-runner git:(pp_13142_install_session_manager) docker build -t governmentdigitalservice/pay-concourse-runner:local .
[+] Building 1.9s (20/20) FINISHED                                                                                                                         docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                       0.0s
 => => transferring dockerfile: 2.42kB                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/docker:24.0.9-dind                                                                                                      1.8s
 => [auth] library/docker:pull token for registry-1.docker.io                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                            0.0s
 => [ 1/14] FROM docker.io/library/docker:24.0.9-dind@sha256:9b17a9f25adf17b88d0a013b4f00160754adf4b07ccbe9986664a49886c2c98e                                              0.0s
 => [internal] load build context                                                                                                                                          0.0s
 => => transferring context: 73B                                                                                                                                           0.0s
 => CACHED [ 2/14] RUN apk add --no-cache   aws-cli   bash   curl   docker-compose   dpkg   netcat-openbsd   gcompat   git   python3   ca-certificates   jq   openjdk21    0.0s
 => CACHED [ 3/14] RUN apk add --virtual build-dependencies build-base                                                                                                     0.0s
 => CACHED [ 4/14] RUN mkdir -p /root/.docker/cli-plugins                                                                                                                  0.0s
 => CACHED [ 5/14] RUN curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/v1.13.0/install.sh | sh -s --                                                         0.0s
 => CACHED [ 6/14] RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.86.0/pact-1.86.0-linux-x86_64.tar.gz     && tar xzf pact-1.8  0.0s
 => CACHED [ 7/14] RUN ln -s /pact/bin/pact /usr/local/bin     && ln -s /pact/bin/pact-broker /usr/local/bin     && ln -s /pact/bin/pact-message /usr/local/bin     && ln  0.0s
 => CACHED [ 8/14] RUN echo "33aa2b56b4852e00fce821073fa74c5302433e61f3cf8d07f44acd34b4cb13c9  /tmp/pkl" >> /tmp/pkl.sha256   && wget -O /tmp/pkl "https://github.com/app  0.0s
 => CACHED [ 9/14] RUN echo "90a05559d36f259903ca76988b51fbca8948f0c30a42e260d27dda659052db22  /tmp/fly" >> /tmp/fly.sha256   && wget -O /tmp/fly 'https://pay-cd.deploy.  0.0s
 => CACHED [10/14] RUN wget "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb"    && dpkg -x session-manager-plug  0.0s
 => CACHED [11/14] RUN ln -s /session-manager-plugin/usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/                                             0.0s
 => CACHED [12/14] RUN chmod +x /usr/local/bin/session-manager-plugin                                                                                                      0.0s
 => CACHED [13/14] COPY ./docker-helpers.sh /                                                                                                                              0.0s
 => CACHED [14/14] COPY ./docker-wrapper /usr/local/bin/                                                                                                                   0.0s
 => exporting to image                                                                                                                                                     0.0s
 => => exporting layers                                                                                                                                                    0.0s
 => => writing image sha256:b4b39b930df0ac6c166025074ad75210c9c16572c402c9fc216ea01ce485d7ba                                                                               0.0s
 => => naming to docker.io/governmentdigitalservice/pay-concourse-runner:local                                                                                             0.0s

```


- session manager version

```
➜  concourse-runner git:(pp_13142_install_session_manager) docker run -it governmentdigitalservice/pay-concourse-runner:local
/ # session-manager-plugin --version
1.2.677.0
```

