### PR TITLE
PP-12686: Shared workflow for dependency reviews on PRs

### DIFF
--- a/.github/workflows/_run-dependency-review.yml
+++ b/.github/workflows/_run-dependency-review.yml
@@ -1,0 +1,33 @@
+name: Github Actions - Run Dependency Review
+
+on:
+  workflow_call:
+    inputs:
+      minimum_severity:
+        type: string
+        required: false
+        default: 'low'
+        description: Override default severity rating (options are 'low', 'moderate', 'high', 'critical')
+      warn_only:
+        type: boolean
+        required: false
+        default: false
+        description: Set to true to allow the action to complete with success status, regardless of findings
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
+        with:
+          show-progress: false
+
+      - name: Review changes to repository supply chain
+        uses: actions/dependency-review-action@4081bf99e2866ebe428fc0477b69eb4fcda7220a  # v4.4.0
+        with:
+          fail-on-severity: ${{ inputs.minimum_severity }}
+          warn-only: ${{ inputs.warn_only }}


### PR DESCRIPTION
Introduce [actions/dependency-review](https://github.com/actions/dependency-review-action) as a shared workflow, based on [GOV.UK's equivalent shared workflow](https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/dependency-review.yml).

This is intended to replace Snyk PR checks which detect if a vulnerable dependency is about to be introduced via a pull request. This is currently only available for our public repositories. 

GOV.UK's implementation includes post-merge checks on the default branch. I've intentionally left these out, as these are covered by existing Dependabot alerts and I want to closely replicate our existing workflow.

I've added in two inputs to allow overrides for:
- minimum severity level 
- whether to 'warn only' and not block merging 

I'll test this by raising a temporary PR on another repo, that will attempt to downgrade a previously-fixed vulnerability.