### PR TITLE
[PP-15492] Simplify pact broker docker image so dependabot can update it

### DIFF
--- a/ci/docker/pact-broker/Dockerfile
+++ b/ci/docker/pact-broker/Dockerfile
@@ -1,1 +1,1 @@
-FROM pactfoundation/pact-broker:2.133.0-pactbroker2.116.0@sha256:e83108a9636b04742d790acb58fb1aece328b6419e96b45b0cd154b1509702bc
+FROM pactfoundation/pact-broker:2@sha256:e83108a9636b04742d790acb58fb1aece328b6419e96b45b0cd154b1509702bc


### PR DESCRIPTION
Simplified the tag for the pact broker docker image to allow dependabot to update it as it hasn't been able to for approx. 11 months