### PR TITLE
[PP-15547] Add inputs for the branch and terraform folder

### DIFF
--- a/.github/workflows/_run-terraform-tests.yml
+++ b/.github/workflows/_run-terraform-tests.yml
@@ -2,6 +2,17 @@ name: Terraform Tests
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        description: The remote branch to compare against to check for changed files. Defaults to main
+        default: main
+        required: false
+        type: string
+      terraform_folder:
+        description: The folder to check for terraform files. Defaults to the root of the repository
+        default: ""
+        required: false
+        type: string
   
 jobs:
   terraform-fmt:
@@ -51,7 +62,13 @@ jobs:
 
           trap help_with_failure ERR
 
-          git diff --name-only origin/master provisioning/**/*.tf | while read -r TF_FILE_PATH; do
+          TERRAFORM_PATH=""
+
+          if [ "${{inputs.terraform_folder}}" != "" ]; then
+            TERRAFORM_PATH = "${{inputs.terraform_folder}}/"
+          fi
+
+          git diff --name-only origin/${{inputs.branch}} "$TERRAFORM_PATH"**/*.tf | while read -r TF_FILE_PATH; do
             if [ ! -f "$TF_FILE_PATH" ]; then
               echo "$TF_FILE_PATH was deleted, not checking"
               continue


### PR DESCRIPTION
The three branches that will be using this workflow (`pay-infra`, `pay-concourse`, and `pay-concourse-deployment`) have differing main branches and terraform folders. So this will allow the correct main branch and terraform folder to be provided to this reusable workflow.

This is to resolve the review comments left on [this](https://github.com/alphagov/pay-ci/pull/1573) PR after it was merged.