### PR TITLE
PP-13898 Add new GHA workflow - run Cypress branding tests

### DIFF
--- a/.github/workflows/_run-node-cypress-tests-rebrand.yml
+++ b/.github/workflows/_run-node-cypress-tests-rebrand.yml
@@ -1,0 +1,48 @@
+name: Github Actions for NodeJS apps - run cypress rebanding tests only
+
+on:
+  workflow_call:
+    inputs:
+      LIBGL_ALWAYS_SOFTWARE:
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cypress-tests-reband:
+    runs-on: ubuntu-latest
+    name: Cypress tests for rebranding
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - name: Setup
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version-file: ".nvmrc"
+      - name: Cache build directories
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+            dist
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Parse Cypress version
+        id: parse-cypress-version
+        run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
+      - name: Cache Cypress
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ steps.parse-cypress-version.outputs.CYPRESS_VERSION }}
+      - name: Run cypress tests
+        env:
+          LIBGL_ALWAYS_SOFTWARE: ${{ inputs.LIBGL_ALWAYS_SOFTWARE }}
+        run: |
+          npm run cypress:server-rebrand > /dev/null 2>&1 &
+          sleep 3
+          npm run cypress:test-rebrand


### PR DESCRIPTION
- New workflow to only run the Cypress tests for the new branding.
- This workflow is run once the main Cypress test suite workflow is done.
- We need a separate workflow for the rebranding tests because they need the Cypress server to run with ENABLE_FLAG=true
- This will be used temporarily until the new branding is live.
- Once it is live, the main Cypress tests will be updated and then this workflow can be removed.
- This is a clone of the existing Cypress tests workflow but runs the following commands instead:
  - npm run cypress:server-rebrand
  - npm run cypress:test-rebrand -