### PR TITLE
PP-12801 Update Validate docker image is manifest action for pactbroker

### DIFF
--- a/.github/workflows/_validate_docker_image_is_manifest.yml
+++ b/.github/workflows/_validate_docker_image_is_manifest.yml
@@ -39,7 +39,7 @@ jobs:
 
           while read -r BASE_CONTAINER_DEFINITION; do
             # Only check images which refer to a remote repository, not another layer in the same manifest
-            if [[ "$BASE_CONTAINER_DEFINITION" =~ ^[A-Za-z0-9_-]+(:[A-Za-z0-9_.-]+)?@.* ]]; then
+            if [[ "$BASE_CONTAINER_DEFINITION" =~ ^[A-Za-z0-9./_-]+(:[A-Za-z0-9_.-]+)?@.*$ ]]; then
               echo "Checking base container definition: $BASE_CONTAINER_DEFINITION"
             else
               echo "FROM $BASE_CONTAINER_DEFINITION is not a reference to an image in a remote registry, not checking"

--- a/.github/workflows/check-pact-broker-base-image-is-manifest.yml
+++ b/.github/workflows/check-pact-broker-base-image-is-manifest.yml
@@ -11,3 +11,5 @@ permissions:
 jobs:
   check-docker-base-images-are-manifests:
     uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+    with:
+      dockerfile: ./ci/docker/pact-broker/Dockerfile


### PR DESCRIPTION
## WHAT
- Changes to support manifest validation for pact-broker image reference, which follows a different pattern from references in other apps

Tested in https://github.com/alphagov/pay-ci/pull/1434 and worked for Java, NodeJS and pact-broker image references. 

Related job https://github.com/alphagov/pay-ci/actions/runs/16563448821/job/46837744284?pr=1434