### PR TITLE
PP-14175: Fix products e2e tests when running locally

### DIFF
--- a/ci/tasks/endtoend/run-endtoend-tests-locally.sh
+++ b/ci/tasks/endtoend/run-endtoend-tests-locally.sh
@@ -58,7 +58,7 @@ fi
 echo "|========================================================================="
 echo "| Running docker compose up"
 echo "|========================================================================="
-docker-compose -f "${END_TO_END_TEST_SUITE}/docker-compose.yml" up -d --quiet-pull --no-recreate
+docker compose -f "${END_TO_END_TEST_SUITE}/docker-compose.yml" up -d --quiet-pull --no-recreate
 
 echo "|========================================================================="
 echo "| Sleeping for 10 seconds to allow everything to come to life"
@@ -71,7 +71,7 @@ echo
 echo "|========================================================================="
 echo "| Displaying running docker containers"
 echo "|========================================================================="
-docker-compose -f "${END_TO_END_TEST_SUITE}/docker-compose.yml" ps
+docker compose -f "${END_TO_END_TEST_SUITE}/docker-compose.yml" ps
 
 echo "|========================================================================="
 echo "| Getting endtoend container id"


### PR DESCRIPTION
The docker compose environment for the Products e2e test suite would not start up, as it was trying to fetch very old `govukpay/products` and `govukpay/products-ui` images from Docker Hub (instead of using the up to date `govermentdigitalservice/...` Docker Hub organisation).

Also updates the deprecated `docker-compose` command to `docker compose`.