### PR TITLE
PP-13652 Update shared workflows to run on ubuntu-latest

### DIFF
--- a/.github/workflows/_create-alpha-release-tag.yml
+++ b/.github/workflows/_create-alpha-release-tag.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   tag-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write

--- a/.github/workflows/_run-app-as-provider-contract-tests.yml
+++ b/.github/workflows/_run-app-as-provider-contract-tests.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   provider-contract-tests:
     name: Contract tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b

--- a/.github/workflows/test-run-codebuild.yml
+++ b/.github/workflows/test-run-codebuild.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test-script-run-codebuild:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Test script run-codebuild
     env:
       working-directory: ci/scripts/run-codebuild


### PR DESCRIPTION
## WHAT
- Updates a few shared workflows to run on `ubuntu-latest` as Ubuntu 20.04 will be unsupported soon.
- The rest of the workflows use ubuntu-latest