### PR TITLE
[PP-15520] updated node-runner's octokit/rest to version 22

### DIFF
--- a/ci/docker/node-runner/Dockerfile.node22
+++ b/ci/docker/node-runner/Dockerfile.node22
@@ -12,7 +12,7 @@ RUN echo "$FLY_CLI_SHA256SUM  /tmp/fly" >> /tmp/fly.sha256 \
 WORKDIR /node-runner
 
 RUN npm install -g aws4@^1.x.x
-RUN npm install -g @octokit/rest@^18.x.x
+RUN npm install -g @octokit/rest@^22.x.x
 RUN npm install -g @aws-sdk/client-sts@^3.x.x
 RUN npm install -g @aws-sdk/client-ecs@^3.x.x
 RUN npm install -g @aws-sdk/client-synthetics@^3.x.x


### PR DESCRIPTION
Updating the version of octokit/rest to version 22 to hopefully fix the breaking failures found when updating the node-runner image from 22.22.x to 22.23.x