### PR TITLE
Add Pay-CI To Create Network Review Task

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
+++ b/ci/pkl-pipelines/pay-deploy/internal-vulnerability-scan.pkl
@@ -90,7 +90,12 @@ jobs = new {
   new {
     name = "create-network-review-jira-story"
     plan {
-      shared_resources_for_times.getTwiceYearlyCronTrigger
+      new InParallelStep {
+        in_parallel = new Listing<Step> {
+          new GetStep { get = "pay-ci" }
+          shared_resources_for_times.getTwiceYearlyCronTrigger
+        }
+      }
       createNetworkReviewJiraStory()
     }
 


### PR DESCRIPTION
Required to run the shell script it contains.

To fix this: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/internal-vulnerability-scan/jobs/create-network-review-jira-story/builds/1