### PR TITLE
PP-15163 Add contents:read permission to CodeQL workflow

### DIFF
--- a/.github/workflows/_run-codeql-scan.yml
+++ b/.github/workflows/_run-codeql-scan.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   # required for CodeQL to raise security issues on the repo
   security-events: write
+  contents: read
 
 jobs:
   run-codeql-scan:


### PR DESCRIPTION
## WHAT
- Adds `content:read` permissions to the workflow, so the CodeQL job can run in private repositories