### PR TITLE
PP-15341 add AWS_REGION to bastion runner

### DIFF
--- a/ci/tasks/run-bastion-e2e.yml
+++ b/ci/tasks/run-bastion-e2e.yml
@@ -13,6 +13,7 @@ inputs:
 params:
   ECR_REPO:
   IMAGE_TAG:
+  AWS_REGION: "eu-west-1"
   AWS_DEFAULT_REGION: "eu-west-1"
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:


### PR DESCRIPTION
When Pay CLI migrated to being node.js based, it used v3 of the AWS SDK which expects AWS_REGION to be set. The old ruby CLI fell back to using AWS_DEFAULT_REGION, which v3 of the AWS SDK doesn’t do.

To fix this particular error it should just be a matter of adding AWS_REGION: “eu-west-1”