### PR TITLE
PP-15341 disable actions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
     - dependencies
     - govuk-pay


### PR DESCRIPTION
Disable dependabot updates of github actions. All current updates are node24 compatible.