### PR TITLE
PP-15194 Use endtoend tag in zap docker-compose

### DIFF
--- a/ci/tasks/endtoend/zap/docker-compose.yml
+++ b/ci/tasks/endtoend/zap/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       driver: "json-file"
 
   endtoend:
-    image: ${DOCKER_REGISTRY_URI:-}${repo_endtoendzap:-govukpay/endtoend-zap}:${tag_endtoendzap:-latest}
+    image: ${DOCKER_REGISTRY_URI:-}${repo_endtoendzap:-govukpay/endtoend-zap}:${tag_endtoend:-latest}
     env_file: ../docker-config/endtoend.env
     environment:
       - MAVEN_OPTS=${END_TO_END_JAVA_OPTS}


### PR DESCRIPTION
## WHAT
- There is no `tag_endtoendzap` tag being set by end-to-end test pipelines, and also the CodeBuild project doesn't define an equivalent env variable https://github.com/alphagov/pay-infra/blob/9215ab5ae62364ae443d2400d2ede6ff2d1b6b03/provisioning/terraform/modules/pay_codebuild/endtoend_tests/buildspec.yml#L5