### PR TITLE
PP-12801 Update Validate docker image is manifest action for pactbroker

### DIFF
--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -39,7 +39,7 @@ jobs:
 
           while read -r BASE_CONTAINER_DEFINITION; do
             # Only check images which refer to a remote repository, not another layer in the same manifest
-            if [[ "$BASE_CONTAINER_DEFINITION" =~ ^[A-Za-z0-9_-]+(:[A-Za-z0-9_.-]+)?@.* ]]; then
+            if [[ "$BASE_CONTAINER_DEFINITION" =~ ^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*(:[A-Za-z0-9._-]+)?(@sha256:[A-Fa-f0-9]+)?$ ]]; then
               echo "Checking base container definition: $BASE_CONTAINER_DEFINITION"
             else
               echo "FROM $BASE_CONTAINER_DEFINITION is not a reference to an image in a remote registry, not checking"
@@ -110,7 +110,7 @@ jobs:
             docker buildx imagetools inspect "$BASE_CONTAINER_DEFINITION" --raw > "$TMPFILE" 2>&1
 
             MEDIATYPE=$(jq --raw-output .mediaType < "$TMPFILE")
-            if [[ "$MEDIATYPE" != "application/vnd.docker.distribution.manifest.list.v2+json" ]] && [[ "$MEDIATYPE" != "application/vnd.oci.image.index.v1+json" ]]; then
+            if !([[ "$MEDIATYPE" == "application/vnd.docker.distribution.manifest.list.v2+json" ]] || [[ "$MEDIATYPE" == "application/vnd.oci.image.index.v1+json" ]]); then
               echo
               echo "ERROR! The image specified by '$BASE_CONTAINER_DEFINITION' does not refer to a manifest"
               bad_manifest_error

--- a/.github/workflows/check-pact-broker-base-image-is-manifest.yml
+++ b/.github/workflows/check-pact-broker-base-image-is-manifest.yml
@@ -11,3 +11,5 @@ permissions:
 jobs:
   check-docker-base-images-are-manifests:
     uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+    with:
+      dockerfile: ./ci/docker/pact-broker/Dockerfile


### PR DESCRIPTION
## WHAT
- Changes to support manifest validation for pact-broker image reference, which follows a different pattern from references in other apps


**Working action**
https://github.com/alphagov/pay-ci/actions/runs/16495643066/job/46640590907?pr=1428

**Action that failed for an invalid Docker manifest**

https://github.com/alphagov/pay-ci/actions/runs/16495704508/job/46640789217?pr=1428