### PR TITLE
[PP-15555] Move generate csvs dependancy to concourse runner

### DIFF
--- a/ci/docker/concourse-runner/Dockerfile
+++ b/ci/docker/concourse-runner/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache \
   gcompat \
   git \
   python3 \
+  py3-yaml \
   ca-certificates \
   jq \
   openjdk25 \

--- a/ci/scripts/generate-github-acl-csvs.sh
+++ b/ci/scripts/generate-github-acl-csvs.sh
@@ -4,6 +4,5 @@ set -euo pipefail
 
 python3 -m venv /tmp/venv
 source /tmp/venv/bin/activate
-pip install -r pay-access-control/scripts/requirements.txt
 
 ./configuration/scripts/generate-csvs.sh


### PR DESCRIPTION
The "generate-github-acl-csvs.sh" script only needs the python yaml package, so this change installs it in the concourse runner docker image instead of having the script install it using pip. Further changes will be done as part of PP-15495