### PR TITLE
[PP-15547] Fix incorrect whitespace in environment variable assignment

### DIFF
--- a/.github/workflows/_run-terraform-tests.yml
+++ b/.github/workflows/_run-terraform-tests.yml
@@ -65,7 +65,7 @@ jobs:
           TERRAFORM_PATH=""
 
           if [ "${{inputs.terraform_folder}}" != "" ]; then
-            TERRAFORM_PATH = "${{inputs.terraform_folder}}/"
+            TERRAFORM_PATH="${{inputs.terraform_folder}}/"
           fi
 
           git diff --name-only origin/${{inputs.branch}} "$TERRAFORM_PATH"**/*.tf | while read -r TF_FILE_PATH; do


### PR DESCRIPTION
Fixes an issue introduced in [https://github.com/alphagov/pay-ci/pull/1574](https://github.com/alphagov/pay-ci/pull/1574) where an environment variable assignment had whitespace inside of it when it shouldn't have