### PR TITLE
PP-13959: Remove pool-resource build

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/concourse-resources.pkl
+++ b/ci/pkl-pipelines/pay-deploy/concourse-resources.pkl
@@ -11,7 +11,6 @@ local class ConcourseResource {
 }
 
 local concourse_resources = new Listing<ConcourseResource> {
-  new { name = "pool-resource" git_branch = "master" }
   new { name = "cron-resource" git_branch = "main" }
 }
 


### PR DESCRIPTION
Now our fork of pool-resource is archived we no longer need the build pipeline