### PR TITLE
PP-15163 Install Cypress

### DIFF
--- a/.github/workflows/_run-node-cypress-tests.yml
+++ b/.github/workflows/_run-node-cypress-tests.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Parse Cypress version
         id: parse-cypress-version
         run: echo "CYPRESS_VERSION=$(jq -r '.devDependencies.cypress' package.json)" >> $GITHUB_OUTPUT
+      - name: Install Cypress binary
+        id: install-cypress-binary
+        run: npx cypress install
       - name: Cache Cypress
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:


### PR DESCRIPTION
## WHAT

- The Cypress Life Cycle script postinstall installs the Cypress binary after the Cypress npm module has been installed. Since we have disabled post-install scripts, we need to add the binary explicitly

- Install the Cypress binary explicitly before caching, so that for any new version upgrades, the Cypress binary is installed. https://github.com/alphagov/pay-products-ui/pull/2842 was failing without this step
