### PR TITLE
PP-13604 Upgrade docker-dind base image for concourse-runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
     time: "03:00"
   ignore:
     - dependency-name: "docker"
-      update-types: ["version-update:semver-major"]
   open-pull-requests-limit: 10
   labels:
     - dependencies

--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:24.0.9-dind
+FROM docker:28.0.0-dind-alpine3.21
 
 ARG FLY_CLI_SHA256SUM=c126f1be24086aea0fa06fecbd4e50956b68aca2b1b920b6fc8e3d0cdbcfa2a2
 ARG PKL_VERSION=0.25.2


### PR DESCRIPTION
The docker-in-docker image for `concourse-runner` was pinned to avoid major version updates in January 2024, as v25 introduced incompatibilities with our pact tests (that run using this image). As such we have fallen behind with patches, including the recent [OpenSSL CVE](https://openssl-library.org/news/secadv/20250211.txt).

Since January 2024 we have upgraded our apps to Java 21 and Pact v4, which we believe will address the issue with the pact tests. We also introduced a PR check for this image in February 2024, that runs the pact tests against Adminusers on Concourse using the built `concourse-runner` image, so it should give a good indication of whether this hypothesis is true [EDIT: the tests pass 🎉 ].