### PR TITLE
BAU - Check for bank holidays for support notifications

### DIFF
--- a/ci/scripts/support-rota-notification/index.js
+++ b/ci/scripts/support-rota-notification/index.js
@@ -32,7 +32,7 @@ async function updateSupportTopics () {
 
 function isABankHoliday (now) {
   //todo: use https://www.gov.uk/bank-holidays.json to get bank holiday dates
-  const bankHolidays = ['25-12-2024', '26-12-2024', '1-Jan-2025', '18-04-2025', '05-05-2025', '26-05-2025',
+  const bankHolidays = ['25-12-2024', '26-12-2024', '01-01-2025', '18-04-2025', '05-05-2025', '26-05-2025',
     '25-08-2025', '25-12-2025', '26-12-2025']
 
   return bankHolidays.includes(now.format('DD-MM-YYYY'))


### PR DESCRIPTION
## WHAT
- Skips updating in-hours topics/sending notifications during bank holidays
- Notifies all on-call engineers (Saturday & Sunday) to triage alerts