### PR TITLE
[PP-15495] Remove python virtual env workaround

### DIFF
--- a/ci/scripts/generate-github-acl-csvs.sh
+++ b/ci/scripts/generate-github-acl-csvs.sh
@@ -2,7 +2,4 @@
 
 set -euo pipefail
 
-python3 -m venv /tmp/venv
-source /tmp/venv/bin/activate
-
 ./configuration/scripts/generate-csvs.sh


### PR DESCRIPTION
The python virtual environment was used as a workaround to handle the packages needed for the python scripts called by the "generate-csvs.sh" script, and is no longer needed.