### PR TITLE
Remove Erroneous Input to Create Network Task

### DIFF
--- a/ci/tasks/create-network-review-jira-issue.yml
+++ b/ci/tasks/create-network-review-jira-issue.yml
@@ -5,7 +5,6 @@ image_resource:
   source:
     repository: governmentdigitalservice/pay-concourse-runner
 inputs:
-  - name: reports
   - name: pay-ci
 outputs:
   - name: jira-story


### PR DESCRIPTION
The 'reports' input was a copy and paste error from a similar task.

To fix: https://pay-cd.deploy.payments.service.gov.uk/teams/pay-deploy/pipelines/internal-vulnerability-scan/jobs/create-network-review-jira-story/builds/2