### PR TITLE
Revert "PP-13989: Add ZAP tests to selfservice end to end tests"

### DIFF
--- a/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
+++ b/ci/pkl-pipelines/pay-dev/deploy-to-test.pkl
@@ -348,7 +348,7 @@ local function getRunE2ETestsJob(app): Job = new {
           when (!(app.name == "products-ui" || app.name == "products")) {
             getCodeBuildTaskToRunEndToEndTests("card", true)
           }
-          when (app.name == "cardid" || app.name == "frontend" || app.name == "publicauth" || app.name == "publicapi" || app.name == "selfservice") {
+          when (app.name == "cardid" || app.name == "frontend" || app.name == "publicauth" || app.name == "publicapi") {
             getCodeBuildTaskToRunEndToEndTests("zap", false)
           }
         }


### PR DESCRIPTION
Reverts alphagov/pay-ci#1381

We have decided instead to remove the zap tests for selfservice from the end to end tests