### PR TITLE
PP_13898 Add Github workflow for Cypress branding tests

### DIFF
--- a/.github/workflows/_run-node-cypress-tests-rebrand.yml
+++ b/.github/workflows/_run-node-cypress-tests-rebrand.yml
@@ -1,0 +1,102 @@
+name: Github Actions for NodeJS apps - run cypress tests with rebranding
+
+on:
+  workflow_call:
+    inputs:
+      LIBGL_ALWAYS_SOFTWARE:
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cypress-tests-rebrand:
+    runs-on: ubuntu-latest
+    name: Cypress tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Setup
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache build directories
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+            dist
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Parse Cypress version
+        id: parse-cypress-version
+        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
+      - name: Cache Cypress
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ steps.parse-cypress-version.outputs.CYPRESS_VERSION }}
+      - name: Run cypress tests
+        env:
+          LIBGL_ALWAYS_SOFTWARE: ${{ inputs.LIBGL_ALWAYS_SOFTWARE }}
+        run: |
+          name: Github Actions for NodeJS apps - run cypress tests
+
+on:
+  workflow_call:
+    inputs:
+      LIBGL_ALWAYS_SOFTWARE:
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cypress-tests:
+    runs-on: ubuntu-latest
+    name: Cypress tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Setup
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache build directories
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+            dist
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Parse Cypress version
+        id: parse-cypress-version
+        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
+      - name: Cache Cypress
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ steps.parse-cypress-version.outputs.CYPRESS_VERSION }}
+      - name: Run cypress tests
+        env:
+          LIBGL_ALWAYS_SOFTWARE: ${{ inputs.LIBGL_ALWAYS_SOFTWARE }}
+        run: |
+          npm run cypress:server > /dev/null 2>&1 &
+          SERVER_PID_1=$!
+          PGID_1=$(ps -o pgid= $SERVER_PID_1 | grep -o '[0-9]*')
+          sleep 3
+          npm run cypress:test
+          kill -TERM -$PGID_1
+          npm run cypress:server-rebrand > /dev/null 2>&1 &
+          SERVER_PID_2=$!
+          PGID_2=$(ps -o pgid= $SERVER_PID_2 | grep -o '[0-9]*')
+          sleep 3
+          npm run cypress:test-rebrand
+          kill -TERM -$PGID_2


### PR DESCRIPTION
- This is a temporary Github action workflow that will do the following:
  - Run the existing Cypress tests.
  - Kill the Cypress server and all sub processes.
  - Restart the Cypress server with the ENABLE_REBRAND=true
  - Run the rebranding tests
- Once the branding is live, will will update the existing Cypress tests and go back to the original Github action workflow.
  - This will then be deleted.