### PR TITLE
PP-15179 Add parameter to PayGitHubResource to override organisation

### DIFF
--- a/ci/pkl-pipelines/common/PayResources.pkl
+++ b/ci/pkl-pipelines/common/PayResources.pkl
@@ -2,9 +2,10 @@ import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pk
 import "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Resources.pkl"
 
 open class PayGitHubResource extends Resources.GitResource {
+  hidden orgName: String = "alphagov"
   hidden repoName: String
   source = new {
-    uri = "https://github.com/alphagov/\(repoName)"
+    uri = "https://github.com/\(orgName)/\(repoName)"
     username = "alphagov-pay-ci-concourse"
     password = "((github-access-token))"
   }


### PR DESCRIPTION
Add a parameter to the PayGitHubResource pkl resource to allow for reuse with the new `govuk-pay` GitHub org.