### PR TITLE
Add Fly Cli to Node-Runner

### DIFF
--- a/ci/docker/node-runner/Dockerfile
+++ b/ci/docker/node-runner/Dockerfile
@@ -1,6 +1,14 @@
 FROM node:18.20.4-alpine3.20@sha256:a25c1e4ecc284985f4cbc449021e9259560c644dd9611e5a72d9c4750f24f6c7
 
+ARG FLY_CLI_SHA256SUM=90a05559d36f259903ca76988b51fbca8948f0c30a42e260d27dda659052db22
+
+RUN echo "$FLY_CLI_SHA256SUM  /tmp/fly" >> /tmp/fly.sha256 \
+  && wget -O /tmp/fly 'https://pay-cd.deploy.payments.service.gov.uk/api/v1/cli?arch=amd64&platform=linux' \
+  && sha256sum -c /tmp/fly.sha256 \
+  && mv /tmp/fly /usr/local/bin/ \
+  && chmod 555 /usr/local/bin/fly
 # As of node 15 the docker container fails to npm install without either a WORKDIR or -g
+
 WORKDIR /node-runner
 
 RUN npm install -g aws4@^1.x.x


### PR DESCRIPTION
The downgrade check runs on the node-runner image and now needs to use the fly cli to check if a downgrade release is the latest enabled release. This add fly using the same process as per the concourse-runner image.

### Testing
Built locally and it seems to work...
```
➤➤ node-runner $ docker build -t my_node_runner .
[+] Building 29.7s (15/15) FINISHED
.....

➤➤ node-runner $ docker run --rm my_node_runner which fly
/usr/local/bin/fly
```