### PR TITLE
PP-12244: Update checkout and setup-node actions

### DIFF
--- a/.github/workflows/test-run-codebuild.yml
+++ b/.github/workflows/test-run-codebuild.yml
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Setup Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version: 18.18.0
       - name: Install dependencies

--- a/.github/workflows/test-semver.yml
+++ b/.github/workflows/test-semver.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: 'actions/next-semver/.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
This resolves the remaining Node16 deprecation warnings on shared workflows.

