### PR TITLE
PP-15181 Add pipeline to manage GitHub organisation repositories

### DIFF
--- a/ci/pkl-pipelines/common/shared_resources_for_github_management.pkl
+++ b/ci/pkl-pipelines/common/shared_resources_for_github_management.pkl
@@ -26,6 +26,24 @@ configurationGitHubResource: PayResources.PayGitHubResource = new {
   }
 }
 
+function configurationPullRequestResource(
+  _paths: Listing<String>,
+): PayResources.PayGitHubPullRequestResource = new {
+  name = "configuration-pr"
+  org = "govuk-pay"
+  repo = "configuration"
+  paths = _paths
+}
+
+getConfigurationPullRequestResource: Pipeline.GetStep = new {
+  get = "configuration-pr"
+  trigger = true
+  version = "every"
+  params {
+    ["integration_tool"] = "checkout"
+  }
+}
+
 open class GetResourcesInParallel extends Pipeline.InParallelStep {
   hidden resources: Listing<Pipeline.GetStep>
   in_parallel = new Listing<Pipeline.GetStep> {
@@ -80,6 +98,38 @@ function terraformInit(configuration_path: String, terraform_subpath: String) =
     }
   } |> commonTerraformParams
 
+function terraformPlan(configuration_path: String, terraform_subpath: String) =
+  new shared_resources_for_deploy_pipelines.TerraformCommandStep {
+    terraform_root = "\(configuration_path)/\(terraform_subpath)"
+    command = "plan"
+    config {
+      inputs = new Listing<TaskConfig.Input> {
+        new {
+          name = configuration_path
+        }
+      }
+      outputs {
+        new {
+          name = "plan"
+        }
+      }
+      run {
+        dir = "."
+        path = "/bin/sh"
+        args = new {
+          "-ce"
+          """
+          echo 'Terraform plan succeeded with:
+          ``` terraform' > plan/output
+          terraform -chdir="\(terraform_root)" plan -out="${PWD}/plan/tfplan"
+          terraform -chdir="\(terraform_root)" show -no-color "${PWD}/plan/tfplan" >> plan/output
+          echo '```' >> plan/output
+          """
+        }
+      }
+    }
+  } |> commonTerraformParams
+
 function terraformApply(configuration_path: String, terraform_subpath: String) = new shared_resources_for_deploy_pipelines
   .TerraformApplyStep {
   terraform_root = "\(configuration_path)/\(terraform_subpath)"
@@ -91,3 +141,17 @@ function terraformApply(configuration_path: String, terraform_subpath: String) =
     }
   }
 } |> commonTerraformParams
+
+putPRPlanSuccessStatus: Pipeline.PutStep = new {
+  put = "configuration-pr"
+  get_params {
+    ["skip_download"] = true
+  }
+  params {
+    ["path"] = "configuration-pr"
+    ["comment_file"] = "plan/output"
+    ["delete_previous_comments"] = true
+    ["status"] = "success"
+    ["context"] = "configuration-plan"
+  }
+}

--- a/ci/pkl-pipelines/pay-deploy/github-repo-management.pkl
+++ b/ci/pkl-pipelines/pay-deploy/github-repo-management.pkl
@@ -1,0 +1,73 @@
+amends
+  "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline/pkl-concourse-pipeline@0.0.4#/Pipeline.pkl"
+
+import "../common/pipeline_self_update.pkl"
+import "../common/shared_resources.pkl"
+import "../common/shared_resources_for_github_management.pkl"
+
+local terraform_subpath: String = "repos"
+local pull_request_paths: Listing<String> = new {
+  "modules/repository/"
+  "repos/"
+}
+
+local function sharedSteps(configuration_path: String) = new Listing<Step> {
+  new InParallelStep {
+    in_parallel = new Listing<Step> {
+      shared_resources_for_github_management.doAssumeRole("github-user-management")
+      shared_resources_for_github_management.doLoadTerraformVersion(configuration_path, "repos")
+    }
+  }
+  shared_resources_for_github_management.terraformInit(configuration_path, terraform_subpath)
+}
+
+resource_types {
+  shared_resources.pullRequestResourceType
+}
+
+resources = new {
+  pipeline_self_update.PayPipelineSelfUpdateResource(
+    "pay-deploy/github-repo-management.pkl",
+    "master",
+  )
+  shared_resources.payCiGitHubResource
+  shared_resources_for_github_management.configurationGitHubResource
+  shared_resources_for_github_management.configurationPullRequestResource(pull_request_paths)
+}
+
+jobs = new {
+  pipeline_self_update.PayPipelineSelfUpdateJob("pay-deploy/github-repo-management.pkl")
+
+  new {
+    name = "plan-github-org-terraform-pr"
+    plan {
+      new shared_resources_for_github_management.GetResourcesInParallel {
+        resources = new {
+          shared_resources_for_github_management.getConfigurationPullRequestResource
+        }
+      }
+      shared_resources.putPRTestPendingStatus("configuration-pr", "configuration-plan")
+      ...sharedSteps("configuration-pr")
+      shared_resources_for_github_management.terraformPlan("configuration-pr", terraform_subpath)
+      shared_resources_for_github_management.putPRPlanSuccessStatus
+    }
+    on_failure = shared_resources.putPRTestFailedStatus("configuration-pr", "configuration-plan")
+    on_error = shared_resources.putPRTestFailedStatus("configuration-pr", "configuration-plan")
+  }
+
+  new {
+    name = "apply-github-org-terraform"
+    plan {
+      new shared_resources_for_github_management.GetResourcesInParallel {
+        resources = new {
+          new {
+            get = "configuration"
+            trigger = true
+          }
+        }
+      }
+      ...sharedSteps("configuration")
+      shared_resources_for_github_management.terraformApply("configuration", terraform_subpath)
+    }
+  }
+}


### PR DESCRIPTION
Adds a pipeline to manage GitHub repos for the new organisation.

Also includes a job which triggers on PRs which comments with the output of `terraform plan` on success.

Depends on https://github.com/alphagov/pay-ci/pull/1581.