### PR TITLE
PP-14175: Use candidate image and tag for endtoend-zap builds

### DIFF
--- a/ci/tasks/endtoend/zap/docker-compose.yml
+++ b/ci/tasks/endtoend/zap/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       driver: "json-file"
 
   endtoend:
-    image: ${DOCKER_REGISTRY_URI:-}govukpay/endtoend-zap:latest
+    image: ${DOCKER_REGISTRY_URI:-}${repo_endtoendzap:-govukpay/endtoend-zap}:${tag_endtoendzap:-latest}
     env_file: ../docker-config/endtoend.env
     environment:
       - MAVEN_OPTS=${END_TO_END_JAVA_OPTS}


### PR DESCRIPTION
This was temporarily hardcoded while the ZAP tests were split into their own build pipeline.

The defaults given below map to that same hardcoded value (`govukpay/endtoend-zap:latest`) which points to an existing image currently available in ECR. However now we can override them with values from Concourse.

See this thread for more details: https://github.com/alphagov/pay-endtoend-zap/pull/2