### PR TITLE
BAU: Wait for DBs to be available before clearing DB

### DIFF
--- a/ci/pkl-pipelines/pay-dev/perf-tests.pkl
+++ b/ci/pkl-pipelines/pay-dev/perf-tests.pkl
@@ -942,6 +942,9 @@ local function runSelfServiceSimulationPerfTest(extended: Boolean): Job = new {
 local cleanup_perf_test_1_plan: Listing<Step> = new {
   (assumeRoleTask("test", "test-perf-1-perf-test-cleanup-runner", "perf-test-cleanup-runner")) {
     task = "assume-cleanup-runner-role"
+    params {
+      ["AWS_ROLE_DURATION"] = "10800"
+    }
     output_mapping {
       ["assume-role"] = "assume-cleanup-runner-role"
     }

--- a/ci/scripts/perf-test-cleanup/check-for-running-db.sh
+++ b/ci/scripts/perf-test-cleanup/check-for-running-db.sh
@@ -3,16 +3,38 @@
 
 set -euo pipefail
 
+TOTAL_WAIT_TIME_IN_MINUTES=$((MAX_ATTEMPTS * 15 / 60))
+
+RDS_INSTANCE_NAME="test-perf-1-connector-rds-0"
+
 DESCRIBE_DB_INSTANCE_OUTPUT=$(mktemp)
 
-aws rds describe-db-instances --db-instance-identifier test-perf-1-connector-rds-0 > "$DESCRIBE_DB_INSTANCE_OUTPUT"
+for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+  aws rds describe-db-instances --db-instance-identifier "$RDS_INSTANCE_NAME" > "$DESCRIBE_DB_INSTANCE_OUTPUT"
 
-DB_STATUS=$(jq -r '.DBInstances[0].DBInstanceStatus' < "$DESCRIBE_DB_INSTANCE_OUTPUT")
+  DB_STATUS=$(jq -r '.DBInstances[0].DBInstanceStatus' < "$DESCRIBE_DB_INSTANCE_OUTPUT")
 
-if [ "$DB_STATUS" != "available" ]; then
-  echo "Error: DB Instance test-perf-1-connector-rds-0 is not in 'available' state"
-  echo "Perhaps you need to scale up the databases?"
-  exit 1
-fi
+  if [ "$DB_STATUS" = "available" ]; then
+    echo "RDS instance $RDS_INSTANCE_NAME is available"
+    exit 0
+  elif [ "${DB_STATUS}" = "stopped" ]; then
+    echo "Error: DB instance $RDS_INSTANCE_NAME is 'stopped'"
+    echo "Perhaps you need to scale up the databases?"
+    exit 1
+  elif [ "${DB_STATUS}" = "backing-up" ] ||
+       [ "${DB_STATUS}" = "configuring-enhanced-monitoring" ] ||
+       [ "${DB_STATUS}" = "rebooting" ] ||
+       [ "${DB_STATUS}" = "starting" ]; then
+    echo "The RDS instance ${RDS_INSTANCE_NAME} is currently in state ${DB_STATUS}. We need to wait for that to complete."
+  else
+    echo "RDS instance ${RDS_INSTANCE_NAME} is not in a suitable state." \
+      "It's currently in ${DB_STATUS}, manual intervention will be required to resolve this."
+    exit 1
+  fi
 
-echo "Database is available"
+  echo "Waiting 15 seconds before checking again. Attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+  sleep 15
+done
+
+echo "RDS instance ${RDS_INSTANCE_NAME} did not reach the available state within ${TOTAL_WAIT_TIME_IN_MINUTES} minutes"
+exit 1

--- a/ci/tasks/perf-test-cleanup/check-for-running-db.yml
+++ b/ci/tasks/perf-test-cleanup/check-for-running-db.yml
@@ -9,6 +9,7 @@ params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
   AWS_SESSION_TOKEN:
+  MAX_ATTEMPTS: 480 # 2 Hours to account for DBs backing up, configuring enhanced monitoring, etc
 run:
   path: "/bin/ash"
   args: ['pay-ci/ci/scripts/perf-test-cleanup/check-for-running-db.sh']


### PR DESCRIPTION
Regularly the daily performance tests fail to start, the DB starts, and is available, and then before the DB cleanup task runs (which checks for connector DB being available) the DB goes into another state (e.g. backing-up).

So lets wait for that to complete, we don't want random reboots etc during the performance test or our baseline will be invalid.

I've also extended the duration of the session for the role doing this work since they may have to wait an extended period for the RDS instance to get to a settled state.

I applied this (amended to point pay-ci to this PR branch) and [ran the scale-and-run-all-simulations build](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-and-run-all-simulations/builds/912)

I discovered I also needed https://github.com/alphagov/pay-infra/pull/5022 so I've applied that, and [reran the failed build mentioned above](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/perf-tests/jobs/scale-and-run-all-simulations/builds/913)