### PR TITLE
PP-14175: Use dedicated endtoend-zap Docker image for ZAP tests

### DIFF
--- a/ci/tasks/endtoend/zap/docker-compose.yml
+++ b/ci/tasks/endtoend/zap/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       driver: "json-file"
 
   endtoend:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_endtoend:-govukpay/endtoend}:${tag_endtoend:-latest-master}
+    image: ${DOCKER_REGISTRY_URI:-}govukpay/endtoend-zap:latest
     env_file: ../docker-config/endtoend.env
     environment:
       - MAVEN_OPTS=${END_TO_END_JAVA_OPTS}


### PR DESCRIPTION
See description in https://github.com/alphagov/pay-infra/pull/5196 for background details.

This PR switches the ZAP suite of the end to end tests to use the duplicated Docker image now held in the new `govukpay/endtoend-zap` ECR repository. I've hardcoded the repository name and image tag for now.

In theory this should be a no-op as the image itself has not changed.