### PR TITLE
[PP-15547] Fix bug where files in the immediate folder weren't being checked

### DIFF
--- a/.github/workflows/_run-terraform-tests.yml
+++ b/.github/workflows/_run-terraform-tests.yml
@@ -68,7 +68,7 @@ jobs:
             TERRAFORM_PATH="${{inputs.terraform_folder}}/"
           fi
 
-          git diff --name-only origin/${{inputs.branch}} "$TERRAFORM_PATH"**/*.tf | while read -r TF_FILE_PATH; do
+          git diff --name-only origin/${{inputs.branch}} "$TERRAFORM_PATH"{**,.}/*.tf | while read -r TF_FILE_PATH; do
             if [ ! -f "$TF_FILE_PATH" ]; then
               echo "$TF_FILE_PATH was deleted, not checking"
               continue


### PR DESCRIPTION
The **/ glob in bash only selects directories in that folder, and ignores any files. This fix adds the terraform path folder as a path option