### PR TITLE
[PP-15547] Refactored bugfix to use git's automatic glob expansion

### DIFF
--- a/.github/workflows/_run-terraform-tests.yml
+++ b/.github/workflows/_run-terraform-tests.yml
@@ -68,7 +68,7 @@ jobs:
             TERRAFORM_PATH="${{inputs.terraform_folder}}/"
           fi
 
-          git diff --name-only origin/${{inputs.branch}} "$TERRAFORM_PATH"{**,.}/*.tf | while read -r TF_FILE_PATH; do
+          git diff --name-only origin/${{inputs.branch}} "$TERRAFORM_PATH*.tf" | while read -r TF_FILE_PATH; do
             if [ ! -f "$TF_FILE_PATH" ]; then
               echo "$TF_FILE_PATH was deleted, not checking"
               continue


### PR DESCRIPTION
The previous fix used a bash list to also check the top level terraform path folder for terraform files. @benjamb requested a change to use git's built-in glob expansion which does recursively check folders, as it would simplify the path and make the behaviour more predictable