### PR TITLE
Revert "PP-13604 Upgrade docker-dind base image for concourse-runner"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     time: "03:00"
   ignore:
     - dependency-name: "docker"
+      update-types: ["version-update:semver-major"]
   open-pull-requests-limit: 10
   labels:
     - dependencies

--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:28.0.0-dind-alpine3.21
+FROM docker:24.0.9-dind
 
 ARG FLY_CLI_SHA256SUM=c126f1be24086aea0fa06fecbd4e50956b68aca2b1b920b6fc8e3d0cdbcfa2a2
 ARG PKL_VERSION=0.25.2


### PR DESCRIPTION
Reverts alphagov/pay-ci#1361

Unfortunately it looks like this still a breaking change.

While the e2e tests pass, it looks like images built with this version of concourse-runner are missing a layer and cannot be pushed to ECR. [See an example here](https://pay-cd.deploy.payments.service.gov.uk/teams/pay-dev/pipelines/pr-ci/jobs/ledger-e2e/builds/2467).