### PR TITLE
PP-13789 Added deploy-pay-cd env to logging pipeline

### DIFF
--- a/ci/pkl-pipelines/pay-deploy/deploy-logging-pipeline.pkl
+++ b/ci/pkl-pipelines/pay-deploy/deploy-logging-pipeline.pkl
@@ -12,5 +12,9 @@ loggingEnvironments = new Listing<LoggingEnv> {
     account = "deploy" environment = "deploy-tooling"
     tf_root = "pay-infra/provisioning/terraform/deployments/deploy/deploy-tooling/management/logging_pipeline"
   }
+  new LoggingEnv {
+    account = "deploy" environment = "deploy-pay-cd"
+    tf_root = "pay-infra/provisioning/terraform/deployments/deploy/deploy-pay-cd/management/logging_pipeline"
+  }
 
 }


### PR DESCRIPTION
## WHAT
- Added `deploy-pay-cd` (which ships Concourse & Prometheus logs) environment to the deploy logging pipeline