### PR TITLE
PP-15341 update codeql-action to 4.35.4

### DIFF
--- a/.github/workflows/_run-codeql-scan.yml
+++ b/.github/workflows/_run-codeql-scan.yml
@@ -44,7 +44,7 @@ jobs:
       # JAVA REPOS ########
       - name: Initialize CodeQL (Java)
         if: ${{ inputs.is_java_repo }}
-        uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e
         with:
           # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
           languages: 'java-kotlin'
@@ -65,14 +65,14 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: ${{ inputs.is_java_repo }}
-        uses: github/codeql-action/analyze@379614612a29c9e28f31f39a59013eb8012a51f0
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e
         with:
           category: "/language:java-kotlin"
 
       # NODE REPOS ########
       - name: Initialize CodeQL (Node)
         if: ${{ inputs.is_node_repo }}
-        uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e
         with:
           # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
           languages: 'javascript-typescript'
@@ -83,7 +83,7 @@ jobs:
 
       - name: Initialize CodeQL (Typescript)
         if: ${{ inputs.is_typescript_repo }}
-        uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e
         with:
           # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
           languages: 'javascript-typescript'
@@ -107,6 +107,6 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: ${{ inputs.is_node_repo || inputs.is_typescript_repo  }}
-        uses: github/codeql-action/analyze@379614612a29c9e28f31f39a59013eb8012a51f0
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
Github retiring node20. Version 4.35.4 of codeql-action is compatible with node24.