### PR TITLE
PP-15165 Remove GitHub token to run pact tests

### DIFF
--- a/.github/workflows/_run-provider-pact-tests-for-consumer.yml
+++ b/.github/workflows/_run-provider-pact-tests-for-consumer.yml
@@ -20,8 +20,6 @@ on:
         required: true
       pact_broker_password:
         required: true
-      repos_readonly_token:
-        required: true
 
 permissions:
   contents: read
@@ -35,7 +33,6 @@ jobs:
         with:
           repository: alphagov/pay-${{ inputs.provider }}
           path: pay-${{ inputs.provider }}
-          token: '${{ secrets.repos_readonly_token }}'
       - name: Get Provider SHA
         id: get-provider-sha
         run: |


### PR DESCRIPTION
##WHAT

- Connector repo is public, and the repo token is not required anymore to run Pact tests.
- Reverts alphagov/pay-ci#1504