### PR TITLE
PP-12801 Upgrade pact broker docker image to latest version

### DIFF
--- a/.github/workflows/check-pact-broker-base-image-is-manifest.yml
+++ b/.github/workflows/check-pact-broker-base-image-is-manifest.yml
@@ -1,0 +1,13 @@
+name: Check Pact broker image
+
+on:
+  pull_request:
+    paths:
+      - 'ci/docker/pact-broker'
+
+permissions:
+  contents: read
+
+jobs:
+  check-docker-base-images-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master

--- a/ci/docker/pact-broker/Dockerfile
+++ b/ci/docker/pact-broker/Dockerfile
@@ -1,1 +1,1 @@
-FROM pactfoundation/pact-broker:2.120.0-pactbroker2.110.0@sha256:f575b5bd738abde06d60d91a24e89d84154bd97b68513a4540bf367d6621a617
+FROM pactfoundation/pact-broker:2.132.0-pactbroker2.116.0@sha256:f57be41844b94b8f5cbf5f76e55c654a1202c71df5daeb0d48edd2e0c797a20d


### PR DESCRIPTION
## WHAT
- Upgrades the pact broker source Docker image to the latest version.

  No breaking changes between the current version (2.110.0) and the latest (2.116.0) - see https://github.com/pact-foundation/pact_broker/releases

- Uses manifest sha instead of the image sha for AMD architecture to support building multi-arch docker images