### PR TITLE
BAU: Don't validate images that are layers in the same Dockerfile

### DIFF
--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -38,7 +38,13 @@ jobs:
           DOCKERFILE=${{ inputs.dockerfile }}
 
           while read -r BASE_CONTAINER_DEFINITION; do
-            echo "Checking base container definition: $BASE_CONTAINER_DEFINITION"
+            # Only check images which refer to a remotre repository, not another layer in the same manifest
+            if [[ "$BASE_CONTAINER_DEFINITION" =~ ^[A-Za-z0-9_-]+(:[A-Za-z0-9_.-]+)?@.* ]]; then
+              echo "Checking base container definition: $BASE_CONTAINER_DEFINITION"
+            else
+              echo "FROM $BASE_CONTAINER_DEFINITION is not a reference to an image in a remote registry, not checking"
+              continue
+            fi
 
             # Image definitions are going to be of one of the forms:
             #

--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -38,7 +38,7 @@ jobs:
           DOCKERFILE=${{ inputs.dockerfile }}
 
           while read -r BASE_CONTAINER_DEFINITION; do
-            # Only check images which refer to a remotre repository, not another layer in the same manifest
+            # Only check images which refer to a remote repository, not another layer in the same manifest
             if [[ "$BASE_CONTAINER_DEFINITION" =~ ^[A-Za-z0-9_-]+(:[A-Za-z0-9_.-]+)?@.* ]]; then
               echo "Checking base container definition: $BASE_CONTAINER_DEFINITION"
             else


### PR DESCRIPTION
Only check images that are remote images, not that are references to other layers in the same manifest