### PR TITLE
PP-13784 Increase logging e2e test wait time

### DIFF
--- a/ci/scripts/test-logging-pipeline/index.js
+++ b/ci/scripts/test-logging-pipeline/index.js
@@ -38,7 +38,7 @@ function checkAlarms (alarms) {
 }
 
 async function waitBeforeQueryingCloudWatchAlarms () {
-  const waitTimeInSeconds = 120
+  const waitTimeInSeconds = 180
   const checkIntervalInSeconds = 5
   let noOfSecondsElapsed = 0
 


### PR DESCRIPTION
## WHAT
- Increases wait time to 3 mins to account for any buffering/async delays before querying CloudWatch alarms