### PR TITLE
PP-13286: Send additional tags on release annotations

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-production.pkl
@@ -44,7 +44,7 @@ resources = new {
   new shared_resources_for_lock_pools.LockPoolResource { pool = "deploy-application-production" }
   shared_resources_for_slack_notifications.slackNotificationResource
   (shared_resources_for_annotations.grafanaAnnotationResource) {
-    source { ["tags"] = new Listing<String> { "release" "production-2" } }
+    source { ["tags"] = new Listing<String> { "release" "production-2" "production-2-fargate" "production" } }
   }
 }
 

--- a/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-to-staging.pkl
@@ -41,7 +41,7 @@ resources = new {
   }
   shared_resources_for_slack_notifications.slackNotificationResource
   (shared_resources_for_annotations.grafanaAnnotationResource) {
-    source { ["tags"] = new Listing<String> { "release" "staging-2" } }
+    source { ["tags"] = new Listing<String> { "release" "staging-2" "staging-2-fargate" "staging" } }
   }
 }
 

--- a/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-perf.pkl
@@ -41,7 +41,7 @@ resources = new {
   }
   shared_resources_for_slack_notifications.slackNotificationResource
   (shared_resources_for_annotations.grafanaAnnotationResource) {
-    source { ["tags"] = new Listing<String> { "release" "test-perf-1" } }
+    source { ["tags"] = new Listing<String> { "release" "test-perf-1" "test-perf-1-fargate" "test" } }
   }
 }
 

--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -100,7 +100,7 @@ resources = new {
 
   shared_resources_for_slack_notifications.slackNotificationResource
   (shared_resources_for_annotations.grafanaAnnotationResource) {
-    source { ["tags"] = new Listing<String> { "release" "test-12" } }
+    source { ["tags"] = new Listing<String> { "release" "test-12" "test-12-fargate" "test" } }
   }
 }
 


### PR DESCRIPTION
We need additional tags on the release annotations.

The ability to filter for annotations is _extremely_ limited, and you can't do any kind of transform, and values based on chained variables don't update. So we need to be able to filter on what is actually selectable in the dashboards. In some cases this is the cluster name (`<env>-fargate`), in some cases the account name.